### PR TITLE
feat(midi-vj): MIDI キーボードで操作する VJ ページを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 .DS_Store
 
+.playwright-mcp
+
 # Test
 test-results
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | `/voxel-walker/` | Voxel Walker（天気連動ジェネラティブアート壁紙） |
 | `/voxel-explorer/` | Voxel Explorer（天気連動ドラクエ風俯瞰ジェネラティブアート） |
 | `/earth-orbit-simulator/` | Earth Orbit Simulator（地球軌道シミュレーター） |
+| `/midi-vj/` | MIDI VJ（MIDI キーボードで操作するビジュアルジョッキー） |
 
 ## トップページ仕様
 

--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/midi-vj/">
+              MIDI VJ
+              <span class="nav-description"
+                >MIDI キーボードで操作するビジュアルジョッキー</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/midi-vj/config.js
+++ b/public/midi-vj/config.js
@@ -1,0 +1,79 @@
+// @ts-check
+
+/** ノート番号の範囲（microKEY25 の中心帯域） */
+export const NOTE_MIN = 48;
+export const NOTE_MAX = 72;
+
+/** パーティクル上限 */
+export const MAX_PARTICLES = 200;
+
+/** パーティクル寿命（秒） */
+export const LIFE_MIN = 2;
+export const LIFE_MAX = 4;
+
+/** サイズ範囲（Canvas ピクセル） */
+export const SIZE_MIN = 8;
+export const SIZE_MAX = 48;
+
+/** 残像の強さ範囲（モジュレーションホイール CC#1 で制御） */
+export const FADE_MIN = 0.01;
+export const FADE_MAX = 0.3;
+
+/** 残像の初期値 */
+export const FADE_DEFAULT = 0.1;
+
+/** モジュレーションホイールの CC 番号 */
+export const CC_MODULATION = 1;
+
+/**
+ * ノート番号から HSL 色相（0-360）を計算する
+ * @param {number} note - MIDI ノート番号
+ * @returns {number} 色相（0-360）
+ */
+export function noteToHue(note) {
+  const clamped = Math.max(NOTE_MIN, Math.min(NOTE_MAX, note));
+  const ratio = (clamped - NOTE_MIN) / (NOTE_MAX - NOTE_MIN);
+  return ratio * 360;
+}
+
+/**
+ * ノート番号からオクターブに基づく形状を返す
+ * @param {number} note - MIDI ノート番号
+ * @returns {'circle' | 'rect' | 'star'} 形状
+ */
+export function noteToShape(note) {
+  const octave = Math.floor(note / 12);
+  if (octave <= 3) return 'circle';
+  if (octave === 4) return 'rect';
+  return 'star';
+}
+
+/**
+ * ベロシティからサイズを計算する
+ * @param {number} velocity - MIDI ベロシティ (0-127)
+ * @returns {number} サイズ（ピクセル）
+ */
+export function velocityToSize(velocity) {
+  const ratio = velocity / 127;
+  return SIZE_MIN + ratio * (SIZE_MAX - SIZE_MIN);
+}
+
+/**
+ * ベロシティから初期透明度を計算する
+ * @param {number} velocity - MIDI ベロシティ (0-127)
+ * @returns {number} 透明度 (0.3-1.0)
+ */
+export function velocityToAlpha(velocity) {
+  const ratio = velocity / 127;
+  return 0.3 + ratio * 0.7;
+}
+
+/**
+ * CC 値から残像の強さを計算する
+ * @param {number} value - CC 値 (0-127)
+ * @returns {number} フェード量
+ */
+export function ccToFade(value) {
+  const ratio = value / 127;
+  return FADE_MIN + ratio * (FADE_MAX - FADE_MIN);
+}

--- a/public/midi-vj/index.html
+++ b/public/midi-vj/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MIDI VJ | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <canvas id="vj-canvas"></canvas>
+      <div id="fallback"></div>
+    </main>
+  </body>
+</html>

--- a/public/midi-vj/main.js
+++ b/public/midi-vj/main.js
@@ -1,0 +1,104 @@
+// @ts-check
+
+import { CC_MODULATION, FADE_DEFAULT, ccToFade } from './config.js';
+import { connectMidi } from './midi.js';
+import {
+  addParticle,
+  createParticle,
+  drawBackground,
+  drawParticles,
+  updateParticles,
+} from './visuals.js';
+
+/**
+ * Canvas のサイズをウィンドウに合わせる
+ * @param {HTMLCanvasElement} canvas
+ */
+function resizeCanvas(canvas) {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+/**
+ * フォールバック画面にメッセージを表示する
+ * @param {HTMLElement} fallback
+ * @param {string} message
+ */
+function showFallback(fallback, message) {
+  fallback.textContent = message;
+  fallback.classList.add('visible');
+}
+
+/**
+ * フォールバック画面を非表示にする
+ * @param {HTMLElement} fallback
+ */
+function hideFallback(fallback) {
+  fallback.classList.remove('visible');
+}
+
+/** アプリケーションの初期化 */
+async function init() {
+  const canvas = /** @type {HTMLCanvasElement | null} */ (
+    document.getElementById('vj-canvas')
+  );
+  const fallback = document.getElementById('fallback');
+
+  if (!canvas || !fallback) return;
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  resizeCanvas(canvas);
+  window.addEventListener('resize', () => resizeCanvas(canvas));
+
+  /** @type {import('./visuals.js').Particle[]} */
+  let particles = [];
+  let fadeAmount = FADE_DEFAULT;
+
+  const connected = await connectMidi({
+    onNoteOn(note, velocity) {
+      const p = createParticle(note, velocity, canvas.width, canvas.height);
+      particles = addParticle(particles, p);
+    },
+    onNoteOff() {
+      // ノートオフ時は特に処理しない
+    },
+    onCC(cc, value) {
+      if (cc === CC_MODULATION) {
+        fadeAmount = ccToFade(value);
+      }
+    },
+  });
+
+  if (!connected) {
+    showFallback(fallback, 'このブラウザは Web MIDI API に対応していません');
+    return;
+  }
+
+  hideFallback(fallback);
+
+  let lastTime = performance.now();
+
+  /** アニメーションループ */
+  function loop() {
+    const now = performance.now();
+    const dt = (now - lastTime) / 1000;
+    lastTime = now;
+
+    drawBackground(
+      /** @type {CanvasRenderingContext2D} */ (ctx),
+      fadeAmount,
+      canvas.width,
+      canvas.height,
+    );
+    particles = updateParticles(particles, dt);
+    drawParticles(/** @type {CanvasRenderingContext2D} */ (ctx), particles);
+
+    requestAnimationFrame(loop);
+  }
+
+  requestAnimationFrame(loop);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/public/midi-vj/main.js
+++ b/public/midi-vj/main.js
@@ -55,30 +55,7 @@ async function init() {
   /** @type {import('./visuals.js').Particle[]} */
   let particles = [];
   let fadeAmount = FADE_DEFAULT;
-
-  const connected = await connectMidi({
-    onNoteOn(note, velocity) {
-      const p = createParticle(note, velocity, canvas.width, canvas.height);
-      particles = addParticle(particles, p);
-    },
-    onNoteOff() {
-      // ノートオフ時は特に処理しない
-    },
-    onCC(cc, value) {
-      if (cc === CC_MODULATION) {
-        fadeAmount = ccToFade(value);
-      }
-    },
-  });
-
-  if (!connected) {
-    showFallback(fallback, 'このブラウザは Web MIDI API に対応していません');
-    return;
-  }
-
-  hideFallback(fallback);
-
-  let lastTime = performance.now();
+  let animationStarted = false;
 
   /** アニメーションループ */
   function loop() {
@@ -98,7 +75,42 @@ async function init() {
     requestAnimationFrame(loop);
   }
 
-  requestAnimationFrame(loop);
+  let lastTime = performance.now();
+
+  /** アニメーションループを開始する（初回のみ） */
+  function startAnimation() {
+    if (animationStarted) return;
+    animationStarted = true;
+    lastTime = performance.now();
+    requestAnimationFrame(loop);
+  }
+
+  const midiSupported = await connectMidi({
+    onNoteOn(note, velocity) {
+      const p = createParticle(note, velocity, canvas.width, canvas.height);
+      particles = addParticle(particles, p);
+    },
+    onNoteOff() {
+      // ノートオフ時は特に処理しない
+    },
+    onCC(cc, value) {
+      if (cc === CC_MODULATION) {
+        fadeAmount = ccToFade(value);
+      }
+    },
+    onConnectionChange(hasDevice) {
+      if (hasDevice) {
+        hideFallback(fallback);
+        startAnimation();
+        return;
+      }
+      showFallback(fallback, 'MIDI デバイスを接続してください');
+    },
+  });
+
+  if (!midiSupported) {
+    showFallback(fallback, 'このブラウザは Web MIDI API に対応していません');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/public/midi-vj/midi.js
+++ b/public/midi-vj/midi.js
@@ -5,6 +5,7 @@
  * @property {(note: number, velocity: number) => void} onNoteOn
  * @property {(note: number) => void} onNoteOff
  * @property {(cc: number, value: number) => void} onCC
+ * @property {(hasDevice: boolean) => void} onConnectionChange
  */
 
 /** MIDI ステータスバイト */
@@ -14,8 +15,8 @@ const STATUS_CC = 0xb0;
 
 /**
  * MIDI メッセージをパースしてコールバックに通知する
- * @param {MIDIMessageEvent} event - MIDI メッセージイベント
- * @param {MidiCallbacks} callbacks - コールバック関数群
+ * @param {MIDIMessageEvent} event
+ * @param {MidiCallbacks} callbacks
  */
 function handleMidiMessage(event, callbacks) {
   const data = event.data;
@@ -44,25 +45,26 @@ function handleMidiMessage(event, callbacks) {
 }
 
 /**
- * 全 MIDI 入力にイベントリスナーを登録する
- * @param {MIDIAccess} midiAccess - MIDI アクセスオブジェクト
- * @param {MidiCallbacks} callbacks - コールバック関数群
+ * 全 MIDI 入力にイベントリスナーを登録する（重複を防ぐため onmidimessage を使用）
+ * @param {MIDIAccess} midiAccess
+ * @param {MidiCallbacks} callbacks
+ * @returns {number} 接続されたデバイス数
  */
 function bindInputs(midiAccess, callbacks) {
+  let count = 0;
   for (const input of midiAccess.inputs.values()) {
-    input.addEventListener(
-      'midimessage',
-      (/** @type {MIDIMessageEvent} */ event) => {
-        handleMidiMessage(event, callbacks);
-      },
-    );
+    input.onmidimessage = (/** @type {MIDIMessageEvent} */ event) => {
+      handleMidiMessage(event, callbacks);
+    };
+    count++;
   }
+  return count;
 }
 
 /**
  * Web MIDI API でデバイスに接続する
- * @param {MidiCallbacks} callbacks - コールバック関数群
- * @returns {Promise<boolean>} 接続成功なら true
+ * @param {MidiCallbacks} callbacks
+ * @returns {Promise<boolean>} MIDI API に対応していれば true
  */
 export async function connectMidi(callbacks) {
   if (!navigator.requestMIDIAccess) {
@@ -71,10 +73,12 @@ export async function connectMidi(callbacks) {
 
   try {
     const midiAccess = await navigator.requestMIDIAccess();
-    bindInputs(midiAccess, callbacks);
+    const deviceCount = bindInputs(midiAccess, callbacks);
+    callbacks.onConnectionChange(deviceCount > 0);
 
     midiAccess.addEventListener('statechange', () => {
-      bindInputs(midiAccess, callbacks);
+      const newCount = bindInputs(midiAccess, callbacks);
+      callbacks.onConnectionChange(newCount > 0);
     });
 
     return true;

--- a/public/midi-vj/midi.js
+++ b/public/midi-vj/midi.js
@@ -1,0 +1,84 @@
+// @ts-check
+
+/**
+ * @typedef {object} MidiCallbacks
+ * @property {(note: number, velocity: number) => void} onNoteOn
+ * @property {(note: number) => void} onNoteOff
+ * @property {(cc: number, value: number) => void} onCC
+ */
+
+/** MIDI ステータスバイト */
+const STATUS_NOTE_ON = 0x90;
+const STATUS_NOTE_OFF = 0x80;
+const STATUS_CC = 0xb0;
+
+/**
+ * MIDI メッセージをパースしてコールバックに通知する
+ * @param {MIDIMessageEvent} event - MIDI メッセージイベント
+ * @param {MidiCallbacks} callbacks - コールバック関数群
+ */
+function handleMidiMessage(event, callbacks) {
+  const data = event.data;
+  if (!data || data.length < 3) return;
+
+  const status = data[0] & 0xf0;
+  const value1 = data[1];
+  const value2 = data[2];
+
+  if (status === STATUS_NOTE_ON && value2 > 0) {
+    callbacks.onNoteOn(value1, value2);
+    return;
+  }
+
+  if (
+    status === STATUS_NOTE_OFF ||
+    (status === STATUS_NOTE_ON && value2 === 0)
+  ) {
+    callbacks.onNoteOff(value1);
+    return;
+  }
+
+  if (status === STATUS_CC) {
+    callbacks.onCC(value1, value2);
+  }
+}
+
+/**
+ * 全 MIDI 入力にイベントリスナーを登録する
+ * @param {MIDIAccess} midiAccess - MIDI アクセスオブジェクト
+ * @param {MidiCallbacks} callbacks - コールバック関数群
+ */
+function bindInputs(midiAccess, callbacks) {
+  for (const input of midiAccess.inputs.values()) {
+    input.addEventListener(
+      'midimessage',
+      (/** @type {MIDIMessageEvent} */ event) => {
+        handleMidiMessage(event, callbacks);
+      },
+    );
+  }
+}
+
+/**
+ * Web MIDI API でデバイスに接続する
+ * @param {MidiCallbacks} callbacks - コールバック関数群
+ * @returns {Promise<boolean>} 接続成功なら true
+ */
+export async function connectMidi(callbacks) {
+  if (!navigator.requestMIDIAccess) {
+    return false;
+  }
+
+  try {
+    const midiAccess = await navigator.requestMIDIAccess();
+    bindInputs(midiAccess, callbacks);
+
+    midiAccess.addEventListener('statechange', () => {
+      bindInputs(midiAccess, callbacks);
+    });
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/public/midi-vj/style.css
+++ b/public/midi-vj/style.css
@@ -1,0 +1,56 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+  background: #000;
+  font-family: system-ui, sans-serif;
+}
+
+canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 10;
+  padding: 0.75rem 1rem;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 0 0 0.5rem 0;
+}
+
+header a {
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+#fallback {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 5;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  font-size: 1.25rem;
+  text-align: center;
+  padding: 2rem;
+}
+
+#fallback.visible {
+  display: flex;
+}

--- a/public/midi-vj/visuals.js
+++ b/public/midi-vj/visuals.js
@@ -1,0 +1,159 @@
+// @ts-check
+
+import {
+  LIFE_MAX,
+  LIFE_MIN,
+  MAX_PARTICLES,
+  noteToHue,
+  noteToShape,
+  velocityToAlpha,
+  velocityToSize,
+} from './config.js';
+
+/**
+ * @typedef {object} Particle
+ * @property {number} x - X 座標
+ * @property {number} y - Y 座標
+ * @property {number} vx - X 方向速度
+ * @property {number} vy - Y 方向速度
+ * @property {number} size - サイズ（半径）
+ * @property {number} hue - HSL 色相
+ * @property {number} alpha - 現在の透明度
+ * @property {number} initialAlpha - 初期透明度
+ * @property {'circle' | 'rect' | 'star'} shape - 形状
+ * @property {number} life - 残り寿命（秒）
+ * @property {number} maxLife - 最大寿命（秒）
+ */
+
+/**
+ * パーティクルを生成する
+ * @param {number} note - MIDI ノート番号
+ * @param {number} velocity - MIDI ベロシティ
+ * @param {number} canvasWidth - Canvas 幅
+ * @param {number} canvasHeight - Canvas 高さ
+ * @returns {Particle}
+ */
+export function createParticle(note, velocity, canvasWidth, canvasHeight) {
+  const life = LIFE_MIN + Math.random() * (LIFE_MAX - LIFE_MIN);
+  const initialAlpha = velocityToAlpha(velocity);
+
+  return {
+    x: Math.random() * canvasWidth,
+    y: Math.random() * canvasHeight,
+    vx: (Math.random() - 0.5) * 30,
+    vy: -(20 + Math.random() * 40),
+    size: velocityToSize(velocity),
+    hue: noteToHue(note),
+    alpha: initialAlpha,
+    initialAlpha,
+    shape: noteToShape(note),
+    life,
+    maxLife: life,
+  };
+}
+
+/**
+ * パーティクル配列を更新し、生存中のものだけ返す
+ * @param {Particle[]} particles - パーティクル配列
+ * @param {number} dt - 経過時間（秒）
+ * @returns {Particle[]} 生存パーティクル
+ */
+export function updateParticles(particles, dt) {
+  const alive = [];
+
+  for (const p of particles) {
+    p.life -= dt;
+    if (p.life <= 0) continue;
+
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+
+    const lifeRatio = p.life / p.maxLife;
+    p.alpha = p.initialAlpha * lifeRatio;
+
+    alive.push(p);
+  }
+
+  return alive;
+}
+
+/**
+ * パーティクルを配列に追加する（上限を超えたら古いものから削除）
+ * @param {Particle[]} particles - パーティクル配列
+ * @param {Particle} particle - 追加するパーティクル
+ * @returns {Particle[]} 更新後の配列
+ */
+export function addParticle(particles, particle) {
+  const next = [...particles, particle];
+  if (next.length > MAX_PARTICLES) {
+    return next.slice(next.length - MAX_PARTICLES);
+  }
+  return next;
+}
+
+/**
+ * 星形のパスを描く
+ * @param {CanvasRenderingContext2D} ctx - Canvas コンテキスト
+ * @param {number} cx - 中心 X
+ * @param {number} cy - 中心 Y
+ * @param {number} size - 外径
+ */
+function drawStar(ctx, cx, cy, size) {
+  const spikes = 5;
+  const outerRadius = size;
+  const innerRadius = size * 0.4;
+
+  ctx.beginPath();
+  for (let i = 0; i < spikes * 2; i++) {
+    const radius = i % 2 === 0 ? outerRadius : innerRadius;
+    const angle = (Math.PI / spikes) * i - Math.PI / 2;
+    const x = cx + Math.cos(angle) * radius;
+    const y = cy + Math.sin(angle) * radius;
+
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+}
+
+/**
+ * パーティクルを Canvas に描画する
+ * @param {CanvasRenderingContext2D} ctx - Canvas コンテキスト
+ * @param {Particle[]} particles - パーティクル配列
+ */
+export function drawParticles(ctx, particles) {
+  for (const p of particles) {
+    const color = `hsla(${p.hue}, 80%, 60%, ${p.alpha})`;
+    ctx.fillStyle = color;
+
+    if (p.shape === 'circle') {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+      ctx.fill();
+      continue;
+    }
+
+    if (p.shape === 'rect') {
+      ctx.fillRect(p.x - p.size, p.y - p.size, p.size * 2, p.size * 2);
+      continue;
+    }
+
+    drawStar(ctx, p.x, p.y, p.size);
+    ctx.fill();
+  }
+}
+
+/**
+ * 半透明黒で残像効果を描く
+ * @param {CanvasRenderingContext2D} ctx - Canvas コンテキスト
+ * @param {number} fadeAmount - 不透明度 (0-1)
+ * @param {number} width - Canvas 幅
+ * @param {number} height - Canvas 高さ
+ */
+export function drawBackground(ctx, fadeAmount, width, height) {
+  ctx.fillStyle = `rgba(0, 0, 0, ${fadeAmount})`;
+  ctx.fillRect(0, 0, width, height);
+}


### PR DESCRIPTION
## Summary
- KORG microKEY25 などの MIDI キーボード入力でリアルタイムにビジュアルエフェクトを生成する VJ ページを新規追加

## Changes
- `public/midi-vj/` に 6 ファイル新規作成（HTML / CSS / JS）
- Web MIDI API でデバイス接続・メッセージパース
- Canvas 2D でパーティクルエフェクト描画（ノート→色/形状、ベロシティ→サイズ/透明度）
- モジュレーションホイールで残像の長さを制御
- MIDI 未接続 / ブラウザ非対応時のフォールバック画面
- トップページ（`index.html`）とドキュメント（`docs/README.md`）にリンク追加

## Test plan
- Chrome で `/midi-vj/` を開き、MIDI デバイス未接続時にフォールバック表示を確認
- MIDI キーボードを接続し、鍵盤押下でパーティクルが表示されることを確認
- `npm run check` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)