### PR TITLE
feat(simple-gui): lil-gui 簡易版 GUI ライブラリと4つの UI バリアントを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@
 | `/earth-orbit-simulator/` | Earth Orbit Simulator（地球軌道シミュレーター） |
 | `/midi-vj/` | MIDI VJ（MIDI キーボードで操作するビジュアルジョッキー） |
 | `/simple-gui/` | Simple GUI（lil-gui 簡易版 GUI ライブラリ デモ） |
+| `/simple-gui-sheet/` | Simple GUI Sheet（ボトムシート型 GUI ライブラリ デモ） |
+| `/simple-gui-pill/` | Simple GUI Pill（ピル型 GUI ライブラリ デモ） |
+| `/simple-gui-tab/` | Simple GUI Tab（タブバー型 GUI ライブラリ デモ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 | `/voxel-explorer/` | Voxel Explorer（天気連動ドラクエ風俯瞰ジェネラティブアート） |
 | `/earth-orbit-simulator/` | Earth Orbit Simulator（地球軌道シミュレーター） |
 | `/midi-vj/` | MIDI VJ（MIDI キーボードで操作するビジュアルジョッキー） |
+| `/simple-gui/` | Simple GUI（lil-gui 簡易版 GUI ライブラリ デモ） |
 
 ## トップページ仕様
 

--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/simple-gui-pill/">
+              Simple GUI Pill
+              <span class="nav-description"
+                >ピル型（Dynamic Island 風）GUI ライブラリ デモ</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -73,6 +73,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/simple-gui/">
+              Simple GUI
+              <span class="nav-description"
+                >lil-gui 簡易版 GUI ライブラリ デモ</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -97,6 +97,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/simple-gui-tab/">
+              Simple GUI Tab
+              <span class="nav-description"
+                >タブバー型 GUI ライブラリ デモ</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -81,6 +81,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/simple-gui-sheet/">
+              Simple GUI Sheet
+              <span class="nav-description"
+                >ボトムシート型 GUI ライブラリ デモ</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/simple-gui-pill/index.html
+++ b/public/simple-gui-pill/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple GUI Pill | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+  </body>
+</html>

--- a/public/simple-gui-pill/main.js
+++ b/public/simple-gui-pill/main.js
@@ -123,6 +123,7 @@ gui.add(params, 'visible');
 
 gui.addButton('Reset', () => {
   Object.assign(params, { ...defaults });
+  gui.updateDisplay();
 });
 
 const folder = gui.addFolder('Advanced');

--- a/public/simple-gui-pill/main.js
+++ b/public/simple-gui-pill/main.js
@@ -1,0 +1,132 @@
+// @ts-check
+import SimpleGuiPill from './simple-gui-pill.js';
+
+// --- パラメータ ---
+
+const params = {
+  color: '#30D158',
+  size: 80,
+  speed: 30,
+  visible: true,
+  opacity: 0.8,
+  sides: 5,
+};
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
+
+// --- Canvas セットアップ ---
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** Canvas をウィンドウサイズに合わせる */
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画ロジック ---
+
+let angle = 0;
+
+/**
+ * hex カラー文字列を rgba 文字列に変換する
+ * @param {string} hex
+ * @param {number} alpha
+ * @returns {string}
+ */
+function hexToRgba(hex, alpha) {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * 正多角形を描画する
+ * @param {number} cx - 中心 X
+ * @param {number} cy - 中心 Y
+ * @param {number} radius - 半径
+ * @param {number} sides - 辺の数
+ * @param {number} rotation - 回転角度（ラジアン）
+ */
+function drawPolygon(cx, cy, radius, sides, rotation) {
+  ctx.beginPath();
+  for (let i = 0; i <= sides; i++) {
+    const a = (i / sides) * Math.PI * 2 - Math.PI / 2 + rotation;
+    const x = cx + radius * Math.cos(a);
+    const y = cy + radius * Math.sin(a);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+}
+
+/** メインの描画フレーム */
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (!params.visible) {
+    requestAnimationFrame(draw);
+    return;
+  }
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  // 軌道上を回転する位置
+  const orbitRadius = params.size * 1.5;
+  const ox = cx + orbitRadius * Math.cos(angle);
+  const oy = cy + orbitRadius * Math.sin(angle);
+
+  // メイン図形（回転する正多角形）
+  ctx.fillStyle = hexToRgba(params.color, params.opacity);
+  drawPolygon(ox, oy, params.size, params.sides, angle * 2);
+  ctx.fill();
+
+  // 中心の小さな円
+  ctx.fillStyle = hexToRgba(params.color, params.opacity * 0.4);
+  ctx.beginPath();
+  ctx.arc(cx, cy, params.size * 0.3, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 軌道の線
+  ctx.strokeStyle = hexToRgba(params.color, 0.15);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  angle += params.speed * 0.001;
+  requestAnimationFrame(draw);
+}
+
+requestAnimationFrame(draw);
+
+// --- GUI セットアップ ---
+
+const gui = new SimpleGuiPill({ title: 'Settings' });
+
+gui.addColor(params, 'color');
+gui.add(params, 'size', 20, 200, 1);
+gui.add(params, 'speed', 0, 100, 1);
+gui.add(params, 'visible');
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+});
+
+const folder = gui.addFolder('Advanced');
+folder.add(params, 'opacity', 0, 1, 0.01);
+folder.add(params, 'sides', 3, 12, 1).onChange((v) => {
+  params.sides = /** @type {number} */ (v);
+});

--- a/public/simple-gui-pill/simple-gui-pill.js
+++ b/public/simple-gui-pill/simple-gui-pill.js
@@ -1,0 +1,921 @@
+// @ts-check
+
+/**
+ * SimpleGuiPill - ピル型（カプセル）GUI ライブラリ
+ * iOS Dynamic Island 風のコンパクトなカプセル UI
+ * 収納時は小さなピル形状、タップで滑らかにモーフィング展開
+ * 四隅にドラッグでスナップ・収納対応
+ *
+ * 単一ファイル構成: CSS も JS から注入する
+ */
+
+// ========================================
+// スタイル注入
+// ========================================
+
+const STYLE_ID = 'simple-gui-pill-style';
+
+/** スタイルを注入する（一度だけ） */
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    :root {
+      --sgp-bg: #1c1c1e;
+      --sgp-bg-hover: #2c2c2e;
+      --sgp-border: #38383a;
+      --sgp-text: #ffffff;
+      --sgp-text-dim: #98989d;
+      --sgp-accent: #30D158;
+      --sgp-accent-hover: #34d65c;
+      --sgp-input-bg: #0a0a0a;
+      --sgp-folder-bg: #141416;
+      --sgp-radius-pill: 100vmax;
+      --sgp-radius-panel: 1rem;
+      --sgp-font-size: 0.75rem;
+      --sgp-row-height: 1.75rem;
+      --sgp-padding: 0.5rem;
+      --sgp-width: 16rem;
+      --sgp-pill-height: 2rem;
+      --sgp-transition: 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+      --sgp-margin: 0.75rem;
+    }
+
+    .sgp-container {
+      position: fixed;
+      z-index: 10000;
+      font-family: system-ui, -apple-system, sans-serif;
+      font-size: var(--sgp-font-size);
+      color: var(--sgp-text);
+      user-select: none;
+      touch-action: none;
+    }
+
+    .sgp-container.sgp-top-right {
+      top: var(--sgp-margin);
+      right: var(--sgp-margin);
+    }
+    .sgp-container.sgp-top-left {
+      top: var(--sgp-margin);
+      left: var(--sgp-margin);
+    }
+    .sgp-container.sgp-bottom-right {
+      bottom: var(--sgp-margin);
+      right: var(--sgp-margin);
+    }
+    .sgp-container.sgp-bottom-left {
+      bottom: var(--sgp-margin);
+      left: var(--sgp-margin);
+    }
+
+    .sgp-pill {
+      background: var(--sgp-bg);
+      box-shadow: 0 0.25rem 1.5rem rgba(0, 0, 0, 0.5),
+                  0 0 0 0.0625rem rgba(255, 255, 255, 0.06);
+      overflow: hidden;
+      transition:
+        width var(--sgp-transition),
+        height var(--sgp-transition),
+        border-radius var(--sgp-transition),
+        max-height var(--sgp-transition);
+    }
+
+    .sgp-pill.sgp-collapsed {
+      width: auto;
+      min-width: 6rem;
+      max-width: 10rem;
+      height: var(--sgp-pill-height);
+      border-radius: var(--sgp-radius-pill);
+      cursor: pointer;
+    }
+
+    .sgp-pill.sgp-expanded {
+      width: var(--sgp-width);
+      border-radius: var(--sgp-radius-panel);
+      max-height: 70vh;
+      overflow: hidden;
+    }
+
+    .sgp-container.sgp-dragging .sgp-pill {
+      transition: none;
+      opacity: 0.85;
+    }
+
+    .sgp-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 0.75rem;
+      height: var(--sgp-pill-height);
+      cursor: pointer;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    .sgp-header-title {
+      font-weight: 600;
+      font-size: 0.8125rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .sgp-header-dot {
+      width: 0.5rem;
+      height: 0.5rem;
+      border-radius: 50%;
+      background: var(--sgp-accent);
+      flex-shrink: 0;
+      margin-left: 0.5rem;
+      transition: transform 0.3s ease;
+    }
+
+    .sgp-pill.sgp-expanded .sgp-header-dot {
+      transform: scale(0);
+    }
+
+    .sgp-header-close {
+      display: none;
+      width: 1.25rem;
+      height: 1.25rem;
+      border: none;
+      background: var(--sgp-border);
+      color: var(--sgp-text-dim);
+      border-radius: 50%;
+      font-size: 0.625rem;
+      cursor: pointer;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      margin-left: 0.5rem;
+      transition: background 0.15s;
+      padding: 0;
+      line-height: 1;
+    }
+
+    .sgp-header-close:hover {
+      background: var(--sgp-accent);
+      color: #000;
+    }
+
+    .sgp-pill.sgp-expanded .sgp-header-close {
+      display: flex;
+    }
+
+    .sgp-body {
+      overflow-y: auto;
+      overflow-x: hidden;
+      max-height: 0;
+      opacity: 0;
+      transition:
+        max-height var(--sgp-transition),
+        opacity 0.3s ease;
+    }
+
+    .sgp-pill.sgp-expanded .sgp-body {
+      max-height: 60vh;
+      opacity: 1;
+    }
+
+    .sgp-children {
+      padding: 0.25rem 0;
+    }
+
+    .sgp-row {
+      display: flex;
+      align-items: center;
+      padding: 0.25rem var(--sgp-padding);
+      min-height: var(--sgp-row-height);
+      border-top: 0.0625rem solid var(--sgp-border);
+    }
+
+    .sgp-row:hover {
+      background: var(--sgp-bg-hover);
+    }
+
+    .sgp-label {
+      flex: 0 0 40%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--sgp-text-dim);
+    }
+
+    .sgp-control {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .sgp-control input[type="range"] {
+      flex: 1;
+      min-width: 0;
+      height: 0.25rem;
+      accent-color: var(--sgp-accent);
+      cursor: pointer;
+    }
+
+    .sgp-control input[type="number"] {
+      width: 27%;
+      min-width: 2.5rem;
+      flex-shrink: 0;
+      background: var(--sgp-input-bg);
+      border: 0.0625rem solid var(--sgp-border);
+      border-radius: 0.25rem;
+      color: var(--sgp-text);
+      font-size: var(--sgp-font-size);
+      padding: 0.125rem 0.25rem;
+      text-align: right;
+    }
+
+    .sgp-control input[type="number"]:focus {
+      outline: 0.0625rem solid var(--sgp-accent);
+    }
+
+    .sgp-control input[type="checkbox"] {
+      accent-color: var(--sgp-accent);
+      cursor: pointer;
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+
+    .sgp-control input[type="color"] {
+      width: 100%;
+      height: var(--sgp-row-height);
+      border: none;
+      background: none;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .sgp-control button {
+      width: 100%;
+      padding: 0.25rem 0.5rem;
+      background: var(--sgp-accent);
+      color: #000;
+      border: none;
+      border-radius: 0.25rem;
+      font-size: var(--sgp-font-size);
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .sgp-control button:hover {
+      background: var(--sgp-accent-hover);
+    }
+
+    .sgp-folder-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.25rem var(--sgp-padding);
+      min-height: var(--sgp-row-height);
+      border-top: 0.0625rem solid var(--sgp-border);
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--sgp-accent);
+    }
+
+    .sgp-folder-title:hover {
+      background: var(--sgp-bg-hover);
+    }
+
+    .sgp-folder-children {
+      padding-left: 0.5rem;
+      background: var(--sgp-folder-bg);
+    }
+
+    .sgp-folder-children.sgp-hidden {
+      display: none;
+    }
+
+    .sgp-folder-toggle {
+      transition: transform 0.2s;
+      font-size: 0.625rem;
+    }
+
+    .sgp-folder-toggle.sgp-collapsed {
+      transform: rotate(-90deg);
+    }
+
+    /* 下隅スナップ時は上方向に展開 */
+    .sgp-container.sgp-bottom-right .sgp-pill,
+    .sgp-container.sgp-bottom-left .sgp-pill {
+      display: flex;
+      flex-direction: column-reverse;
+    }
+
+    .sgp-container.sgp-bottom-right .sgp-body,
+    .sgp-container.sgp-bottom-left .sgp-body {
+      display: flex;
+      flex-direction: column-reverse;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+/** スタイル要素を除去する */
+function removeStyles() {
+  const styleEl = document.getElementById(STYLE_ID);
+  if (styleEl) {
+    styleEl.remove();
+  }
+}
+
+// ========================================
+// コントローラー
+// ========================================
+
+/** コントローラー基底クラス */
+class Controller {
+  /** @type {Record<string, unknown>} */
+  _obj;
+  /** @type {string} */
+  _prop;
+  /** @type {((value: unknown) => void) | null} */
+  _onChangeCallback;
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    this._obj = obj;
+    this._prop = prop;
+    this._onChangeCallback = null;
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgp-row');
+  }
+
+  /**
+   * onChange コールバックを設定する
+   * @param {(value: unknown) => void} callback
+   * @returns {this}
+   */
+  onChange(callback) {
+    this._onChangeCallback = callback;
+    return this;
+  }
+
+  /**
+   * 値を更新してコールバックを発火する
+   * @param {unknown} value
+   */
+  _setValue(value) {
+    this._obj[this._prop] = value;
+    if (this._onChangeCallback) {
+      this._onChangeCallback(value);
+    }
+  }
+}
+
+/** 数値コントローラー */
+class NumberController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   */
+  constructor(obj, prop, min, max, step) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgp-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgp-control');
+
+    const hasRange = min !== undefined && max !== undefined;
+
+    const numberInput = document.createElement('input');
+    numberInput.type = 'number';
+    numberInput.value = String(obj[prop]);
+    if (min !== undefined) numberInput.min = String(min);
+    if (max !== undefined) numberInput.max = String(max);
+    if (step !== undefined) numberInput.step = String(step);
+
+    if (hasRange) {
+      const rangeInput = document.createElement('input');
+      rangeInput.type = 'range';
+      rangeInput.min = String(min);
+      rangeInput.max = String(max);
+      rangeInput.step = String(step ?? 1);
+      rangeInput.value = String(obj[prop]);
+
+      rangeInput.addEventListener('input', () => {
+        const val = Number(rangeInput.value);
+        numberInput.value = String(val);
+        this._setValue(val);
+      });
+
+      numberInput.addEventListener('input', () => {
+        const val = Number(numberInput.value);
+        rangeInput.value = String(val);
+        this._setValue(val);
+      });
+
+      control.appendChild(rangeInput);
+    } else {
+      numberInput.addEventListener('input', () => {
+        this._setValue(Number(numberInput.value));
+      });
+    }
+
+    control.appendChild(numberInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+/** 真偽値コントローラー */
+class BooleanController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgp-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgp-control');
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = /** @type {boolean} */ (obj[prop]);
+
+    checkbox.addEventListener('change', () => {
+      this._setValue(checkbox.checked);
+    });
+
+    control.appendChild(checkbox);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+/** カラーコントローラー */
+class ColorController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgp-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgp-control');
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = /** @type {string} */ (obj[prop]);
+
+    colorInput.addEventListener('input', () => {
+      this._setValue(colorInput.value);
+    });
+
+    control.appendChild(colorInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+/** ボタンコントローラー */
+class ButtonController {
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {string} label
+   * @param {() => void} callback
+   */
+  constructor(label, callback) {
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgp-row');
+
+    const spacer = document.createElement('span');
+    spacer.classList.add('sgp-label');
+
+    const control = document.createElement('div');
+    control.classList.add('sgp-control');
+
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.addEventListener('click', callback);
+
+    control.appendChild(button);
+    this.domElement.appendChild(spacer);
+    this.domElement.appendChild(control);
+  }
+}
+
+// ========================================
+// ドラッグ＆スナップ
+// ========================================
+
+/** ドラッグ判定の閾値（ピクセル相当） */
+const DRAG_THRESHOLD = 5;
+
+/** スナップ位置 */
+const SnapCorner = /** @type {const} */ ({
+  TOP_RIGHT: 'top-right',
+  TOP_LEFT: 'top-left',
+  BOTTOM_RIGHT: 'bottom-right',
+  BOTTOM_LEFT: 'bottom-left',
+});
+
+/**
+ * clientX/Y を vw/vh 単位の文字列に変換する
+ * @param {number} clientX
+ * @param {number} clientY
+ * @param {number} offsetX
+ * @param {number} offsetY
+ * @returns {{ left: string, top: string }}
+ */
+function toViewportUnits(clientX, clientY, offsetX, offsetY) {
+  const left = ((clientX - offsetX) / window.innerWidth) * 100;
+  const top = ((clientY - offsetY) / window.innerHeight) * 100;
+  return { left: `${left}vw`, top: `${top}vh` };
+}
+
+// ========================================
+// SimpleGuiPill 本体
+// ========================================
+
+class SimpleGuiPill {
+  /** @type {HTMLElement} */
+  domElement;
+  /** @type {HTMLElement} */
+  _pillEl;
+  /** @type {HTMLElement} */
+  _headerEl;
+  /** @type {HTMLElement} */
+  _bodyEl;
+  /** @type {HTMLElement} */
+  _childrenEl;
+  /** @type {boolean} */
+  _isRoot;
+  /** @type {boolean} */
+  _expanded;
+  /** @type {typeof SnapCorner[keyof typeof SnapCorner]} */
+  _corner;
+  /** @type {boolean} */
+  _isDragging;
+  /** @type {number} */
+  _dragStartX;
+  /** @type {number} */
+  _dragStartY;
+  /** @type {number} */
+  _dragOffsetX;
+  /** @type {number} */
+  _dragOffsetY;
+  /** @type {boolean} */
+  _dragMoved;
+  /** @type {Array<() => void>} */
+  _cleanupFns;
+
+  /**
+   * @param {{ title?: string, parent?: HTMLElement }} [options]
+   */
+  constructor(options = {}) {
+    const { title = 'Controls', parent } = options;
+
+    injectStyles();
+
+    this._isRoot = !parent;
+    this._expanded = false;
+    this._corner = SnapCorner.TOP_RIGHT;
+    this._isDragging = false;
+    this._dragStartX = 0;
+    this._dragStartY = 0;
+    this._dragOffsetX = 0;
+    this._dragOffsetY = 0;
+    this._dragMoved = false;
+    this._cleanupFns = [];
+
+    this.domElement = document.createElement('div');
+    this._pillEl = document.createElement('div');
+    this._headerEl = document.createElement('div');
+    this._bodyEl = document.createElement('div');
+    this._childrenEl = document.createElement('div');
+
+    if (this._isRoot) {
+      this._buildRootPill(title);
+    } else {
+      this._buildFolder(title, /** @type {HTMLElement} */ (parent));
+    }
+  }
+
+  /**
+   * ルートのピル（カプセル）を構築する
+   * @param {string} title
+   */
+  _buildRootPill(title) {
+    this.domElement.classList.add('sgp-container', 'sgp-top-right');
+    this._pillEl.classList.add('sgp-pill', 'sgp-collapsed');
+
+    // ヘッダー
+    this._headerEl.classList.add('sgp-header');
+
+    const titleText = document.createElement('span');
+    titleText.classList.add('sgp-header-title');
+    titleText.textContent = title;
+
+    const dot = document.createElement('span');
+    dot.classList.add('sgp-header-dot');
+
+    const closeBtn = document.createElement('button');
+    closeBtn.classList.add('sgp-header-close');
+    closeBtn.textContent = '\u2715';
+    closeBtn.title = '\u53CE\u7D0D';
+
+    this._headerEl.appendChild(titleText);
+    this._headerEl.appendChild(dot);
+    this._headerEl.appendChild(closeBtn);
+
+    // ボディ
+    this._bodyEl.classList.add('sgp-body');
+    this._childrenEl.classList.add('sgp-children');
+    this._bodyEl.appendChild(this._childrenEl);
+
+    this._pillEl.appendChild(this._headerEl);
+    this._pillEl.appendChild(this._bodyEl);
+    this.domElement.appendChild(this._pillEl);
+    document.body.appendChild(this.domElement);
+
+    this._setupToggle(closeBtn);
+    this._setupDrag();
+  }
+
+  /**
+   * フォルダ（子パネル）を構築する
+   * @param {string} title
+   * @param {HTMLElement} parentEl
+   */
+  _buildFolder(title, parentEl) {
+    const folderTitle = document.createElement('div');
+    folderTitle.classList.add('sgp-folder-title');
+
+    const folderText = document.createElement('span');
+    folderText.textContent = title;
+
+    const toggle = document.createElement('span');
+    toggle.classList.add('sgp-folder-toggle');
+    toggle.textContent = '\u25BC';
+
+    folderTitle.appendChild(folderText);
+    folderTitle.appendChild(toggle);
+
+    this._childrenEl.classList.add('sgp-folder-children');
+
+    folderTitle.addEventListener('click', () => {
+      const hidden = this._childrenEl.classList.toggle('sgp-hidden');
+      toggle.classList.toggle('sgp-collapsed', hidden);
+    });
+
+    this.domElement.appendChild(folderTitle);
+    this.domElement.appendChild(this._childrenEl);
+    parentEl.appendChild(this.domElement);
+  }
+
+  /**
+   * トグル（展開/収納）イベントを設定する
+   * @param {HTMLElement} closeBtn
+   */
+  _setupToggle(closeBtn) {
+    const onHeaderClick = () => {
+      if (this._dragMoved) {
+        return;
+      }
+      if (!this._expanded) {
+        this._expand();
+      }
+    };
+    this._headerEl.addEventListener('click', onHeaderClick);
+    this._cleanupFns.push(() =>
+      this._headerEl.removeEventListener('click', onHeaderClick),
+    );
+
+    const onClose = (/** @type {Event} */ e) => {
+      e.stopPropagation();
+      this._collapse();
+    };
+    closeBtn.addEventListener('click', onClose);
+    this._cleanupFns.push(() => closeBtn.removeEventListener('click', onClose));
+  }
+
+  /** パネルを展開する */
+  _expand() {
+    this._expanded = true;
+    this._pillEl.classList.remove('sgp-collapsed');
+    this._pillEl.classList.add('sgp-expanded');
+  }
+
+  /** パネルを収納する（ピルに戻す） */
+  _collapse() {
+    this._expanded = false;
+    this._pillEl.classList.remove('sgp-expanded');
+    this._pillEl.classList.add('sgp-collapsed');
+  }
+
+  /** ドラッグ＆四隅スナップを設定する */
+  _setupDrag() {
+    /** @type {(e: PointerEvent) => void} */
+    const onDown = (e) => {
+      if (!this._headerEl.contains(/** @type {Node} */ (e.target))) {
+        return;
+      }
+      this._isDragging = true;
+      this._dragMoved = false;
+      const rect = this.domElement.getBoundingClientRect();
+      this._dragStartX = e.clientX;
+      this._dragStartY = e.clientY;
+      this._dragOffsetX = e.clientX - rect.left;
+      this._dragOffsetY = e.clientY - rect.top;
+      this.domElement.classList.add('sgp-dragging');
+      this._headerEl.setPointerCapture(e.pointerId);
+    };
+
+    /** @type {(e: PointerEvent) => void} */
+    const onMove = (e) => {
+      if (!this._isDragging) {
+        return;
+      }
+      const dx = e.clientX - this._dragStartX;
+      const dy = e.clientY - this._dragStartY;
+      if (
+        !this._dragMoved &&
+        Math.abs(dx) < DRAG_THRESHOLD &&
+        Math.abs(dy) < DRAG_THRESHOLD
+      ) {
+        return;
+      }
+      this._dragMoved = true;
+      const pos = toViewportUnits(
+        e.clientX,
+        e.clientY,
+        this._dragOffsetX,
+        this._dragOffsetY,
+      );
+      const s = this.domElement.style;
+      s.left = pos.left;
+      s.top = pos.top;
+      s.right = 'auto';
+      s.bottom = 'auto';
+    };
+
+    /** @type {() => void} */
+    const onUp = () => {
+      if (!this._isDragging) {
+        return;
+      }
+      this._isDragging = false;
+      this.domElement.classList.remove('sgp-dragging');
+      if (!this._dragMoved) {
+        this._clearInlinePosition();
+        return;
+      }
+      this._snapToNearestCorner();
+    };
+
+    this._headerEl.addEventListener('pointerdown', onDown);
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+    this._cleanupFns.push(() => {
+      this._headerEl.removeEventListener('pointerdown', onDown);
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+    });
+  }
+
+  /** 最も近い四隅にスナップする */
+  _snapToNearestCorner() {
+    const rect = this.domElement.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const isRight = cx > window.innerWidth / 2;
+    const isBottom = cy > window.innerHeight / 2;
+
+    /** @type {typeof SnapCorner[keyof typeof SnapCorner]} */
+    let corner;
+    if (isBottom && isRight) {
+      corner = SnapCorner.BOTTOM_RIGHT;
+    } else if (isBottom) {
+      corner = SnapCorner.BOTTOM_LEFT;
+    } else if (isRight) {
+      corner = SnapCorner.TOP_RIGHT;
+    } else {
+      corner = SnapCorner.TOP_LEFT;
+    }
+
+    this._corner = corner;
+    this.domElement.classList.remove(
+      'sgp-top-right',
+      'sgp-top-left',
+      'sgp-bottom-right',
+      'sgp-bottom-left',
+    );
+    this._clearInlinePosition();
+    this.domElement.classList.add(`sgp-${corner}`);
+  }
+
+  /** インラインの位置スタイルをクリアする */
+  _clearInlinePosition() {
+    const s = this.domElement.style;
+    s.removeProperty('left');
+    s.removeProperty('top');
+    s.removeProperty('right');
+    s.removeProperty('bottom');
+  }
+
+  // --- パブリック API ---
+
+  /**
+   * 値の型に応じたコントローラーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   * @returns {Controller}
+   */
+  add(obj, prop, min, max, step) {
+    if (typeof obj[prop] === 'boolean') {
+      const ctrl = new BooleanController(obj, prop);
+      this._childrenEl.appendChild(ctrl.domElement);
+      return ctrl;
+    }
+    const ctrl = new NumberController(obj, prop, min, max, step);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * カラーピッカーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @returns {Controller}
+   */
+  addColor(obj, prop) {
+    const ctrl = new ColorController(obj, prop);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * ボタンを追加する
+   * @param {string} label
+   * @param {() => void} callback
+   * @returns {ButtonController}
+   */
+  addButton(label, callback) {
+    const ctrl = new ButtonController(label, callback);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * 折りたたみフォルダを追加する
+   * @param {string} title
+   * @returns {SimpleGuiPill}
+   */
+  addFolder(title) {
+    return new SimpleGuiPill({ title, parent: this._childrenEl });
+  }
+
+  /** DOM とイベントリスナーを完全に除去する */
+  destroy() {
+    for (const cleanup of this._cleanupFns) {
+      cleanup();
+    }
+    this._cleanupFns = [];
+
+    if (this._isRoot && this.domElement.parentNode) {
+      this.domElement.parentNode.removeChild(this.domElement);
+    }
+
+    if (document.querySelectorAll('.sgp-container').length === 0) {
+      removeStyles();
+    }
+  }
+}
+
+export default SimpleGuiPill;

--- a/public/simple-gui-pill/simple-gui-pill.js
+++ b/public/simple-gui-pill/simple-gui-pill.js
@@ -375,10 +375,17 @@ class Controller {
       this._onChangeCallback(value);
     }
   }
+
+  /** DOM 表示を現在の値に同期する（サブクラスでオーバーライド） */
+  updateDisplay() {}
 }
 
 /** 数値コントローラー */
 class NumberController extends Controller {
+  /** @type {HTMLInputElement} */
+  _numberInput;
+  /** @type {HTMLInputElement | null} */
+  _rangeInput;
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -388,6 +395,8 @@ class NumberController extends Controller {
    */
   constructor(obj, prop, min, max, step) {
     super(obj, prop);
+
+    this._rangeInput = null;
 
     const label = document.createElement('span');
     label.classList.add('sgp-label');
@@ -404,6 +413,7 @@ class NumberController extends Controller {
     if (min !== undefined) numberInput.min = String(min);
     if (max !== undefined) numberInput.max = String(max);
     if (step !== undefined) numberInput.step = String(step);
+    this._numberInput = numberInput;
 
     if (hasRange) {
       const rangeInput = document.createElement('input');
@@ -412,6 +422,7 @@ class NumberController extends Controller {
       rangeInput.max = String(max);
       rangeInput.step = String(step ?? 1);
       rangeInput.value = String(obj[prop]);
+      this._rangeInput = rangeInput;
 
       rangeInput.addEventListener('input', () => {
         const val = Number(rangeInput.value);
@@ -436,10 +447,22 @@ class NumberController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    const val = String(this._obj[this._prop]);
+    this._numberInput.value = val;
+    if (this._rangeInput) {
+      this._rangeInput.value = val;
+    }
+  }
 }
 
 /** 真偽値コントローラー */
 class BooleanController extends Controller {
+  /** @type {HTMLInputElement} */
+  _checkbox;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -457,6 +480,7 @@ class BooleanController extends Controller {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.checked = /** @type {boolean} */ (obj[prop]);
+    this._checkbox = checkbox;
 
     checkbox.addEventListener('change', () => {
       this._setValue(checkbox.checked);
@@ -466,10 +490,18 @@ class BooleanController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._checkbox.checked = /** @type {boolean} */ (this._obj[this._prop]);
+  }
 }
 
 /** カラーコントローラー */
 class ColorController extends Controller {
+  /** @type {HTMLInputElement} */
+  _colorInput;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -487,6 +519,7 @@ class ColorController extends Controller {
     const colorInput = document.createElement('input');
     colorInput.type = 'color';
     colorInput.value = /** @type {string} */ (obj[prop]);
+    this._colorInput = colorInput;
 
     colorInput.addEventListener('input', () => {
       this._setValue(colorInput.value);
@@ -495,6 +528,11 @@ class ColorController extends Controller {
     control.appendChild(colorInput);
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
+  }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._colorInput.value = /** @type {string} */ (this._obj[this._prop]);
   }
 }
 
@@ -591,6 +629,10 @@ class SimpleGuiPill {
   _dragMoved;
   /** @type {Array<() => void>} */
   _cleanupFns;
+  /** @type {Controller[]} */
+  _controllers;
+  /** @type {SimpleGuiPill[]} */
+  _folders;
 
   /**
    * @param {{ title?: string, parent?: HTMLElement }} [options]
@@ -601,6 +643,8 @@ class SimpleGuiPill {
     injectStyles();
 
     this._isRoot = !parent;
+    this._controllers = [];
+    this._folders = [];
     this._expanded = false;
     this._corner = SnapCorner.TOP_RIGHT;
     this._isDragging = false;
@@ -861,10 +905,12 @@ class SimpleGuiPill {
     if (typeof obj[prop] === 'boolean') {
       const ctrl = new BooleanController(obj, prop);
       this._childrenEl.appendChild(ctrl.domElement);
+      this._controllers.push(ctrl);
       return ctrl;
     }
     const ctrl = new NumberController(obj, prop, min, max, step);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -877,6 +923,7 @@ class SimpleGuiPill {
   addColor(obj, prop) {
     const ctrl = new ColorController(obj, prop);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -898,7 +945,19 @@ class SimpleGuiPill {
    * @returns {SimpleGuiPill}
    */
   addFolder(title) {
-    return new SimpleGuiPill({ title, parent: this._childrenEl });
+    const folder = new SimpleGuiPill({ title, parent: this._childrenEl });
+    this._folders.push(folder);
+    return folder;
+  }
+
+  /** 全コントローラーとフォルダの DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    for (const ctrl of this._controllers) {
+      ctrl.updateDisplay();
+    }
+    for (const folder of this._folders) {
+      folder.updateDisplay();
+    }
   }
 
   /** DOM とイベントリスナーを完全に除去する */

--- a/public/simple-gui-pill/style.css
+++ b/public/simple-gui-pill/style.css
@@ -1,0 +1,47 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0a0a;
+  color: #e0e0e0;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/public/simple-gui-sheet/controllers.js
+++ b/public/simple-gui-sheet/controllers.js
@@ -48,11 +48,19 @@ export class Controller {
       this._onChangeCallback(value);
     }
   }
+
+  /** DOM 表示を現在の値に同期する（サブクラスでオーバーライド） */
+  updateDisplay() {}
 }
 
 // --- NumberController ---
 
 export class NumberController extends Controller {
+  /** @type {HTMLInputElement} */
+  _numberInput;
+  /** @type {HTMLInputElement | null} */
+  _rangeInput;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -62,6 +70,8 @@ export class NumberController extends Controller {
    */
   constructor(obj, prop, min, max, step) {
     super(obj, prop);
+
+    this._rangeInput = null;
 
     const label = document.createElement('span');
     label.classList.add('sgs-label');
@@ -78,6 +88,7 @@ export class NumberController extends Controller {
     if (min !== undefined) numberInput.min = String(min);
     if (max !== undefined) numberInput.max = String(max);
     if (step !== undefined) numberInput.step = String(step);
+    this._numberInput = numberInput;
 
     if (hasRange) {
       const rangeInput = document.createElement('input');
@@ -86,6 +97,7 @@ export class NumberController extends Controller {
       rangeInput.max = String(max);
       rangeInput.step = String(step ?? 1);
       rangeInput.value = String(obj[prop]);
+      this._rangeInput = rangeInput;
 
       rangeInput.addEventListener('input', () => {
         const val = Number(rangeInput.value);
@@ -110,11 +122,23 @@ export class NumberController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    const val = String(this._obj[this._prop]);
+    this._numberInput.value = val;
+    if (this._rangeInput) {
+      this._rangeInput.value = val;
+    }
+  }
 }
 
 // --- BooleanController ---
 
 export class BooleanController extends Controller {
+  /** @type {HTMLInputElement} */
+  _checkbox;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -132,6 +156,7 @@ export class BooleanController extends Controller {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.checked = /** @type {boolean} */ (obj[prop]);
+    this._checkbox = checkbox;
 
     checkbox.addEventListener('change', () => {
       this._setValue(checkbox.checked);
@@ -141,11 +166,19 @@ export class BooleanController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._checkbox.checked = /** @type {boolean} */ (this._obj[this._prop]);
+  }
 }
 
 // --- ColorController ---
 
 export class ColorController extends Controller {
+  /** @type {HTMLInputElement} */
+  _colorInput;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -163,6 +196,7 @@ export class ColorController extends Controller {
     const colorInput = document.createElement('input');
     colorInput.type = 'color';
     colorInput.value = /** @type {string} */ (obj[prop]);
+    this._colorInput = colorInput;
 
     colorInput.addEventListener('input', () => {
       this._setValue(colorInput.value);
@@ -171,6 +205,11 @@ export class ColorController extends Controller {
     control.appendChild(colorInput);
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
+  }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._colorInput.value = /** @type {string} */ (this._obj[this._prop]);
   }
 }
 

--- a/public/simple-gui-sheet/controllers.js
+++ b/public/simple-gui-sheet/controllers.js
@@ -1,0 +1,205 @@
+// @ts-check
+
+/**
+ * SimpleGuiSheet 用コントローラーモジュール
+ */
+
+// --- コントローラー基底クラス ---
+
+export class Controller {
+  /** @type {Record<string, unknown>} */
+  _obj;
+  /** @type {string} */
+  _prop;
+  /** @type {((value: unknown) => void) | null} */
+  _onChangeCallback;
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    this._obj = obj;
+    this._prop = prop;
+    this._onChangeCallback = null;
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgs-row');
+  }
+
+  /**
+   * onChange コールバックを設定する
+   * @param {(value: unknown) => void} callback
+   * @returns {this}
+   */
+  onChange(callback) {
+    this._onChangeCallback = callback;
+    return this;
+  }
+
+  /**
+   * 値を更新してコールバックを発火する
+   * @param {unknown} value
+   */
+  _setValue(value) {
+    this._obj[this._prop] = value;
+    if (this._onChangeCallback) {
+      this._onChangeCallback(value);
+    }
+  }
+}
+
+// --- NumberController ---
+
+export class NumberController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   */
+  constructor(obj, prop, min, max, step) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgs-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgs-control');
+
+    const hasRange = min !== undefined && max !== undefined;
+
+    const numberInput = document.createElement('input');
+    numberInput.type = 'number';
+    numberInput.value = String(obj[prop]);
+    if (min !== undefined) numberInput.min = String(min);
+    if (max !== undefined) numberInput.max = String(max);
+    if (step !== undefined) numberInput.step = String(step);
+
+    if (hasRange) {
+      const rangeInput = document.createElement('input');
+      rangeInput.type = 'range';
+      rangeInput.min = String(min);
+      rangeInput.max = String(max);
+      rangeInput.step = String(step ?? 1);
+      rangeInput.value = String(obj[prop]);
+
+      rangeInput.addEventListener('input', () => {
+        const val = Number(rangeInput.value);
+        numberInput.value = String(val);
+        this._setValue(val);
+      });
+
+      numberInput.addEventListener('input', () => {
+        const val = Number(numberInput.value);
+        rangeInput.value = String(val);
+        this._setValue(val);
+      });
+
+      control.appendChild(rangeInput);
+    } else {
+      numberInput.addEventListener('input', () => {
+        this._setValue(Number(numberInput.value));
+      });
+    }
+
+    control.appendChild(numberInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- BooleanController ---
+
+export class BooleanController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgs-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgs-control');
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = /** @type {boolean} */ (obj[prop]);
+
+    checkbox.addEventListener('change', () => {
+      this._setValue(checkbox.checked);
+    });
+
+    control.appendChild(checkbox);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- ColorController ---
+
+export class ColorController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgs-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgs-control');
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = /** @type {string} */ (obj[prop]);
+
+    colorInput.addEventListener('input', () => {
+      this._setValue(colorInput.value);
+    });
+
+    control.appendChild(colorInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- ButtonController ---
+
+export class ButtonController {
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {string} label
+   * @param {() => void} callback
+   */
+  constructor(label, callback) {
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgs-row');
+
+    const spacer = document.createElement('span');
+    spacer.classList.add('sgs-label');
+
+    const control = document.createElement('div');
+    control.classList.add('sgs-control');
+
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.addEventListener('click', callback);
+
+    control.appendChild(button);
+    this.domElement.appendChild(spacer);
+    this.domElement.appendChild(control);
+  }
+}

--- a/public/simple-gui-sheet/index.html
+++ b/public/simple-gui-sheet/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple GUI Sheet | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+  </body>
+</html>

--- a/public/simple-gui-sheet/main.js
+++ b/public/simple-gui-sheet/main.js
@@ -123,6 +123,7 @@ gui.add(params, 'visible');
 
 gui.addButton('Reset', () => {
   Object.assign(params, { ...defaults });
+  gui.updateDisplay();
 });
 
 const folder = gui.addFolder('Advanced');

--- a/public/simple-gui-sheet/main.js
+++ b/public/simple-gui-sheet/main.js
@@ -1,0 +1,130 @@
+// @ts-check
+import SimpleGuiSheet from './simple-gui-sheet.js';
+
+// --- パラメータ ---
+
+const params = {
+  color: '#007AFF',
+  size: 80,
+  speed: 30,
+  visible: true,
+  opacity: 0.8,
+  sides: 6,
+};
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
+
+// --- Canvas セットアップ ---
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** Canvas をウィンドウサイズに合わせる */
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画ロジック ---
+
+let angle = 0;
+
+/**
+ * hex カラー文字列を rgba 文字列に変換する
+ * @param {string} hex
+ * @param {number} alpha
+ * @returns {string}
+ */
+function hexToRgba(hex, alpha) {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * 正多角形を描画する
+ * @param {number} cx - 中心 X
+ * @param {number} cy - 中心 Y
+ * @param {number} radius - 半径
+ * @param {number} sides - 辺の数
+ * @param {number} rotation - 回転角度（ラジアン）
+ */
+function drawPolygon(cx, cy, radius, sides, rotation) {
+  ctx.beginPath();
+  for (let i = 0; i <= sides; i++) {
+    const a = (i / sides) * Math.PI * 2 - Math.PI / 2 + rotation;
+    const x = cx + radius * Math.cos(a);
+    const y = cy + radius * Math.sin(a);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+}
+
+/** メインの描画フレーム */
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (!params.visible) {
+    requestAnimationFrame(draw);
+    return;
+  }
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  // 軌道上を回転する位置
+  const orbitRadius = params.size * 1.5;
+  const ox = cx + orbitRadius * Math.cos(angle);
+  const oy = cy + orbitRadius * Math.sin(angle);
+
+  // メイン図形（回転する正多角形）
+  ctx.fillStyle = hexToRgba(params.color, params.opacity);
+  drawPolygon(ox, oy, params.size, params.sides, angle * 2);
+  ctx.fill();
+
+  // 中心の小さな円
+  ctx.fillStyle = hexToRgba(params.color, params.opacity * 0.4);
+  ctx.beginPath();
+  ctx.arc(cx, cy, params.size * 0.3, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 軌道の線
+  ctx.strokeStyle = hexToRgba(params.color, 0.15);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  angle += params.speed * 0.001;
+  requestAnimationFrame(draw);
+}
+
+requestAnimationFrame(draw);
+
+// --- GUI セットアップ ---
+
+const gui = new SimpleGuiSheet({ title: 'Settings' });
+
+gui.addColor(params, 'color');
+gui.add(params, 'size', 20, 200, 1);
+gui.add(params, 'speed', 0, 100, 1);
+gui.add(params, 'visible');
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+});
+
+const folder = gui.addFolder('Advanced');
+folder.add(params, 'opacity', 0, 1, 0.01);
+folder.add(params, 'sides', 3, 12, 1);

--- a/public/simple-gui-sheet/simple-gui-sheet.js
+++ b/public/simple-gui-sheet/simple-gui-sheet.js
@@ -80,6 +80,10 @@ class SimpleGuiSheet {
   _dragMoved;
   /** @type {Array<() => void>} */
   _cleanupFns;
+  /** @type {Controller[]} */
+  _controllers;
+  /** @type {SimpleGuiSheet[]} */
+  _folders;
 
   /**
    * @param {{ title?: string, parent?: HTMLElement }} [options]
@@ -90,6 +94,8 @@ class SimpleGuiSheet {
     injectStyles();
 
     this._isRoot = !parent;
+    this._controllers = [];
+    this._folders = [];
     this._state = SheetState.HALF;
     this._corner = SnapCorner.BOTTOM_RIGHT;
     this._isDragging = false;
@@ -382,10 +388,12 @@ class SimpleGuiSheet {
     if (typeof obj[prop] === 'boolean') {
       const ctrl = new BooleanController(obj, prop);
       this._childrenEl.appendChild(ctrl.domElement);
+      this._controllers.push(ctrl);
       return ctrl;
     }
     const ctrl = new NumberController(obj, prop, min, max, step);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -398,6 +406,7 @@ class SimpleGuiSheet {
   addColor(obj, prop) {
     const ctrl = new ColorController(obj, prop);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -419,7 +428,19 @@ class SimpleGuiSheet {
    * @returns {SimpleGuiSheet}
    */
   addFolder(title) {
-    return new SimpleGuiSheet({ title, parent: this._childrenEl });
+    const folder = new SimpleGuiSheet({ title, parent: this._childrenEl });
+    this._folders.push(folder);
+    return folder;
+  }
+
+  /** 全コントローラーとフォルダの DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    for (const ctrl of this._controllers) {
+      ctrl.updateDisplay();
+    }
+    for (const folder of this._folders) {
+      folder.updateDisplay();
+    }
   }
 
   /** DOM とイベントリスナーを完全に除去する */

--- a/public/simple-gui-sheet/simple-gui-sheet.js
+++ b/public/simple-gui-sheet/simple-gui-sheet.js
@@ -1,0 +1,443 @@
+// @ts-check
+
+/**
+ * SimpleGuiSheet - ボトムシート型 GUI ライブラリ
+ * iOS/Android のボトムシートを模したスライドアップ UI
+ * すりガラス風半透明背景、四隅スナップ、FAB 収納対応
+ */
+
+import {
+  BooleanController,
+  ButtonController,
+  ColorController,
+  Controller,
+  NumberController,
+} from './controllers.js';
+import { injectStyles, removeStyles } from './styles.js';
+
+/** シートの展開状態 */
+const SheetState = /** @type {const} */ ({
+  COLLAPSED: 'collapsed',
+  HALF: 'half',
+  FULL: 'full',
+  FAB: 'fab',
+});
+
+/** スナップ位置 */
+const SnapCorner = /** @type {const} */ ({
+  BOTTOM_RIGHT: 'bottom-right',
+  BOTTOM_LEFT: 'bottom-left',
+  TOP_RIGHT: 'top-right',
+  TOP_LEFT: 'top-left',
+});
+
+/** 歯車アイコンの SVG */
+const GEAR_SVG =
+  '<svg width="1.25em" height="1.25em" viewBox="0 0 24 24" fill="none" ' +
+  'stroke="currentColor" stroke-width="2" stroke-linecap="round" ' +
+  'stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 ' +
+  '0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22' +
+  '.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74' +
+  'l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 ' +
+  '0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2' +
+  'v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73' +
+  '-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0' +
+  ' 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73' +
+  'l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"' +
+  '/><circle cx="12" cy="12" r="3"/></svg>';
+
+/** ドラッグ判定の閾値 */
+const DRAG_THRESHOLD = 5;
+
+class SimpleGuiSheet {
+  /** @type {HTMLElement} */
+  domElement;
+  /** @type {HTMLElement} */
+  _childrenEl;
+  /** @type {HTMLElement} */
+  _bodyEl;
+  /** @type {HTMLElement} */
+  _handleEl;
+  /** @type {HTMLElement} */
+  _fabIconEl;
+  /** @type {boolean} */
+  _isRoot;
+  /** @type {typeof SheetState[keyof typeof SheetState]} */
+  _state;
+  /** @type {typeof SnapCorner[keyof typeof SnapCorner]} */
+  _corner;
+  /** @type {boolean} */
+  _isDragging;
+  /** @type {number} */
+  _dragStartX;
+  /** @type {number} */
+  _dragStartY;
+  /** @type {number} */
+  _dragOffsetX;
+  /** @type {number} */
+  _dragOffsetY;
+  /** @type {boolean} */
+  _dragMoved;
+  /** @type {Array<() => void>} */
+  _cleanupFns;
+
+  /**
+   * @param {{ title?: string, parent?: HTMLElement }} [options]
+   */
+  constructor(options = {}) {
+    const { title = 'Controls', parent } = options;
+
+    injectStyles();
+
+    this._isRoot = !parent;
+    this._state = SheetState.HALF;
+    this._corner = SnapCorner.BOTTOM_RIGHT;
+    this._isDragging = false;
+    this._dragStartX = 0;
+    this._dragStartY = 0;
+    this._dragOffsetX = 0;
+    this._dragOffsetY = 0;
+    this._dragMoved = false;
+    this._cleanupFns = [];
+    this._bodyEl = document.createElement('div');
+    this._handleEl = document.createElement('div');
+    this._fabIconEl = document.createElement('div');
+    this._childrenEl = document.createElement('div');
+
+    if (this._isRoot) {
+      this._buildRootPanel(title);
+    } else {
+      this._buildFolder(title, /** @type {HTMLElement} */ (parent));
+    }
+  }
+
+  /**
+   * ルートパネル（ボトムシート）を構築する
+   * @param {string} title
+   */
+  _buildRootPanel(title) {
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgs-sheet', 'sgs-bottom-right');
+    this._applyState(SheetState.HALF);
+
+    this._buildFabIcon();
+    this._buildHandle();
+    this._buildTitleBar(title);
+    this._buildBody();
+
+    document.body.appendChild(this.domElement);
+    this._setupDrag();
+    this._setupHandleTap();
+  }
+
+  /** FAB アイコンを構築する */
+  _buildFabIcon() {
+    this._fabIconEl.classList.add('sgs-fab-icon');
+    this._fabIconEl.innerHTML = GEAR_SVG;
+    this.domElement.appendChild(this._fabIconEl);
+
+    const onFabClick = () => {
+      if (this._state === SheetState.FAB) {
+        this._applyState(SheetState.HALF);
+      }
+    };
+    this._fabIconEl.addEventListener('click', onFabClick);
+    this._cleanupFns.push(() =>
+      this._fabIconEl.removeEventListener('click', onFabClick),
+    );
+  }
+
+  /** ハンドルバーを構築する */
+  _buildHandle() {
+    this._handleEl.classList.add('sgs-handle');
+    const bar = document.createElement('div');
+    bar.classList.add('sgs-handle-bar');
+    this._handleEl.appendChild(bar);
+    this.domElement.appendChild(this._handleEl);
+  }
+
+  /**
+   * タイトルバーを構築する
+   * @param {string} title
+   */
+  _buildTitleBar(title) {
+    const titleBar = document.createElement('div');
+    titleBar.classList.add('sgs-title');
+
+    const titleText = document.createElement('span');
+    titleText.textContent = title;
+
+    const minimizeBtn = document.createElement('button');
+    minimizeBtn.classList.add('sgs-minimize-btn');
+    minimizeBtn.textContent = '\u2212';
+    minimizeBtn.title = 'FAB\u306B\u53CE\u7D0D';
+    const onMinimize = () => this._applyState(SheetState.FAB);
+    minimizeBtn.addEventListener('click', onMinimize);
+    this._cleanupFns.push(() =>
+      minimizeBtn.removeEventListener('click', onMinimize),
+    );
+
+    titleBar.appendChild(titleText);
+    titleBar.appendChild(minimizeBtn);
+    this.domElement.appendChild(titleBar);
+  }
+
+  /** ボディ（スクロール領域）を構築する */
+  _buildBody() {
+    this._bodyEl.classList.add('sgs-body');
+    this._childrenEl.classList.add('sgs-children');
+    this._bodyEl.appendChild(this._childrenEl);
+    this.domElement.appendChild(this._bodyEl);
+  }
+
+  /**
+   * フォルダ（子パネル）を構築する
+   * @param {string} title
+   * @param {HTMLElement} parentEl
+   */
+  _buildFolder(title, parentEl) {
+    this.domElement = document.createElement('div');
+
+    const folderTitle = document.createElement('div');
+    folderTitle.classList.add('sgs-folder-title');
+
+    const folderText = document.createElement('span');
+    folderText.textContent = title;
+
+    const toggle = document.createElement('span');
+    toggle.classList.add('sgs-folder-toggle');
+    toggle.textContent = '\u25BC';
+
+    folderTitle.appendChild(folderText);
+    folderTitle.appendChild(toggle);
+
+    this._childrenEl.classList.add('sgs-folder-children');
+
+    folderTitle.addEventListener('click', () => {
+      const hidden = this._childrenEl.classList.toggle('sgs-hidden');
+      toggle.classList.toggle('sgs-collapsed', hidden);
+    });
+
+    this.domElement.appendChild(folderTitle);
+    this.domElement.appendChild(this._childrenEl);
+    parentEl.appendChild(this.domElement);
+  }
+
+  /**
+   * シートの状態を適用する
+   * @param {typeof SheetState[keyof typeof SheetState]} state
+   */
+  _applyState(state) {
+    this._state = state;
+    const el = this.domElement;
+    el.classList.remove(
+      'sgs-state-collapsed',
+      'sgs-state-half',
+      'sgs-state-full',
+      'sgs-state-fab',
+    );
+    el.classList.add(`sgs-state-${state}`);
+
+    if (state === SheetState.FAB) {
+      el.style.removeProperty('transform');
+    }
+  }
+
+  /** ハンドルバーのタップで展開状態を切り替える */
+  _setupHandleTap() {
+    const onClick = () => {
+      if (this._dragMoved) {
+        return;
+      }
+      if (this._state === SheetState.COLLAPSED) {
+        this._applyState(SheetState.HALF);
+      } else if (this._state === SheetState.HALF) {
+        this._applyState(SheetState.FULL);
+      } else if (this._state === SheetState.FULL) {
+        this._applyState(SheetState.COLLAPSED);
+      }
+    };
+    this._handleEl.addEventListener('click', onClick);
+    this._cleanupFns.push(() =>
+      this._handleEl.removeEventListener('click', onClick),
+    );
+  }
+
+  /** ドラッグ＆四隅スナップを設定する */
+  _setupDrag() {
+    /** @type {(e: PointerEvent) => void} */
+    const onDown = (e) => {
+      if (!this._handleEl.contains(/** @type {Node} */ (e.target))) {
+        return;
+      }
+      this._isDragging = true;
+      this._dragMoved = false;
+      const rect = this.domElement.getBoundingClientRect();
+      this._dragStartX = e.clientX;
+      this._dragStartY = e.clientY;
+      this._dragOffsetX = e.clientX - rect.left;
+      this._dragOffsetY = e.clientY - rect.top;
+      this.domElement.classList.add('sgs-dragging');
+      this._handleEl.setPointerCapture(e.pointerId);
+    };
+
+    /** @type {(e: PointerEvent) => void} */
+    const onMove = (e) => {
+      if (!this._isDragging) {
+        return;
+      }
+      const dx = e.clientX - this._dragStartX;
+      const dy = e.clientY - this._dragStartY;
+      if (
+        !this._dragMoved &&
+        Math.abs(dx) < DRAG_THRESHOLD &&
+        Math.abs(dy) < DRAG_THRESHOLD
+      ) {
+        return;
+      }
+      this._dragMoved = true;
+      this.domElement.style.left = `${e.clientX - this._dragOffsetX}px`;
+      this.domElement.style.top = `${e.clientY - this._dragOffsetY}px`;
+      this.domElement.style.right = 'auto';
+      this.domElement.style.bottom = 'auto';
+    };
+
+    /** @type {() => void} */
+    const onUp = () => {
+      if (!this._isDragging) {
+        return;
+      }
+      this._isDragging = false;
+      this.domElement.classList.remove('sgs-dragging');
+      if (!this._dragMoved) {
+        this._clearInlinePosition();
+        return;
+      }
+      this._snapToNearestCorner();
+    };
+
+    this._handleEl.addEventListener('pointerdown', onDown);
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+    this._cleanupFns.push(() => {
+      this._handleEl.removeEventListener('pointerdown', onDown);
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+    });
+  }
+
+  /** 最も近い四隅にスナップする */
+  _snapToNearestCorner() {
+    const rect = this.domElement.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const isRight = cx > window.innerWidth / 2;
+    const isBottom = cy > window.innerHeight / 2;
+
+    /** @type {typeof SnapCorner[keyof typeof SnapCorner]} */
+    let corner;
+    if (isBottom && isRight) {
+      corner = SnapCorner.BOTTOM_RIGHT;
+    } else if (isBottom) {
+      corner = SnapCorner.BOTTOM_LEFT;
+    } else if (isRight) {
+      corner = SnapCorner.TOP_RIGHT;
+    } else {
+      corner = SnapCorner.TOP_LEFT;
+    }
+
+    this._corner = corner;
+    this.domElement.classList.remove(
+      'sgs-bottom-right',
+      'sgs-bottom-left',
+      'sgs-top-right',
+      'sgs-top-left',
+    );
+    this._clearInlinePosition();
+    this.domElement.classList.add(`sgs-${corner}`);
+    this._applyState(this._state);
+  }
+
+  /** インラインの位置スタイルをクリアする */
+  _clearInlinePosition() {
+    const s = this.domElement.style;
+    s.removeProperty('left');
+    s.removeProperty('top');
+    s.removeProperty('right');
+    s.removeProperty('bottom');
+  }
+
+  // --- パブリック API ---
+
+  /**
+   * 値の型に応じたコントローラーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   * @returns {Controller}
+   */
+  add(obj, prop, min, max, step) {
+    if (typeof obj[prop] === 'boolean') {
+      const ctrl = new BooleanController(obj, prop);
+      this._childrenEl.appendChild(ctrl.domElement);
+      return ctrl;
+    }
+    const ctrl = new NumberController(obj, prop, min, max, step);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * カラーピッカーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @returns {Controller}
+   */
+  addColor(obj, prop) {
+    const ctrl = new ColorController(obj, prop);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * ボタンを追加する
+   * @param {string} label
+   * @param {() => void} callback
+   * @returns {ButtonController}
+   */
+  addButton(label, callback) {
+    const ctrl = new ButtonController(label, callback);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * 折りたたみフォルダを追加する
+   * @param {string} title
+   * @returns {SimpleGuiSheet}
+   */
+  addFolder(title) {
+    return new SimpleGuiSheet({ title, parent: this._childrenEl });
+  }
+
+  /** DOM とイベントリスナーを完全に除去する */
+  destroy() {
+    for (const cleanup of this._cleanupFns) {
+      cleanup();
+    }
+    this._cleanupFns = [];
+
+    if (this._isRoot && this.domElement.parentNode) {
+      this.domElement.parentNode.removeChild(this.domElement);
+    }
+
+    // 他のインスタンスがなければスタイルも除去
+    if (document.querySelectorAll('.sgs-sheet').length === 0) {
+      removeStyles();
+    }
+  }
+}
+
+export default SimpleGuiSheet;

--- a/public/simple-gui-sheet/style.css
+++ b/public/simple-gui-sheet/style.css
@@ -1,0 +1,47 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #f2f2f7;
+  color: #1c1c1e;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #8e8e93;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #007aff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/public/simple-gui-sheet/styles.js
+++ b/public/simple-gui-sheet/styles.js
@@ -249,13 +249,15 @@ export function injectStyles() {
 
     .sgs-control input[type="range"] {
       flex: 1;
+      min-width: 0;
       height: 0.25rem;
       accent-color: var(--sgs-accent);
       cursor: pointer;
     }
 
     .sgs-control input[type="number"] {
-      width: 3.75rem;
+      width: 27%;
+      min-width: 2.5rem;
       background: var(--sgs-input-bg);
       border: 0.0625rem solid var(--sgs-border);
       border-radius: 0.375rem;

--- a/public/simple-gui-sheet/styles.js
+++ b/public/simple-gui-sheet/styles.js
@@ -1,0 +1,355 @@
+// @ts-check
+
+/**
+ * SimpleGuiSheet 用スタイル注入モジュール
+ */
+
+const STYLE_ID = 'simple-gui-sheet-style';
+
+/**
+ * スタイルを注入する（一度だけ）
+ */
+export function injectStyles() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    :root {
+      --sgs-bg: rgba(255, 255, 255, 0.72);
+      --sgs-bg-hover: rgba(240, 240, 245, 0.85);
+      --sgs-border: rgba(200, 200, 210, 0.5);
+      --sgs-text: #1c1c1e;
+      --sgs-text-dim: #8e8e93;
+      --sgs-accent: #007AFF;
+      --sgs-accent-hover: #0066d6;
+      --sgs-input-bg: rgba(240, 240, 245, 0.8);
+      --sgs-folder-bg: rgba(245, 245, 250, 0.6);
+      --sgs-radius: 0.75rem;
+      --sgs-font-size: 0.8125rem;
+      --sgs-row-height: 2.25rem;
+      --sgs-padding: 0.75rem;
+      --sgs-width: 20rem;
+      --sgs-handle-height: 1.75rem;
+      --sgs-shadow: 0 -0.25rem 1.5rem rgba(0, 0, 0, 0.12);
+      --sgs-fab-size: 3rem;
+      --sgs-transition: 0.35s cubic-bezier(0.32, 0.72, 0, 1);
+    }
+
+    .sgs-sheet {
+      position: fixed;
+      width: var(--sgs-width);
+      max-width: 90%;
+      font-family: system-ui, -apple-system, sans-serif;
+      font-size: var(--sgs-font-size);
+      color: var(--sgs-text);
+      background: var(--sgs-bg);
+      backdrop-filter: blur(1.5rem) saturate(180%);
+      -webkit-backdrop-filter: blur(1.5rem) saturate(180%);
+      border: 0.0625rem solid var(--sgs-border);
+      border-radius: var(--sgs-radius) var(--sgs-radius) 0 0;
+      z-index: 10000;
+      user-select: none;
+      box-shadow: var(--sgs-shadow);
+      transition:
+        transform var(--sgs-transition),
+        left var(--sgs-transition),
+        bottom var(--sgs-transition),
+        top var(--sgs-transition),
+        right var(--sgs-transition),
+        width var(--sgs-transition),
+        height var(--sgs-transition),
+        border-radius var(--sgs-transition),
+        opacity var(--sgs-transition);
+      overflow: hidden;
+    }
+
+    .sgs-sheet.sgs-dragging {
+      transition: none;
+    }
+
+    .sgs-sheet.sgs-bottom-right {
+      bottom: 0;
+      right: 1rem;
+    }
+
+    .sgs-sheet.sgs-bottom-left {
+      bottom: 0;
+      left: 1rem;
+    }
+
+    .sgs-sheet.sgs-top-right {
+      top: 0;
+      right: 1rem;
+      border-radius: 0 0 var(--sgs-radius) var(--sgs-radius);
+    }
+
+    .sgs-sheet.sgs-top-left {
+      top: 0;
+      left: 1rem;
+      border-radius: 0 0 var(--sgs-radius) var(--sgs-radius);
+    }
+
+    .sgs-sheet.sgs-state-collapsed {
+      transform: translateY(calc(100% - var(--sgs-handle-height)));
+    }
+
+    .sgs-sheet.sgs-top-right.sgs-state-collapsed,
+    .sgs-sheet.sgs-top-left.sgs-state-collapsed {
+      transform: translateY(calc(-100% + var(--sgs-handle-height)));
+    }
+
+    .sgs-sheet.sgs-state-half {
+      height: 40vh;
+      transform: translateY(0);
+    }
+
+    .sgs-sheet.sgs-state-full {
+      height: 80vh;
+      transform: translateY(0);
+    }
+
+    .sgs-sheet.sgs-state-fab {
+      width: var(--sgs-fab-size);
+      height: var(--sgs-fab-size);
+      border-radius: 50%;
+      overflow: hidden;
+      cursor: pointer;
+      box-shadow: 0 0.125rem 0.75rem rgba(0, 0, 0, 0.2);
+    }
+
+    .sgs-sheet.sgs-state-fab.sgs-bottom-right {
+      bottom: 1rem;
+      right: 1rem;
+    }
+
+    .sgs-sheet.sgs-state-fab.sgs-bottom-left {
+      bottom: 1rem;
+      left: 1rem;
+    }
+
+    .sgs-sheet.sgs-state-fab.sgs-top-right {
+      top: 1rem;
+      right: 1rem;
+    }
+
+    .sgs-sheet.sgs-state-fab.sgs-top-left {
+      top: 1rem;
+      left: 1rem;
+    }
+
+    .sgs-fab-icon {
+      display: none;
+      width: 100%;
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      background: var(--sgs-accent);
+      color: #fff;
+      font-size: 1.25rem;
+      line-height: 1;
+    }
+
+    .sgs-state-fab .sgs-fab-icon {
+      display: flex;
+    }
+
+    .sgs-state-fab .sgs-handle,
+    .sgs-state-fab .sgs-title,
+    .sgs-state-fab .sgs-body {
+      display: none;
+    }
+
+    .sgs-handle {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: var(--sgs-handle-height);
+      cursor: grab;
+      touch-action: none;
+    }
+
+    .sgs-handle:active {
+      cursor: grabbing;
+    }
+
+    .sgs-handle-bar {
+      width: 2.25rem;
+      height: 0.25rem;
+      border-radius: 0.125rem;
+      background: rgba(150, 150, 160, 0.5);
+    }
+
+    .sgs-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 var(--sgs-padding) 0.375rem;
+      font-weight: 600;
+      font-size: 0.875rem;
+      color: var(--sgs-text);
+    }
+
+    .sgs-minimize-btn {
+      background: none;
+      border: none;
+      color: var(--sgs-accent);
+      font-size: 1rem;
+      cursor: pointer;
+      padding: 0.125rem 0.25rem;
+      line-height: 1;
+      border-radius: 0.25rem;
+    }
+
+    .sgs-minimize-btn:hover {
+      background: var(--sgs-bg-hover);
+    }
+
+    .sgs-body {
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .sgs-children {
+      overflow: hidden;
+    }
+
+    .sgs-children.sgs-hidden {
+      display: none;
+    }
+
+    .sgs-row {
+      display: flex;
+      align-items: center;
+      padding: 0.25rem var(--sgs-padding);
+      min-height: var(--sgs-row-height);
+      border-bottom: 0.0625rem solid var(--sgs-border);
+    }
+
+    .sgs-row:hover {
+      background: var(--sgs-bg-hover);
+    }
+
+    .sgs-label {
+      flex: 0 0 40%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--sgs-text-dim);
+    }
+
+    .sgs-control {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .sgs-control input[type="range"] {
+      flex: 1;
+      height: 0.25rem;
+      accent-color: var(--sgs-accent);
+      cursor: pointer;
+    }
+
+    .sgs-control input[type="number"] {
+      width: 3.75rem;
+      background: var(--sgs-input-bg);
+      border: 0.0625rem solid var(--sgs-border);
+      border-radius: 0.375rem;
+      color: var(--sgs-text);
+      font-size: var(--sgs-font-size);
+      padding: 0.25rem 0.375rem;
+      text-align: right;
+    }
+
+    .sgs-control input[type="number"]:focus {
+      outline: 0.125rem solid var(--sgs-accent);
+      outline-offset: -0.0625rem;
+    }
+
+    .sgs-control input[type="checkbox"] {
+      accent-color: var(--sgs-accent);
+      cursor: pointer;
+      width: 1rem;
+      height: 1rem;
+    }
+
+    .sgs-control input[type="color"] {
+      width: 100%;
+      height: var(--sgs-row-height);
+      border: none;
+      background: none;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .sgs-control button {
+      width: 100%;
+      padding: 0.375rem 0.75rem;
+      background: var(--sgs-accent);
+      color: #fff;
+      border: none;
+      border-radius: 0.375rem;
+      font-size: var(--sgs-font-size);
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .sgs-control button:hover {
+      background: var(--sgs-accent-hover);
+    }
+
+    .sgs-control button:active {
+      transform: scale(0.98);
+    }
+
+    .sgs-folder-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.25rem var(--sgs-padding);
+      min-height: var(--sgs-row-height);
+      border-bottom: 0.0625rem solid var(--sgs-border);
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--sgs-accent);
+    }
+
+    .sgs-folder-title:hover {
+      background: var(--sgs-bg-hover);
+    }
+
+    .sgs-folder-children {
+      padding-left: 0.5rem;
+      background: var(--sgs-folder-bg);
+    }
+
+    .sgs-folder-children.sgs-hidden {
+      display: none;
+    }
+
+    .sgs-folder-toggle {
+      transition: transform 0.2s;
+      font-size: 0.625rem;
+    }
+
+    .sgs-folder-toggle.sgs-collapsed {
+      transform: rotate(-90deg);
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+/**
+ * スタイル要素を除去する
+ */
+export function removeStyles() {
+  const styleEl = document.getElementById(STYLE_ID);
+  if (styleEl) {
+    styleEl.remove();
+  }
+}

--- a/public/simple-gui-tab/index.html
+++ b/public/simple-gui-tab/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple GUI Tab | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+  </body>
+</html>

--- a/public/simple-gui-tab/main.js
+++ b/public/simple-gui-tab/main.js
@@ -123,6 +123,7 @@ gui.add(params, 'visible');
 
 gui.addButton('Reset', () => {
   Object.assign(params, { ...defaults });
+  gui.updateDisplay();
 });
 
 const folder = gui.addFolder('Advanced');

--- a/public/simple-gui-tab/main.js
+++ b/public/simple-gui-tab/main.js
@@ -1,0 +1,132 @@
+// @ts-check
+import SimpleGuiTab from './simple-gui-tab.js';
+
+// --- パラメータ ---
+
+const params = {
+  color: '#BF5AF2',
+  size: 80,
+  speed: 30,
+  visible: true,
+  opacity: 0.8,
+  sides: 5,
+};
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
+
+// --- Canvas セットアップ ---
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** Canvas をウィンドウサイズに合わせる */
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画ロジック ---
+
+let angle = 0;
+
+/**
+ * hex カラー文字列を rgba 文字列に変換する
+ * @param {string} hex
+ * @param {number} alpha
+ * @returns {string}
+ */
+function hexToRgba(hex, alpha) {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * 正多角形を描画する
+ * @param {number} cx - 中心 X
+ * @param {number} cy - 中心 Y
+ * @param {number} radius - 半径
+ * @param {number} sides - 辺の数
+ * @param {number} rotation - 回転角度（ラジアン）
+ */
+function drawPolygon(cx, cy, radius, sides, rotation) {
+  ctx.beginPath();
+  for (let i = 0; i <= sides; i++) {
+    const a = (i / sides) * Math.PI * 2 - Math.PI / 2 + rotation;
+    const x = cx + radius * Math.cos(a);
+    const y = cy + radius * Math.sin(a);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+}
+
+/** メインの描画フレーム */
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (!params.visible) {
+    requestAnimationFrame(draw);
+    return;
+  }
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  // 軌道上を回転する位置
+  const orbitRadius = params.size * 1.5;
+  const ox = cx + orbitRadius * Math.cos(angle);
+  const oy = cy + orbitRadius * Math.sin(angle);
+
+  // メイン図形（回転する正多角形）
+  ctx.fillStyle = hexToRgba(params.color, params.opacity);
+  drawPolygon(ox, oy, params.size, params.sides, angle * 2);
+  ctx.fill();
+
+  // 中心の小さな円
+  ctx.fillStyle = hexToRgba(params.color, params.opacity * 0.4);
+  ctx.beginPath();
+  ctx.arc(cx, cy, params.size * 0.3, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 軌道の線
+  ctx.strokeStyle = hexToRgba(params.color, 0.15);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  angle += params.speed * 0.001;
+  requestAnimationFrame(draw);
+}
+
+requestAnimationFrame(draw);
+
+// --- GUI セットアップ ---
+
+const gui = new SimpleGuiTab({ title: 'General' });
+
+gui.addColor(params, 'color');
+gui.add(params, 'size', 20, 200, 1);
+gui.add(params, 'speed', 0, 100, 1);
+gui.add(params, 'visible');
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+});
+
+const folder = gui.addFolder('Advanced');
+folder.add(params, 'opacity', 0, 1, 0.01);
+folder.add(params, 'sides', 3, 12, 1).onChange((v) => {
+  params.sides = /** @type {number} */ (v);
+});

--- a/public/simple-gui-tab/simple-gui-tab.js
+++ b/public/simple-gui-tab/simple-gui-tab.js
@@ -356,10 +356,17 @@ class Controller {
       this._onChangeCallback(value);
     }
   }
+
+  /** DOM 表示を現在の値に同期する（サブクラスでオーバーライド） */
+  updateDisplay() {}
 }
 
 /** 数値コントローラー */
 class NumberController extends Controller {
+  /** @type {HTMLInputElement} */
+  _numberInput;
+  /** @type {HTMLInputElement | null} */
+  _rangeInput;
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -369,6 +376,8 @@ class NumberController extends Controller {
    */
   constructor(obj, prop, min, max, step) {
     super(obj, prop);
+
+    this._rangeInput = null;
 
     const label = document.createElement('span');
     label.classList.add('sgt-label');
@@ -385,6 +394,7 @@ class NumberController extends Controller {
     if (min !== undefined) numberInput.min = String(min);
     if (max !== undefined) numberInput.max = String(max);
     if (step !== undefined) numberInput.step = String(step);
+    this._numberInput = numberInput;
 
     if (hasRange) {
       const rangeInput = document.createElement('input');
@@ -393,6 +403,7 @@ class NumberController extends Controller {
       rangeInput.max = String(max);
       rangeInput.step = String(step ?? 1);
       rangeInput.value = String(obj[prop]);
+      this._rangeInput = rangeInput;
 
       rangeInput.addEventListener('input', () => {
         const val = Number(rangeInput.value);
@@ -417,10 +428,22 @@ class NumberController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    const val = String(this._obj[this._prop]);
+    this._numberInput.value = val;
+    if (this._rangeInput) {
+      this._rangeInput.value = val;
+    }
+  }
 }
 
 /** 真偽値コントローラー */
 class BooleanController extends Controller {
+  /** @type {HTMLInputElement} */
+  _checkbox;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -438,6 +461,7 @@ class BooleanController extends Controller {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.checked = /** @type {boolean} */ (obj[prop]);
+    this._checkbox = checkbox;
 
     checkbox.addEventListener('change', () => {
       this._setValue(checkbox.checked);
@@ -447,10 +471,18 @@ class BooleanController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._checkbox.checked = /** @type {boolean} */ (this._obj[this._prop]);
+  }
 }
 
 /** カラーコントローラー */
 class ColorController extends Controller {
+  /** @type {HTMLInputElement} */
+  _colorInput;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -468,6 +500,7 @@ class ColorController extends Controller {
     const colorInput = document.createElement('input');
     colorInput.type = 'color';
     colorInput.value = /** @type {string} */ (obj[prop]);
+    this._colorInput = colorInput;
 
     colorInput.addEventListener('input', () => {
       this._setValue(colorInput.value);
@@ -476,6 +509,11 @@ class ColorController extends Controller {
     control.appendChild(colorInput);
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
+  }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._colorInput.value = /** @type {string} */ (this._obj[this._prop]);
   }
 }
 
@@ -573,6 +611,10 @@ class SimpleGuiTab {
   _cleanupFns;
   /** @type {number} */
   _iconCounter;
+  /** @type {Controller[]} */
+  _controllers;
+  /** @type {SimpleGuiTabFolder[]} */
+  _folders;
 
   /**
    * @param {{ title?: string }} [options]
@@ -583,6 +625,8 @@ class SimpleGuiTab {
     injectStyles();
 
     this._tabs = [];
+    this._controllers = [];
+    this._folders = [];
     this._activeTabIndex = 0;
     this._expanded = false;
     this._corner = SnapCorner.TOP_RIGHT;
@@ -873,10 +917,12 @@ class SimpleGuiTab {
     if (typeof obj[prop] === 'boolean') {
       const ctrl = new BooleanController(obj, prop);
       this._currentChildren().appendChild(ctrl.domElement);
+      this._controllers.push(ctrl);
       return ctrl;
     }
     const ctrl = new NumberController(obj, prop, min, max, step);
     this._currentChildren().appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -889,6 +935,7 @@ class SimpleGuiTab {
   addColor(obj, prop) {
     const ctrl = new ColorController(obj, prop);
     this._currentChildren().appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -911,7 +958,19 @@ class SimpleGuiTab {
    */
   addFolder(title) {
     const tab = this._createTab(title);
-    return new SimpleGuiTabFolder(tab.childrenEl);
+    const folder = new SimpleGuiTabFolder(tab.childrenEl);
+    this._folders.push(folder);
+    return folder;
+  }
+
+  /** 全コントローラーとフォルダの DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    for (const ctrl of this._controllers) {
+      ctrl.updateDisplay();
+    }
+    for (const folder of this._folders) {
+      folder.updateDisplay();
+    }
   }
 
   /** DOM とイベントリスナーを完全に除去する */
@@ -938,12 +997,15 @@ class SimpleGuiTab {
 class SimpleGuiTabFolder {
   /** @type {HTMLElement} */
   _childrenEl;
+  /** @type {Controller[]} */
+  _controllers;
 
   /**
    * @param {HTMLElement} childrenEl
    */
   constructor(childrenEl) {
     this._childrenEl = childrenEl;
+    this._controllers = [];
   }
 
   /**
@@ -959,10 +1021,12 @@ class SimpleGuiTabFolder {
     if (typeof obj[prop] === 'boolean') {
       const ctrl = new BooleanController(obj, prop);
       this._childrenEl.appendChild(ctrl.domElement);
+      this._controllers.push(ctrl);
       return ctrl;
     }
     const ctrl = new NumberController(obj, prop, min, max, step);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -975,6 +1039,7 @@ class SimpleGuiTabFolder {
   addColor(obj, prop) {
     const ctrl = new ColorController(obj, prop);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -988,6 +1053,13 @@ class SimpleGuiTabFolder {
     const ctrl = new ButtonController(label, callback);
     this._childrenEl.appendChild(ctrl.domElement);
     return ctrl;
+  }
+
+  /** 全コントローラーの DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    for (const ctrl of this._controllers) {
+      ctrl.updateDisplay();
+    }
   }
 }
 

--- a/public/simple-gui-tab/simple-gui-tab.js
+++ b/public/simple-gui-tab/simple-gui-tab.js
@@ -1,0 +1,994 @@
+// @ts-check
+
+/**
+ * SimpleGuiTab - タブバー型 GUI ライブラリ
+ * モバイルアプリの下部タブバー風 UI
+ * addFolder() が新タブとして追加される
+ * 四隅にドラッグでスナップ・収納対応
+ *
+ * 単一ファイル構成: CSS も JS から注入する
+ */
+
+// ========================================
+// SVG アイコン定義
+// ========================================
+
+const ICONS = {
+  general: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
+  sliders: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>`,
+  layers: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>`,
+  eye: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>`,
+  zap: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>`,
+  star: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>`,
+};
+
+/** アイコン名の一覧（タブに循環的に割り当てる） */
+const ICON_KEYS = ['general', 'sliders', 'layers', 'eye', 'zap', 'star'];
+
+// ========================================
+// スタイル注入
+// ========================================
+
+const STYLE_ID = 'simple-gui-tab-style';
+
+/** スタイルを注入する（一度だけ） */
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    :root {
+      --sgt-bg: #1c1c1e;
+      --sgt-bg-panel: #2c2c2e;
+      --sgt-bg-hover: #3a3a3c;
+      --sgt-border: #38383a;
+      --sgt-text: #ffffff;
+      --sgt-text-dim: #98989d;
+      --sgt-accent: #BF5AF2;
+      --sgt-accent-hover: #c96ef5;
+      --sgt-input-bg: #0a0a0a;
+      --sgt-font-size: 0.75rem;
+      --sgt-row-height: 1.75rem;
+      --sgt-padding: 0.5rem;
+      --sgt-width: 17rem;
+      --sgt-tab-height: 2.75rem;
+      --sgt-transition: 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+      --sgt-margin: 0.75rem;
+      --sgt-radius: 0.75rem;
+    }
+
+    .sgt-container {
+      position: fixed;
+      z-index: 10000;
+      font-family: system-ui, -apple-system, sans-serif;
+      font-size: var(--sgt-font-size);
+      color: var(--sgt-text);
+      user-select: none;
+      touch-action: none;
+      width: var(--sgt-width);
+    }
+
+    .sgt-container.sgt-top-right {
+      top: var(--sgt-margin);
+      right: var(--sgt-margin);
+    }
+    .sgt-container.sgt-top-left {
+      top: var(--sgt-margin);
+      left: var(--sgt-margin);
+    }
+    .sgt-container.sgt-bottom-right {
+      bottom: var(--sgt-margin);
+      right: var(--sgt-margin);
+    }
+    .sgt-container.sgt-bottom-left {
+      bottom: var(--sgt-margin);
+      left: var(--sgt-margin);
+    }
+
+    .sgt-shell {
+      background: var(--sgt-bg);
+      border-radius: var(--sgt-radius);
+      box-shadow: 0 0.25rem 1.5rem rgba(0, 0, 0, 0.5),
+                  0 0 0 0.0625rem rgba(255, 255, 255, 0.06);
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* 下隅スナップ時はタブを下に配置 */
+    .sgt-container.sgt-bottom-right .sgt-shell,
+    .sgt-container.sgt-bottom-left .sgt-shell {
+      flex-direction: column-reverse;
+    }
+
+    .sgt-container.sgt-dragging .sgt-shell {
+      opacity: 0.85;
+    }
+
+    /* タブバー */
+    .sgt-tab-bar {
+      display: flex;
+      align-items: stretch;
+      background: var(--sgt-bg);
+      border-bottom: 0.0625rem solid var(--sgt-border);
+      min-height: var(--sgt-tab-height);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    .sgt-container.sgt-bottom-right .sgt-tab-bar,
+    .sgt-container.sgt-bottom-left .sgt-tab-bar {
+      border-bottom: none;
+      border-top: 0.0625rem solid var(--sgt-border);
+    }
+
+    .sgt-tab {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.125rem;
+      padding: 0.25rem 0.125rem;
+      cursor: pointer;
+      color: var(--sgt-text-dim);
+      transition: color 0.2s, background 0.2s;
+      border: none;
+      background: none;
+      font-family: inherit;
+      font-size: 0.5625rem;
+      min-width: 0;
+    }
+
+    .sgt-tab:hover {
+      background: var(--sgt-bg-hover);
+    }
+
+    .sgt-tab.sgt-tab-active {
+      color: var(--sgt-accent);
+    }
+
+    .sgt-tab-icon {
+      width: 1.125rem;
+      height: 1.125rem;
+      flex-shrink: 0;
+    }
+
+    .sgt-tab-icon svg {
+      width: 100%;
+      height: 100%;
+    }
+
+    .sgt-tab-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 100%;
+    }
+
+    /* コンテンツエリア */
+    .sgt-content-area {
+      position: relative;
+      overflow: hidden;
+      transition: max-height var(--sgt-transition);
+      max-height: 0;
+    }
+
+    .sgt-container.sgt-expanded .sgt-content-area {
+      max-height: 60vh;
+    }
+
+    .sgt-tab-panel {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s ease;
+    }
+
+    .sgt-tab-panel.sgt-panel-active {
+      position: relative;
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .sgt-panel-scroll {
+      overflow-y: auto;
+      overflow-x: hidden;
+      max-height: 55vh;
+    }
+
+    .sgt-children {
+      padding: 0.25rem 0;
+    }
+
+    /* コントローラー行 */
+    .sgt-row {
+      display: flex;
+      align-items: center;
+      padding: 0.25rem var(--sgt-padding);
+      min-height: var(--sgt-row-height);
+      border-top: 0.0625rem solid var(--sgt-border);
+    }
+
+    .sgt-row:first-child {
+      border-top: none;
+    }
+
+    .sgt-row:hover {
+      background: var(--sgt-bg-hover);
+    }
+
+    .sgt-label {
+      flex: 0 0 40%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--sgt-text-dim);
+    }
+
+    .sgt-control {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .sgt-control input[type="range"] {
+      flex: 1;
+      min-width: 0;
+      height: 0.25rem;
+      accent-color: var(--sgt-accent);
+      cursor: pointer;
+    }
+
+    .sgt-control input[type="number"] {
+      width: 27%;
+      min-width: 2.5rem;
+      flex-shrink: 0;
+      background: var(--sgt-input-bg);
+      border: 0.0625rem solid var(--sgt-border);
+      border-radius: 0.25rem;
+      color: var(--sgt-text);
+      font-size: var(--sgt-font-size);
+      padding: 0.125rem 0.25rem;
+      text-align: right;
+    }
+
+    .sgt-control input[type="number"]:focus {
+      outline: 0.0625rem solid var(--sgt-accent);
+    }
+
+    .sgt-control input[type="checkbox"] {
+      accent-color: var(--sgt-accent);
+      cursor: pointer;
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+
+    .sgt-control input[type="color"] {
+      width: 100%;
+      height: var(--sgt-row-height);
+      border: none;
+      background: none;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .sgt-control button {
+      width: 100%;
+      padding: 0.25rem 0.5rem;
+      background: var(--sgt-accent);
+      color: #fff;
+      border: none;
+      border-radius: 0.25rem;
+      font-size: var(--sgt-font-size);
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .sgt-control button:hover {
+      background: var(--sgt-accent-hover);
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+/** スタイル要素を除去する */
+function removeStyles() {
+  const styleEl = document.getElementById(STYLE_ID);
+  if (styleEl) {
+    styleEl.remove();
+  }
+}
+
+// ========================================
+// コントローラー
+// ========================================
+
+/** コントローラー基底クラス */
+class Controller {
+  /** @type {Record<string, unknown>} */
+  _obj;
+  /** @type {string} */
+  _prop;
+  /** @type {((value: unknown) => void) | null} */
+  _onChangeCallback;
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    this._obj = obj;
+    this._prop = prop;
+    this._onChangeCallback = null;
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgt-row');
+  }
+
+  /**
+   * onChange コールバックを設定する
+   * @param {(value: unknown) => void} callback
+   * @returns {this}
+   */
+  onChange(callback) {
+    this._onChangeCallback = callback;
+    return this;
+  }
+
+  /**
+   * 値を更新してコールバックを発火する
+   * @param {unknown} value
+   */
+  _setValue(value) {
+    this._obj[this._prop] = value;
+    if (this._onChangeCallback) {
+      this._onChangeCallback(value);
+    }
+  }
+}
+
+/** 数値コントローラー */
+class NumberController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   */
+  constructor(obj, prop, min, max, step) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgt-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgt-control');
+
+    const hasRange = min !== undefined && max !== undefined;
+
+    const numberInput = document.createElement('input');
+    numberInput.type = 'number';
+    numberInput.value = String(obj[prop]);
+    if (min !== undefined) numberInput.min = String(min);
+    if (max !== undefined) numberInput.max = String(max);
+    if (step !== undefined) numberInput.step = String(step);
+
+    if (hasRange) {
+      const rangeInput = document.createElement('input');
+      rangeInput.type = 'range';
+      rangeInput.min = String(min);
+      rangeInput.max = String(max);
+      rangeInput.step = String(step ?? 1);
+      rangeInput.value = String(obj[prop]);
+
+      rangeInput.addEventListener('input', () => {
+        const val = Number(rangeInput.value);
+        numberInput.value = String(val);
+        this._setValue(val);
+      });
+
+      numberInput.addEventListener('input', () => {
+        const val = Number(numberInput.value);
+        rangeInput.value = String(val);
+        this._setValue(val);
+      });
+
+      control.appendChild(rangeInput);
+    } else {
+      numberInput.addEventListener('input', () => {
+        this._setValue(Number(numberInput.value));
+      });
+    }
+
+    control.appendChild(numberInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+/** 真偽値コントローラー */
+class BooleanController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgt-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgt-control');
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = /** @type {boolean} */ (obj[prop]);
+
+    checkbox.addEventListener('change', () => {
+      this._setValue(checkbox.checked);
+    });
+
+    control.appendChild(checkbox);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+/** カラーコントローラー */
+class ColorController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sgt-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sgt-control');
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = /** @type {string} */ (obj[prop]);
+
+    colorInput.addEventListener('input', () => {
+      this._setValue(colorInput.value);
+    });
+
+    control.appendChild(colorInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+/** ボタンコントローラー */
+class ButtonController {
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {string} label
+   * @param {() => void} callback
+   */
+  constructor(label, callback) {
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sgt-row');
+
+    const spacer = document.createElement('span');
+    spacer.classList.add('sgt-label');
+
+    const control = document.createElement('div');
+    control.classList.add('sgt-control');
+
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.addEventListener('click', callback);
+
+    control.appendChild(button);
+    this.domElement.appendChild(spacer);
+    this.domElement.appendChild(control);
+  }
+}
+
+// ========================================
+// ドラッグ＆スナップ
+// ========================================
+
+/** ドラッグ判定の閾値 */
+const DRAG_THRESHOLD = 5;
+
+/** スナップ位置 */
+const SnapCorner = /** @type {const} */ ({
+  TOP_RIGHT: 'top-right',
+  TOP_LEFT: 'top-left',
+  BOTTOM_RIGHT: 'bottom-right',
+  BOTTOM_LEFT: 'bottom-left',
+});
+
+// ========================================
+// タブ情報
+// ========================================
+
+/**
+ * @typedef {object} TabInfo
+ * @property {string} name - タブ名
+ * @property {string} iconKey - アイコンキー
+ * @property {HTMLElement} panelEl - パネル要素
+ * @property {HTMLElement} childrenEl - コントローラーの親要素
+ * @property {HTMLButtonElement} tabBtn - タブボタン要素
+ */
+
+// ========================================
+// SimpleGuiTab 本体
+// ========================================
+
+class SimpleGuiTab {
+  /** @type {HTMLElement} */
+  domElement;
+  /** @type {HTMLElement} */
+  _shellEl;
+  /** @type {HTMLElement} */
+  _tabBarEl;
+  /** @type {HTMLElement} */
+  _contentAreaEl;
+  /** @type {TabInfo[]} */
+  _tabs;
+  /** @type {number} */
+  _activeTabIndex;
+  /** @type {boolean} */
+  _expanded;
+  /** @type {typeof SnapCorner[keyof typeof SnapCorner]} */
+  _corner;
+  /** @type {boolean} */
+  _isDragging;
+  /** @type {number} */
+  _dragStartX;
+  /** @type {number} */
+  _dragStartY;
+  /** @type {number} */
+  _dragOffsetX;
+  /** @type {number} */
+  _dragOffsetY;
+  /** @type {boolean} */
+  _dragMoved;
+  /** @type {Array<() => void>} */
+  _cleanupFns;
+  /** @type {number} */
+  _iconCounter;
+
+  /**
+   * @param {{ title?: string }} [options]
+   */
+  constructor(options = {}) {
+    const { title = 'General' } = options;
+
+    injectStyles();
+
+    this._tabs = [];
+    this._activeTabIndex = 0;
+    this._expanded = false;
+    this._corner = SnapCorner.TOP_RIGHT;
+    this._isDragging = false;
+    this._dragStartX = 0;
+    this._dragStartY = 0;
+    this._dragOffsetX = 0;
+    this._dragOffsetY = 0;
+    this._dragMoved = false;
+    this._cleanupFns = [];
+    this._iconCounter = 0;
+
+    this.domElement = document.createElement('div');
+    this._shellEl = document.createElement('div');
+    this._tabBarEl = document.createElement('div');
+    this._contentAreaEl = document.createElement('div');
+
+    this._buildRoot(title);
+  }
+
+  /**
+   * ルートコンテナを構築する
+   * @param {string} title
+   */
+  _buildRoot(title) {
+    this.domElement.classList.add('sgt-container', 'sgt-top-right');
+    this._shellEl.classList.add('sgt-shell');
+    this._tabBarEl.classList.add('sgt-tab-bar');
+    this._contentAreaEl.classList.add('sgt-content-area');
+
+    this._shellEl.appendChild(this._tabBarEl);
+    this._shellEl.appendChild(this._contentAreaEl);
+    this.domElement.appendChild(this._shellEl);
+    document.body.appendChild(this.domElement);
+
+    // デフォルトの General タブを作成
+    this._createTab(title);
+    this._activateTab(0);
+
+    this._setupTabBarToggle();
+    this._setupDrag();
+  }
+
+  /**
+   * 新しいタブを作成する
+   * @param {string} name
+   * @returns {TabInfo}
+   */
+  _createTab(name) {
+    const iconKey = ICON_KEYS[this._iconCounter % ICON_KEYS.length];
+    this._iconCounter++;
+
+    // タブボタン
+    const tabBtn = /** @type {HTMLButtonElement} */ (
+      document.createElement('button')
+    );
+    tabBtn.classList.add('sgt-tab');
+    tabBtn.type = 'button';
+
+    const iconSpan = document.createElement('span');
+    iconSpan.classList.add('sgt-tab-icon');
+    iconSpan.innerHTML = ICONS[iconKey] || ICONS.general;
+
+    const labelSpan = document.createElement('span');
+    labelSpan.classList.add('sgt-tab-label');
+    labelSpan.textContent = name;
+
+    tabBtn.appendChild(iconSpan);
+    tabBtn.appendChild(labelSpan);
+    this._tabBarEl.appendChild(tabBtn);
+
+    // パネル
+    const panelEl = document.createElement('div');
+    panelEl.classList.add('sgt-tab-panel');
+
+    const scrollEl = document.createElement('div');
+    scrollEl.classList.add('sgt-panel-scroll');
+
+    const childrenEl = document.createElement('div');
+    childrenEl.classList.add('sgt-children');
+
+    scrollEl.appendChild(childrenEl);
+    panelEl.appendChild(scrollEl);
+    this._contentAreaEl.appendChild(panelEl);
+
+    const index = this._tabs.length;
+
+    const onClick = () => {
+      if (this._dragMoved) {
+        return;
+      }
+      if (!this._expanded) {
+        this._expand();
+      }
+      this._activateTab(index);
+    };
+    tabBtn.addEventListener('click', onClick);
+    this._cleanupFns.push(() => tabBtn.removeEventListener('click', onClick));
+
+    /** @type {TabInfo} */
+    const tab = { name, iconKey, panelEl, childrenEl, tabBtn };
+    this._tabs.push(tab);
+
+    return tab;
+  }
+
+  /**
+   * 指定インデックスのタブをアクティブにする
+   * @param {number} index
+   */
+  _activateTab(index) {
+    this._activeTabIndex = index;
+
+    for (let i = 0; i < this._tabs.length; i++) {
+      const tab = this._tabs[i];
+      const isActive = i === index;
+      tab.tabBtn.classList.toggle('sgt-tab-active', isActive);
+      tab.panelEl.classList.toggle('sgt-panel-active', isActive);
+    }
+  }
+
+  /** タブバーのタップで展開/収納をトグルする */
+  _setupTabBarToggle() {
+    // タブバー領域のダブルクリックで収納
+    const onDblClick = () => {
+      if (this._expanded) {
+        this._collapse();
+      }
+    };
+    this._tabBarEl.addEventListener('dblclick', onDblClick);
+    this._cleanupFns.push(() =>
+      this._tabBarEl.removeEventListener('dblclick', onDblClick),
+    );
+  }
+
+  /** コンテンツエリアを展開する */
+  _expand() {
+    this._expanded = true;
+    this.domElement.classList.add('sgt-expanded');
+  }
+
+  /** コンテンツエリアを収納する */
+  _collapse() {
+    this._expanded = false;
+    this.domElement.classList.remove('sgt-expanded');
+  }
+
+  /** ドラッグ＆四隅スナップを設定する */
+  _setupDrag() {
+    /** @type {(e: PointerEvent) => void} */
+    const onDown = (e) => {
+      if (!this._tabBarEl.contains(/** @type {Node} */ (e.target))) {
+        return;
+      }
+      this._isDragging = true;
+      this._dragMoved = false;
+      const rect = this.domElement.getBoundingClientRect();
+      this._dragStartX = e.clientX;
+      this._dragStartY = e.clientY;
+      this._dragOffsetX = e.clientX - rect.left;
+      this._dragOffsetY = e.clientY - rect.top;
+      this.domElement.classList.add('sgt-dragging');
+      this._tabBarEl.setPointerCapture(e.pointerId);
+    };
+
+    /** @type {(e: PointerEvent) => void} */
+    const onMove = (e) => {
+      if (!this._isDragging) {
+        return;
+      }
+      const dx = e.clientX - this._dragStartX;
+      const dy = e.clientY - this._dragStartY;
+      if (
+        !this._dragMoved &&
+        Math.abs(dx) < DRAG_THRESHOLD &&
+        Math.abs(dy) < DRAG_THRESHOLD
+      ) {
+        return;
+      }
+      this._dragMoved = true;
+      const left = ((e.clientX - this._dragOffsetX) / window.innerWidth) * 100;
+      const top = ((e.clientY - this._dragOffsetY) / window.innerHeight) * 100;
+      const s = this.domElement.style;
+      s.left = `${left}vw`;
+      s.top = `${top}vh`;
+      s.right = 'auto';
+      s.bottom = 'auto';
+    };
+
+    /** @type {(e: PointerEvent) => void} */
+    const onUp = (e) => {
+      if (!this._isDragging) {
+        return;
+      }
+      this._isDragging = false;
+      this.domElement.classList.remove('sgt-dragging');
+      if (!this._dragMoved) {
+        this._clearInlinePosition();
+        // ドラッグなしのタップ — クリック先のタブを特定して展開
+        const target = document.elementFromPoint(e.clientX, e.clientY);
+        if (target) {
+          const tabBtn = target.closest('.sgt-tab');
+          if (tabBtn) {
+            const idx = this._tabs.findIndex((t) => t.tabBtn === tabBtn);
+            if (idx >= 0) {
+              if (!this._expanded) {
+                this._expand();
+              }
+              this._activateTab(idx);
+            }
+          }
+        }
+        return;
+      }
+      this._snapToNearestCorner();
+    };
+
+    this._tabBarEl.addEventListener('pointerdown', onDown);
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+    this._cleanupFns.push(() => {
+      this._tabBarEl.removeEventListener('pointerdown', onDown);
+      document.removeEventListener('pointermove', onMove);
+      document.removeEventListener('pointerup', onUp);
+    });
+  }
+
+  /** 最も近い四隅にスナップする */
+  _snapToNearestCorner() {
+    const rect = this.domElement.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const isRight = cx > window.innerWidth / 2;
+    const isBottom = cy > window.innerHeight / 2;
+
+    /** @type {typeof SnapCorner[keyof typeof SnapCorner]} */
+    let corner;
+    if (isBottom && isRight) {
+      corner = SnapCorner.BOTTOM_RIGHT;
+    } else if (isBottom) {
+      corner = SnapCorner.BOTTOM_LEFT;
+    } else if (isRight) {
+      corner = SnapCorner.TOP_RIGHT;
+    } else {
+      corner = SnapCorner.TOP_LEFT;
+    }
+
+    this._corner = corner;
+    this.domElement.classList.remove(
+      'sgt-top-right',
+      'sgt-top-left',
+      'sgt-bottom-right',
+      'sgt-bottom-left',
+    );
+    this._clearInlinePosition();
+    this.domElement.classList.add(`sgt-${corner}`);
+  }
+
+  /** インラインの位置スタイルをクリアする */
+  _clearInlinePosition() {
+    const s = this.domElement.style;
+    s.removeProperty('left');
+    s.removeProperty('top');
+    s.removeProperty('right');
+    s.removeProperty('bottom');
+  }
+
+  // --- パブリック API ---
+
+  /**
+   * 現在のアクティブタブの children を取得する
+   * @returns {HTMLElement}
+   */
+  _currentChildren() {
+    return this._tabs[0].childrenEl;
+  }
+
+  /**
+   * 値の型に応じたコントローラーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   * @returns {Controller}
+   */
+  add(obj, prop, min, max, step) {
+    if (typeof obj[prop] === 'boolean') {
+      const ctrl = new BooleanController(obj, prop);
+      this._currentChildren().appendChild(ctrl.domElement);
+      return ctrl;
+    }
+    const ctrl = new NumberController(obj, prop, min, max, step);
+    this._currentChildren().appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * カラーピッカーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @returns {Controller}
+   */
+  addColor(obj, prop) {
+    const ctrl = new ColorController(obj, prop);
+    this._currentChildren().appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * ボタンを追加する
+   * @param {string} label
+   * @param {() => void} callback
+   * @returns {ButtonController}
+   */
+  addButton(label, callback) {
+    const ctrl = new ButtonController(label, callback);
+    this._currentChildren().appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * フォルダ（= 新タブ）を追加する
+   * @param {string} title
+   * @returns {SimpleGuiTabFolder}
+   */
+  addFolder(title) {
+    const tab = this._createTab(title);
+    return new SimpleGuiTabFolder(tab.childrenEl);
+  }
+
+  /** DOM とイベントリスナーを完全に除去する */
+  destroy() {
+    for (const cleanup of this._cleanupFns) {
+      cleanup();
+    }
+    this._cleanupFns = [];
+
+    if (this.domElement.parentNode) {
+      this.domElement.parentNode.removeChild(this.domElement);
+    }
+
+    if (document.querySelectorAll('.sgt-container').length === 0) {
+      removeStyles();
+    }
+  }
+}
+
+// ========================================
+// フォルダ（タブのコンテンツ操作用プロキシ）
+// ========================================
+
+class SimpleGuiTabFolder {
+  /** @type {HTMLElement} */
+  _childrenEl;
+
+  /**
+   * @param {HTMLElement} childrenEl
+   */
+  constructor(childrenEl) {
+    this._childrenEl = childrenEl;
+  }
+
+  /**
+   * 値の型に応じたコントローラーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   * @returns {Controller}
+   */
+  add(obj, prop, min, max, step) {
+    if (typeof obj[prop] === 'boolean') {
+      const ctrl = new BooleanController(obj, prop);
+      this._childrenEl.appendChild(ctrl.domElement);
+      return ctrl;
+    }
+    const ctrl = new NumberController(obj, prop, min, max, step);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * カラーピッカーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @returns {Controller}
+   */
+  addColor(obj, prop) {
+    const ctrl = new ColorController(obj, prop);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * ボタンを追加する
+   * @param {string} label
+   * @param {() => void} callback
+   * @returns {ButtonController}
+   */
+  addButton(label, callback) {
+    const ctrl = new ButtonController(label, callback);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+}
+
+export default SimpleGuiTab;

--- a/public/simple-gui-tab/style.css
+++ b/public/simple-gui-tab/style.css
@@ -1,0 +1,47 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0a0a;
+  color: #e0e0e0;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}

--- a/public/simple-gui/index.html
+++ b/public/simple-gui/index.html
@@ -1,68 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SimpleGui Demo</title>
-  <style>
-    body {
-      margin: 0;
-      min-height: 100vh;
-      background: #0a0a1a;
-      color: #e0e0e0;
-      font-family: system-ui, -apple-system, sans-serif;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    #output {
-      font-size: 1rem;
-      line-height: 2;
-    }
-  </style>
-</head>
-<body>
-  <div id="output"></div>
-  <script type="module">
-    import SimpleGui from './simple-gui.js';
-
-    const params = {
-      speed: 50,
-      visible: true,
-      color: '#6c63ff',
-      detail: 5,
-      opacity: 0.8,
-    };
-
-    const output = document.getElementById('output');
-
-    function updateOutput() {
-      if (!output) return;
-      output.innerHTML = Object.entries(params)
-        .map(([k, v]) => `<div><strong>${k}:</strong> ${v}</div>`)
-        .join('');
-    }
-
-    const gui = new SimpleGui({ title: 'Settings' });
-
-    gui.add(params, 'speed', 0, 100, 1).onChange(() => updateOutput());
-    gui.add(params, 'visible').onChange(() => updateOutput());
-    gui.addColor(params, 'color').onChange(() => updateOutput());
-
-    gui.addButton('Reset', () => {
-      params.speed = 50;
-      params.visible = true;
-      params.color = '#6c63ff';
-      params.detail = 5;
-      params.opacity = 0.8;
-      updateOutput();
-    });
-
-    const folder = gui.addFolder('Advanced');
-    folder.add(params, 'detail', 1, 10, 1).onChange(() => updateOutput());
-    folder.add(params, 'opacity', 0, 1, 0.01).onChange(() => updateOutput());
-
-    updateOutput();
-  </script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple GUI | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+  </body>
 </html>

--- a/public/simple-gui/index.html
+++ b/public/simple-gui/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SimpleGui Demo</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #0a0a1a;
+      color: #e0e0e0;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    #output {
+      font-size: 1rem;
+      line-height: 2;
+    }
+  </style>
+</head>
+<body>
+  <div id="output"></div>
+  <script type="module">
+    import SimpleGui from './simple-gui.js';
+
+    const params = {
+      speed: 50,
+      visible: true,
+      color: '#6c63ff',
+      detail: 5,
+      opacity: 0.8,
+    };
+
+    const output = document.getElementById('output');
+
+    function updateOutput() {
+      if (!output) return;
+      output.innerHTML = Object.entries(params)
+        .map(([k, v]) => `<div><strong>${k}:</strong> ${v}</div>`)
+        .join('');
+    }
+
+    const gui = new SimpleGui({ title: 'Settings' });
+
+    gui.add(params, 'speed', 0, 100, 1).onChange(() => updateOutput());
+    gui.add(params, 'visible').onChange(() => updateOutput());
+    gui.addColor(params, 'color').onChange(() => updateOutput());
+
+    gui.addButton('Reset', () => {
+      params.speed = 50;
+      params.visible = true;
+      params.color = '#6c63ff';
+      params.detail = 5;
+      params.opacity = 0.8;
+      updateOutput();
+    });
+
+    const folder = gui.addFolder('Advanced');
+    folder.add(params, 'detail', 1, 10, 1).onChange(() => updateOutput());
+    folder.add(params, 'opacity', 0, 1, 0.01).onChange(() => updateOutput());
+
+    updateOutput();
+  </script>
+</body>
+</html>

--- a/public/simple-gui/main.js
+++ b/public/simple-gui/main.js
@@ -124,6 +124,7 @@ gui.add(params, 'visible');
 
 gui.addButton('Reset', () => {
   Object.assign(params, { ...defaults });
+  gui.updateDisplay();
 });
 
 const folder = gui.addFolder('Advanced');

--- a/public/simple-gui/main.js
+++ b/public/simple-gui/main.js
@@ -1,0 +1,131 @@
+// @ts-check
+import SimpleGui from './simple-gui.js';
+
+// --- パラメータ ---
+
+const params = {
+  color: '#6c63ff',
+  size: 80,
+  speed: 30,
+  visible: true,
+  shape: 'circle',
+  opacity: 0.8,
+  detail: 5,
+};
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
+
+// --- Canvas セットアップ ---
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** Canvas をウィンドウサイズに合わせる */
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画ロジック ---
+
+let angle = 0;
+
+/**
+ * hex カラー文字列を rgba 文字列に変換する
+ * @param {string} hex
+ * @param {number} alpha
+ * @returns {string}
+ */
+function hexToRgba(hex, alpha) {
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/**
+ * 正多角形を描画する
+ * @param {number} cx - 中心 X
+ * @param {number} cy - 中心 Y
+ * @param {number} radius - 半径
+ * @param {number} sides - 辺の数
+ */
+function drawPolygon(cx, cy, radius, sides) {
+  ctx.beginPath();
+  for (let i = 0; i <= sides; i++) {
+    const a = (i / sides) * Math.PI * 2 - Math.PI / 2;
+    const x = cx + radius * Math.cos(a);
+    const y = cy + radius * Math.sin(a);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+}
+
+/** メインの描画フレーム */
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (!params.visible) {
+    requestAnimationFrame(draw);
+    return;
+  }
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const time = angle;
+
+  // 軌道上を回転する位置
+  const orbitRadius = params.size * 1.5;
+  const ox = cx + orbitRadius * Math.cos(time);
+  const oy = cy + orbitRadius * Math.sin(time);
+
+  // メイン図形
+  ctx.fillStyle = hexToRgba(params.color, params.opacity);
+  drawPolygon(ox, oy, params.size, params.detail);
+  ctx.fill();
+
+  // 中心の小さな円
+  ctx.fillStyle = hexToRgba(params.color, params.opacity * 0.4);
+  ctx.beginPath();
+  ctx.arc(cx, cy, params.size * 0.3, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 軌道の線
+  ctx.strokeStyle = hexToRgba(params.color, 0.15);
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(cx, cy, orbitRadius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  angle += params.speed * 0.001;
+  requestAnimationFrame(draw);
+}
+
+requestAnimationFrame(draw);
+
+// --- GUI セットアップ ---
+
+const gui = new SimpleGui({ title: 'Settings' });
+
+gui.addColor(params, 'color');
+gui.add(params, 'size', 20, 200, 1);
+gui.add(params, 'speed', 0, 100, 1);
+gui.add(params, 'visible');
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+});
+
+const folder = gui.addFolder('Advanced');
+folder.add(params, 'opacity', 0, 1, 0.01);
+folder.add(params, 'detail', 3, 12, 1);

--- a/public/simple-gui/simple-gui.js
+++ b/public/simple-gui/simple-gui.js
@@ -1,0 +1,540 @@
+// @ts-check
+
+/**
+ * SimpleGui - lil-gui 簡易版の GUI ライブラリ
+ * フローティングパネルで数値・boolean・色・ボタンのコントロールを提供する
+ */
+
+// CSS 注入（一度だけ）
+const STYLE_ID = 'simple-gui-style';
+
+/**
+ * スタイルを注入する
+ */
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    :root {
+      --sg-bg: #1a1a2e;
+      --sg-bg-hover: #252542;
+      --sg-border: #333355;
+      --sg-text: #e0e0e0;
+      --sg-text-dim: #999;
+      --sg-accent: #6c63ff;
+      --sg-accent-hover: #857dff;
+      --sg-input-bg: #0f0f1a;
+      --sg-folder-bg: #15152a;
+      --sg-radius: 0.25rem;
+      --sg-font-size: 0.75rem;
+      --sg-row-height: 1.75rem;
+      --sg-padding: 0.5rem;
+      --sg-width: 16rem;
+    }
+
+    .sg-panel {
+      position: fixed;
+      top: 0.5rem;
+      right: 0.5rem;
+      width: var(--sg-width);
+      font-family: system-ui, -apple-system, sans-serif;
+      font-size: var(--sg-font-size);
+      color: var(--sg-text);
+      background: var(--sg-bg);
+      border: 0.0625rem solid var(--sg-border);
+      border-radius: var(--sg-radius);
+      z-index: 10000;
+      user-select: none;
+      box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.4);
+    }
+
+    .sg-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--sg-padding);
+      background: var(--sg-bg);
+      border-bottom: 0.0625rem solid var(--sg-border);
+      border-radius: var(--sg-radius) var(--sg-radius) 0 0;
+      cursor: pointer;
+      font-weight: 600;
+      font-size: 0.8125rem;
+    }
+
+    .sg-title-toggle {
+      transition: transform 0.2s;
+    }
+
+    .sg-title-toggle.sg-collapsed {
+      transform: rotate(-90deg);
+    }
+
+    .sg-children {
+      overflow: hidden;
+    }
+
+    .sg-children.sg-hidden {
+      display: none;
+    }
+
+    .sg-row {
+      display: flex;
+      align-items: center;
+      padding: 0.25rem var(--sg-padding);
+      min-height: var(--sg-row-height);
+      border-bottom: 0.0625rem solid var(--sg-border);
+    }
+
+    .sg-row:hover {
+      background: var(--sg-bg-hover);
+    }
+
+    .sg-label {
+      flex: 0 0 40%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--sg-text-dim);
+    }
+
+    .sg-control {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .sg-control input[type="range"] {
+      flex: 1;
+      height: 0.25rem;
+      accent-color: var(--sg-accent);
+      cursor: pointer;
+    }
+
+    .sg-control input[type="number"] {
+      width: 3.5rem;
+      background: var(--sg-input-bg);
+      border: 0.0625rem solid var(--sg-border);
+      border-radius: var(--sg-radius);
+      color: var(--sg-text);
+      font-size: var(--sg-font-size);
+      padding: 0.125rem 0.25rem;
+      text-align: right;
+    }
+
+    .sg-control input[type="number"]:focus {
+      outline: 0.0625rem solid var(--sg-accent);
+    }
+
+    .sg-control input[type="checkbox"] {
+      accent-color: var(--sg-accent);
+      cursor: pointer;
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+
+    .sg-control input[type="color"] {
+      width: 100%;
+      height: var(--sg-row-height);
+      border: none;
+      background: none;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .sg-control button {
+      width: 100%;
+      padding: 0.25rem 0.5rem;
+      background: var(--sg-accent);
+      color: #fff;
+      border: none;
+      border-radius: var(--sg-radius);
+      font-size: var(--sg-font-size);
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .sg-control button:hover {
+      background: var(--sg-accent-hover);
+    }
+
+    .sg-folder-title {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.25rem var(--sg-padding);
+      min-height: var(--sg-row-height);
+      border-bottom: 0.0625rem solid var(--sg-border);
+      cursor: pointer;
+      font-weight: 600;
+      color: var(--sg-accent);
+    }
+
+    .sg-folder-title:hover {
+      background: var(--sg-bg-hover);
+    }
+
+    .sg-folder-children {
+      padding-left: 0.5rem;
+      background: var(--sg-folder-bg);
+    }
+
+    .sg-folder-children.sg-hidden {
+      display: none;
+    }
+
+    .sg-folder-toggle {
+      transition: transform 0.2s;
+    }
+
+    .sg-folder-toggle.sg-collapsed {
+      transform: rotate(-90deg);
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+// --- コントローラー基底クラス ---
+
+class Controller {
+  /** @type {Record<string, unknown>} */
+  _obj;
+  /** @type {string} */
+  _prop;
+  /** @type {((value: unknown) => void) | null} */
+  _onChangeCallback;
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    this._obj = obj;
+    this._prop = prop;
+    this._onChangeCallback = null;
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sg-row');
+  }
+
+  /**
+   * onChange コールバックを設定する
+   * @param {(value: unknown) => void} callback
+   * @returns {this}
+   */
+  onChange(callback) {
+    this._onChangeCallback = callback;
+    return this;
+  }
+
+  /**
+   * 値を更新してコールバックを発火する
+   * @param {unknown} value
+   */
+  _setValue(value) {
+    this._obj[this._prop] = value;
+    if (this._onChangeCallback) {
+      this._onChangeCallback(value);
+    }
+  }
+}
+
+// --- NumberController ---
+
+class NumberController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   */
+  constructor(obj, prop, min, max, step) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sg-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sg-control');
+
+    const hasRange = min !== undefined && max !== undefined;
+
+    const numberInput = document.createElement('input');
+    numberInput.type = 'number';
+    numberInput.value = String(obj[prop]);
+    if (min !== undefined) numberInput.min = String(min);
+    if (max !== undefined) numberInput.max = String(max);
+    if (step !== undefined) numberInput.step = String(step);
+
+    if (hasRange) {
+      const rangeInput = document.createElement('input');
+      rangeInput.type = 'range';
+      rangeInput.min = String(min);
+      rangeInput.max = String(max);
+      rangeInput.step = String(step ?? 1);
+      rangeInput.value = String(obj[prop]);
+
+      rangeInput.addEventListener('input', () => {
+        const val = Number(rangeInput.value);
+        numberInput.value = String(val);
+        this._setValue(val);
+      });
+
+      numberInput.addEventListener('input', () => {
+        const val = Number(numberInput.value);
+        rangeInput.value = String(val);
+        this._setValue(val);
+      });
+
+      control.appendChild(rangeInput);
+    } else {
+      numberInput.addEventListener('input', () => {
+        this._setValue(Number(numberInput.value));
+      });
+    }
+
+    control.appendChild(numberInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- BooleanController ---
+
+class BooleanController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sg-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sg-control');
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = /** @type {boolean} */ (obj[prop]);
+
+    checkbox.addEventListener('change', () => {
+      this._setValue(checkbox.checked);
+    });
+
+    control.appendChild(checkbox);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- ColorController ---
+
+class ColorController extends Controller {
+  /**
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   */
+  constructor(obj, prop) {
+    super(obj, prop);
+
+    const label = document.createElement('span');
+    label.classList.add('sg-label');
+    label.textContent = prop;
+
+    const control = document.createElement('div');
+    control.classList.add('sg-control');
+
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = /** @type {string} */ (obj[prop]);
+
+    colorInput.addEventListener('input', () => {
+      this._setValue(colorInput.value);
+    });
+
+    control.appendChild(colorInput);
+    this.domElement.appendChild(label);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- ButtonController ---
+
+class ButtonController {
+  /** @type {HTMLElement} */
+  domElement;
+
+  /**
+   * @param {string} label
+   * @param {() => void} callback
+   */
+  constructor(label, callback) {
+    this.domElement = document.createElement('div');
+    this.domElement.classList.add('sg-row');
+
+    const spacer = document.createElement('span');
+    spacer.classList.add('sg-label');
+
+    const control = document.createElement('div');
+    control.classList.add('sg-control');
+
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.addEventListener('click', callback);
+
+    control.appendChild(button);
+    this.domElement.appendChild(spacer);
+    this.domElement.appendChild(control);
+  }
+}
+
+// --- SimpleGui ---
+
+class SimpleGui {
+  /** @type {HTMLElement} */
+  domElement;
+  /** @type {HTMLElement} */
+  _childrenEl;
+  /** @type {boolean} */
+  _isRoot;
+
+  /**
+   * @param {{ title?: string, parent?: HTMLElement }} [options]
+   */
+  constructor(options = {}) {
+    const { title = 'Controls', parent } = options;
+
+    injectStyles();
+
+    this._isRoot = !parent;
+
+    if (this._isRoot) {
+      // ルートパネル
+      this.domElement = document.createElement('div');
+      this.domElement.classList.add('sg-panel');
+
+      const titleBar = document.createElement('div');
+      titleBar.classList.add('sg-title');
+
+      const titleText = document.createElement('span');
+      titleText.textContent = title;
+
+      const toggle = document.createElement('span');
+      toggle.classList.add('sg-title-toggle');
+      toggle.textContent = '\u25BC';
+
+      titleBar.appendChild(titleText);
+      titleBar.appendChild(toggle);
+
+      this._childrenEl = document.createElement('div');
+      this._childrenEl.classList.add('sg-children');
+
+      titleBar.addEventListener('click', () => {
+        const isHidden = this._childrenEl.classList.toggle('sg-hidden');
+        toggle.classList.toggle('sg-collapsed', isHidden);
+      });
+
+      this.domElement.appendChild(titleBar);
+      this.domElement.appendChild(this._childrenEl);
+      document.body.appendChild(this.domElement);
+    } else {
+      // フォルダ（子パネル）
+      this.domElement = document.createElement('div');
+
+      const folderTitle = document.createElement('div');
+      folderTitle.classList.add('sg-folder-title');
+
+      const folderText = document.createElement('span');
+      folderText.textContent = title;
+
+      const folderToggle = document.createElement('span');
+      folderToggle.classList.add('sg-folder-toggle');
+      folderToggle.textContent = '\u25BC';
+
+      folderTitle.appendChild(folderText);
+      folderTitle.appendChild(folderToggle);
+
+      this._childrenEl = document.createElement('div');
+      this._childrenEl.classList.add('sg-folder-children');
+
+      folderTitle.addEventListener('click', () => {
+        const isHidden = this._childrenEl.classList.toggle('sg-hidden');
+        folderToggle.classList.toggle('sg-collapsed', isHidden);
+      });
+
+      this.domElement.appendChild(folderTitle);
+      this.domElement.appendChild(this._childrenEl);
+      /** @type {HTMLElement} */ (parent).appendChild(this.domElement);
+    }
+  }
+
+  /**
+   * 値の型に応じたコントローラーを追加する
+   * - boolean: チェックボックス
+   * - number: 数値スライダー
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @param {number} [min]
+   * @param {number} [max]
+   * @param {number} [step]
+   * @returns {Controller}
+   */
+  add(obj, prop, min, max, step) {
+    const value = obj[prop];
+
+    if (typeof value === 'boolean') {
+      const ctrl = new BooleanController(obj, prop);
+      this._childrenEl.appendChild(ctrl.domElement);
+      return ctrl;
+    }
+
+    const ctrl = new NumberController(obj, prop, min, max, step);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * カラーピッカーを追加する
+   * @param {Record<string, unknown>} obj
+   * @param {string} prop
+   * @returns {Controller}
+   */
+  addColor(obj, prop) {
+    const ctrl = new ColorController(obj, prop);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * ボタンを追加する
+   * @param {string} label
+   * @param {() => void} callback
+   * @returns {ButtonController}
+   */
+  addButton(label, callback) {
+    const ctrl = new ButtonController(label, callback);
+    this._childrenEl.appendChild(ctrl.domElement);
+    return ctrl;
+  }
+
+  /**
+   * 折りたたみフォルダを追加する
+   * @param {string} title
+   * @returns {SimpleGui}
+   */
+  addFolder(title) {
+    return new SimpleGui({ title, parent: this._childrenEl });
+  }
+}
+
+export default SimpleGui;

--- a/public/simple-gui/simple-gui.js
+++ b/public/simple-gui/simple-gui.js
@@ -247,11 +247,19 @@ class Controller {
       this._onChangeCallback(value);
     }
   }
+
+  /** DOM 表示を現在の値に同期する（サブクラスでオーバーライド） */
+  updateDisplay() {}
 }
 
 // --- NumberController ---
 
 class NumberController extends Controller {
+  /** @type {HTMLInputElement} */
+  _numberInput;
+  /** @type {HTMLInputElement | null} */
+  _rangeInput;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -261,6 +269,8 @@ class NumberController extends Controller {
    */
   constructor(obj, prop, min, max, step) {
     super(obj, prop);
+
+    this._rangeInput = null;
 
     const label = document.createElement('span');
     label.classList.add('sg-label');
@@ -277,6 +287,7 @@ class NumberController extends Controller {
     if (min !== undefined) numberInput.min = String(min);
     if (max !== undefined) numberInput.max = String(max);
     if (step !== undefined) numberInput.step = String(step);
+    this._numberInput = numberInput;
 
     if (hasRange) {
       const rangeInput = document.createElement('input');
@@ -285,6 +296,7 @@ class NumberController extends Controller {
       rangeInput.max = String(max);
       rangeInput.step = String(step ?? 1);
       rangeInput.value = String(obj[prop]);
+      this._rangeInput = rangeInput;
 
       rangeInput.addEventListener('input', () => {
         const val = Number(rangeInput.value);
@@ -309,11 +321,23 @@ class NumberController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    const val = String(this._obj[this._prop]);
+    this._numberInput.value = val;
+    if (this._rangeInput) {
+      this._rangeInput.value = val;
+    }
+  }
 }
 
 // --- BooleanController ---
 
 class BooleanController extends Controller {
+  /** @type {HTMLInputElement} */
+  _checkbox;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -331,6 +355,7 @@ class BooleanController extends Controller {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.checked = /** @type {boolean} */ (obj[prop]);
+    this._checkbox = checkbox;
 
     checkbox.addEventListener('change', () => {
       this._setValue(checkbox.checked);
@@ -340,11 +365,19 @@ class BooleanController extends Controller {
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
   }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._checkbox.checked = /** @type {boolean} */ (this._obj[this._prop]);
+  }
 }
 
 // --- ColorController ---
 
 class ColorController extends Controller {
+  /** @type {HTMLInputElement} */
+  _colorInput;
+
   /**
    * @param {Record<string, unknown>} obj
    * @param {string} prop
@@ -362,6 +395,7 @@ class ColorController extends Controller {
     const colorInput = document.createElement('input');
     colorInput.type = 'color';
     colorInput.value = /** @type {string} */ (obj[prop]);
+    this._colorInput = colorInput;
 
     colorInput.addEventListener('input', () => {
       this._setValue(colorInput.value);
@@ -370,6 +404,11 @@ class ColorController extends Controller {
     control.appendChild(colorInput);
     this.domElement.appendChild(label);
     this.domElement.appendChild(control);
+  }
+
+  /** DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    this._colorInput.value = /** @type {string} */ (this._obj[this._prop]);
   }
 }
 
@@ -412,6 +451,10 @@ class SimpleGui {
   _childrenEl;
   /** @type {boolean} */
   _isRoot;
+  /** @type {Controller[]} */
+  _controllers;
+  /** @type {SimpleGui[]} */
+  _folders;
 
   /**
    * @param {{ title?: string, parent?: HTMLElement }} [options]
@@ -422,6 +465,8 @@ class SimpleGui {
     injectStyles();
 
     this._isRoot = !parent;
+    this._controllers = [];
+    this._folders = [];
 
     if (this._isRoot) {
       // ルートパネル
@@ -500,11 +545,13 @@ class SimpleGui {
     if (typeof value === 'boolean') {
       const ctrl = new BooleanController(obj, prop);
       this._childrenEl.appendChild(ctrl.domElement);
+      this._controllers.push(ctrl);
       return ctrl;
     }
 
     const ctrl = new NumberController(obj, prop, min, max, step);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -517,6 +564,7 @@ class SimpleGui {
   addColor(obj, prop) {
     const ctrl = new ColorController(obj, prop);
     this._childrenEl.appendChild(ctrl.domElement);
+    this._controllers.push(ctrl);
     return ctrl;
   }
 
@@ -538,7 +586,19 @@ class SimpleGui {
    * @returns {SimpleGui}
    */
   addFolder(title) {
-    return new SimpleGui({ title, parent: this._childrenEl });
+    const folder = new SimpleGui({ title, parent: this._childrenEl });
+    this._folders.push(folder);
+    return folder;
+  }
+
+  /** 全コントローラーとフォルダの DOM 表示を現在の値に同期する */
+  updateDisplay() {
+    for (const ctrl of this._controllers) {
+      ctrl.updateDisplay();
+    }
+    for (const folder of this._folders) {
+      folder.updateDisplay();
+    }
   }
 }
 

--- a/public/simple-gui/simple-gui.js
+++ b/public/simple-gui/simple-gui.js
@@ -50,6 +50,7 @@ function injectStyles() {
       z-index: 10000;
       user-select: none;
       box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.4);
+      overflow: hidden;
     }
 
     .sg-title {
@@ -103,6 +104,7 @@ function injectStyles() {
 
     .sg-control {
       flex: 1;
+      min-width: 0;
       display: flex;
       align-items: center;
       gap: 0.375rem;
@@ -110,13 +112,16 @@ function injectStyles() {
 
     .sg-control input[type="range"] {
       flex: 1;
+      min-width: 0;
       height: 0.25rem;
       accent-color: var(--sg-accent);
       cursor: pointer;
     }
 
     .sg-control input[type="number"] {
-      width: 3.5rem;
+      width: 27%;
+      min-width: 2.5rem;
+      flex-shrink: 0;
       background: var(--sg-input-bg);
       border: 0.0625rem solid var(--sg-border);
       border-radius: var(--sg-radius);

--- a/public/simple-gui/style.css
+++ b/public/simple-gui/style.css
@@ -1,0 +1,47 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0a1a;
+  color: #e0e0e0;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- lil-gui にインスパイアされたフローティング GUI ライブラリのプロトタイプと、3つの UI バリアント（ボトムシート/ピル/タブバー）を追加

## Changes
- **SimpleGui** (`/simple-gui/`): lil-gui 互換 API のオリジナル実装（ダーク+パープル）
- **SimpleGuiSheet** (`/simple-gui-sheet/`): iOS ボトムシート型（すりガラス白+ブルー、ハーフ/フル展開）
- **SimpleGuiPill** (`/simple-gui-pill/`): Dynamic Island 風ピル型（ミニマル黒+グリーン）
- **SimpleGuiTab** (`/simple-gui-tab/`): モバイルタブバー型（ダーク+パープル、フォルダ=タブ）
- 全バリアント共通: 四隅スナップ、`updateDisplay()` によるリセット同期、Canvas デモ
- `input[type=range]` の `min-width: 0` で数値入力の見切れを修正

## Test plan
- [ ] 各ページで Canvas アニメーションが表示される
- [ ] GUI パネルの各コントローラーが操作可能
- [ ] Reset ボタンでスライダー等の表示が初期値に戻る
- [ ] 四隅へのドラッグスナップが動作する
- [ ] トップページから全ページにリンク遷移できる
- [ ] `npm run check` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)