### PR TITLE
feat: dev サーバーのバックグラウンド実行コマンドを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 node_modules
 .DS_Store
+.vite.pid
 
 .playwright-mcp
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "scripts": {
     "dev": "vite public",
+    "dev:bg": "vite public > /dev/null 2>&1 & echo $! > .vite.pid && echo 'Vite started (PID:'$(cat .vite.pid)')'",
+    "dev:status": "if [ -f .vite.pid ] && kill -0 $(cat .vite.pid) 2>/dev/null; then echo \"Running (PID: $(cat .vite.pid))\"; curl -s http://localhost:5173 > /dev/null && echo 'http://localhost:5173' || echo 'Starting...'; else echo 'Not running'; fi",
+    "dev:stop": "if [ -f .vite.pid ] && kill -0 $(cat .vite.pid) 2>/dev/null; then kill $(cat .vite.pid) && rm -f .vite.pid && echo 'Stopped'; else echo 'Not running'; rm -f .vite.pid; fi",
     "check": "biome check .",
     "format": "biome check --write ."
   },


### PR DESCRIPTION
## Summary
- dev サーバーをバックグラウンドで起動・状態確認・停止する npm scripts を追加

## Changes
- `dev:bg`: バックグラウンドで Vite dev サーバーを起動（PID を .vite.pid に保存）
- `dev:status`: 実行中ならPIDとアドレス (http://localhost:5173) を表示
- `dev:stop`: バックグラウンドの dev サーバーを停止
- `.gitignore` に `.vite.pid` を追加

## Test plan
- [x] `npm run dev:bg` でバックグラウンド起動を確認
- [x] `npm run dev:status` でアドレスが表示されることを確認
- [x] `npm run dev:stop` で停止を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)