### PR TITLE
feat(tileui-demo): TileUI パーティクルデモページを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .playwright-mcp
 
 # Test
+e2e
 test-results
 
 # AI tools

--- a/public/index.html
+++ b/public/index.html
@@ -121,6 +121,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/tileui-demo/">
+              TileUI Demo
+              <span class="nav-description"
+                >TileUI パーティクルデモ（CDN 版）</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/tileui-demo/index.html
+++ b/public/tileui-demo/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TileUI Demo | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+  </body>
+</html>

--- a/public/tileui-demo/index.html
+++ b/public/tileui-demo/index.html
@@ -14,5 +14,6 @@
     <main>
       <canvas id="canvas"></canvas>
     </main>
+    <div id="gui-container"></div>
   </body>
 </html>

--- a/public/tileui-demo/main.js
+++ b/public/tileui-demo/main.js
@@ -1,0 +1,175 @@
+// @ts-check
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui@0.2.1/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  count: 120,
+  radius: 200,
+  speed: 1,
+  size: 3,
+  spread: 0.5,
+  color: '#4ecdc4',
+  bgColor: '#0a0a1a',
+  glow: true,
+  trail: true,
+  visible: true,
+};
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
+
+// --- Canvas セットアップ ---
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** Canvas をウィンドウサイズに合わせる */
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- パーティクル ---
+
+/**
+ * @typedef {{ x: number, y: number, angle: number, orbitRadius: number, orbitSpeed: number, phase: number, size: number }} Particle
+ */
+
+/** @type {Particle[]} */
+let particles = [];
+
+/** パーティクルを生成 */
+function createParticles() {
+  particles = [];
+  for (let i = 0; i < params.count; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const orbitRadius =
+      params.radius * (0.3 + Math.random() * 0.7) * params.spread;
+    particles.push({
+      x: 0,
+      y: 0,
+      angle,
+      orbitRadius,
+      orbitSpeed: (0.5 + Math.random() * 1.5) * (Math.random() > 0.5 ? 1 : -1),
+      phase: Math.random() * Math.PI * 2,
+      size: 0.5 + Math.random() * 1.5,
+    });
+  }
+}
+
+createParticles();
+
+/**
+ * hex → RGB 分解
+ * @param {string} hex
+ * @returns {{ r: number, g: number, b: number }}
+ */
+function hexToRgb(hex) {
+  return {
+    r: Number.parseInt(hex.slice(1, 3), 16),
+    g: Number.parseInt(hex.slice(3, 5), 16),
+    b: Number.parseInt(hex.slice(5, 7), 16),
+  };
+}
+
+// --- 描画 ---
+
+let time = 0;
+
+/** メインの描画ループ */
+function draw() {
+  if (params.trail) {
+    // 残像効果
+    ctx.fillStyle = `${params.bgColor}33`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  } else {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = params.bgColor;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  if (!params.visible) {
+    requestAnimationFrame(draw);
+    return;
+  }
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const { r, g, b } = hexToRgb(params.color);
+
+  if (params.glow) {
+    ctx.shadowColor = params.color;
+    ctx.shadowBlur = 15;
+  } else {
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
+  }
+
+  for (const p of particles) {
+    // 軌道を更新
+    p.angle += p.orbitSpeed * params.speed * 0.01;
+
+    // リサジュー曲線風の軌道
+    const rx = p.orbitRadius * params.spread;
+    const ry = p.orbitRadius * params.spread * 0.6;
+    p.x =
+      cx +
+      Math.cos(p.angle) * rx +
+      Math.sin(p.angle * 0.7 + p.phase) * rx * 0.3;
+    p.y =
+      cy +
+      Math.sin(p.angle) * ry +
+      Math.cos(p.angle * 0.5 + p.phase) * ry * 0.4;
+
+    // 距離に応じた明るさ
+    const dist = Math.sqrt((p.x - cx) ** 2 + (p.y - cy) ** 2);
+    const maxDist = Math.max(canvas.width, canvas.height) * 0.5;
+    const brightness = 0.4 + 0.6 * (1 - Math.min(dist / maxDist, 1));
+    const alpha = 0.5 + Math.sin(time * 2 + p.phase) * 0.3;
+
+    ctx.beginPath();
+    ctx.fillStyle = `rgba(${Math.round(r * brightness)}, ${Math.round(g * brightness)}, ${Math.round(b * brightness)}, ${alpha})`;
+    ctx.arc(p.x, p.y, p.size * params.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.shadowBlur = 0;
+  time += 0.016 * params.speed;
+
+  requestAnimationFrame(draw);
+}
+
+requestAnimationFrame(draw);
+
+// --- GUI セットアップ ---
+
+const gui = new TileUI({ title: 'Particles' });
+
+gui.add(params, 'count', 10, 500, 10).onChange(() => {
+  createParticles();
+});
+gui.add(params, 'radius', 50, 500, 10);
+gui.add(params, 'speed', 0.1, 5, 0.1);
+gui.add(params, 'size', 0.5, 10, 0.5);
+gui.add(params, 'spread', 0.1, 2, 0.1);
+gui.addBoolean(params, 'visible');
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  createParticles();
+  time = 0;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  gui.updateDisplay();
+});
+
+const styleFolder = gui.addFolder('Style');
+styleFolder.addColor(params, 'color');
+styleFolder.addColor(params, 'bgColor');
+styleFolder.addBoolean(params, 'glow');
+styleFolder.addBoolean(params, 'trail');

--- a/public/tileui-demo/main.js
+++ b/public/tileui-demo/main.js
@@ -149,7 +149,13 @@ requestAnimationFrame(draw);
 
 // --- GUI セットアップ ---
 
-const gui = new TileUI({ title: 'Particles' });
+const guiContainer = /** @type {HTMLElement} */ (
+  document.getElementById('gui-container')
+);
+const gui = new TileUI({
+  title: 'Particles',
+  container: guiContainer,
+});
 
 gui.add(params, 'count', 10, 500, 10).onChange(() => {
   createParticles();
@@ -160,6 +166,27 @@ gui.add(params, 'size', 0.5, 10, 0.5);
 gui.add(params, 'spread', 0.1, 2, 0.1);
 gui.addBoolean(params, 'visible');
 
+gui.addColor(params, 'color');
+gui.addColor(params, 'bgColor');
+gui.addBoolean(params, 'glow');
+gui.addBoolean(params, 'trail');
+
+gui.addButton('Random', () => {
+  params.count = Math.round((10 + Math.random() * 490) / 10) * 10;
+  params.radius = Math.round((50 + Math.random() * 450) / 10) * 10;
+  params.speed = Math.round((0.1 + Math.random() * 4.9) * 10) / 10;
+  params.size = Math.round((0.5 + Math.random() * 9.5) * 2) / 2;
+  params.spread = Math.round((0.1 + Math.random() * 1.9) * 10) / 10;
+  params.color = `#${Math.floor(Math.random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')}`;
+  params.glow = Math.random() > 0.3;
+  params.trail = Math.random() > 0.3;
+  createParticles();
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  gui.updateDisplay();
+});
+
 gui.addButton('Reset', () => {
   Object.assign(params, { ...defaults });
   createParticles();
@@ -167,9 +194,3 @@ gui.addButton('Reset', () => {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   gui.updateDisplay();
 });
-
-const styleFolder = gui.addFolder('Style');
-styleFolder.addColor(params, 'color');
-styleFolder.addColor(params, 'bgColor');
-styleFolder.addBoolean(params, 'glow');
-styleFolder.addBoolean(params, 'trail');

--- a/public/tileui-demo/style.css
+++ b/public/tileui-demo/style.css
@@ -45,3 +45,33 @@ canvas {
   width: 100%;
   height: 100%;
 }
+
+#gui-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 50;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
+  pointer-events: none;
+}
+
+#gui-container > * {
+  pointer-events: auto;
+  width: 100%;
+}
+
+/* tileui テーマ調整 */
+#gui-container {
+  --tileui-bg: rgba(10, 10, 26, 0.85);
+  --tileui-tile-bg: rgba(20, 20, 40, 0.6);
+  --tileui-tile-bg-hover: rgba(30, 30, 55, 0.8);
+  --tileui-border: rgba(78, 205, 196, 0.15);
+  --tileui-knob-track: rgba(78, 205, 196, 0.15);
+}
+
+#gui-container .tileui-panel {
+  justify-content: center;
+}

--- a/public/tileui-demo/style.css
+++ b/public/tileui-demo/style.css
@@ -1,0 +1,47 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0a1a;
+  color: #e0e0e0;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## 概要
- 自作ライブラリ TileUI を CDN 経由で使用したインタラクティブデモページを追加

## 変更内容
- CDN 経由で @yuske-nakajima/tileui@0.2.1 を ESM import
- Canvas パーティクルデモ（リサジュー曲線風軌道）を実装
- TileUI 主要 API を網羅（add, addBoolean, addColor, addButton, onChange, updateDisplay）
- GUI パネルを画面下部に固定配置（レスポンシブ対応）
- Random ボタンでパラメータをランダム変更
- 半透明背景・統一ボーダーでテーマ調整
- トップページのナビゲーションにリンク追加

## テスト計画
- [x] `/tileui-demo/` でデモページが表示される
- [x] TileUI パネルが画面下部に表示される
- [x] ノブ・トグル・カラーピッカー・ボタンが操作できる
- [x] Random / Reset ボタンが動作する
- [x] 画面幅を変えるとタイルが自動折り返しする
- [x] トップページにリンクがある

🤖 Generated with [Claude Code](https://claude.com/claude-code)