### PR TITLE
chore: VS Code ワークスペースカラー設定を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#5b21b6",
+    "activityBar.foreground": "#ffffff",
+    "activityBar.inactiveForeground": "#c4b5fd",
+    "activityBarBadge.background": "#fbbf24",
+    "activityBarBadge.foreground": "#5b21b6",
+    "statusBar.background": "#6d28d9",
+    "statusBar.foreground": "#ffffff",
+    "titleBar.activeBackground": "#5b21b6",
+    "titleBar.activeForeground": "#ffffff"
+  }
+}


### PR DESCRIPTION
## 概要
- VS Code のワークスペースカラーカスタマイズ設定を追加

## 変更内容
- `.vscode/settings.json` を新規作成
- アクティビティバー・ステータスバー・タイトルバーを紫系カラーに設定

## テスト計画
- [x] VS Code でプロジェクトを開いた際にカラーが反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)