### PR TITLE
feat(shapes): 図形モーフィング タイルアートページを追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -145,6 +145,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/shapes/">
+              シェイプモーフ
+              <span class="nav-description"
+                >図形がモーフィングするタイルアート</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/shapes/index.html
+++ b/public/shapes/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>シェイプモーフ | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main id="canvas-container"></main>
+    <div id="gui-wrapper">
+      <button id="gui-toggle" type="button" aria-label="コントロールの表示切替">
+        <span id="gui-toggle-icon">&#x25B2;</span>
+      </button>
+      <div id="gui-container"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/p5@2/lib/p5.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/tkyko13/p5.lerpShape@main/p5.lerpShape.js"></script>
+    <script src="./main.js"></script>
+  </body>
+</html>

--- a/public/shapes/main.js
+++ b/public/shapes/main.js
@@ -10,8 +10,9 @@ const params = {
   colorful: true,
   bgColor: '#1a1a2e',
   shapeColor: '#e94560',
-  strokeWt: 0,
-  showStroke: false,
+  strokeColor: '#ffffff',
+  strokeWt: 2,
+  fill: true,
 };
 
 /** 初期値（リセット用） */
@@ -75,29 +76,67 @@ function drawHeart(x, y, size) {
 
 /** 図形描画関数のリスト */
 const shapeDrawers = [
-  (x, y, r) => drawPolygon(x, y, r, 3), // 三角形
-  (x, y, r) => drawPolygon(x, y, r, 4), // 四角形
-  (x, y, r) => drawPolygon(x, y, r, 5), // 五角形
-  (x, y, r) => drawPolygon(x, y, r, 6), // 六角形
-  (x, y, r) => drawPolygon(x, y, r, 8), // 八角形
-  (x, y, r) => circle(x, y, r * 2), // 円
-  (x, y, r) => drawStar(x, y, r, r * 0.4, 5), // 五芒星
-  (x, y, r) => drawStar(x, y, r, r * 0.5, 4), // 四芒星
-  (x, y, r) => drawHeart(x, y, r), // ハート
-  (x, y, r) => drawPolygon(x, y, r, 10), // 十角形
+  (x, y, r) => circle(x, y, r * 2), // 0: 円
+  (x, y, r) => drawPolygon(x, y, r, 3), // 1: 三角形
+  (x, y, r) => drawPolygon(x, y, r, 4), // 2: 四角形
+  (x, y, r) => drawPolygon(x, y, r, 5), // 3: 五角形
+  (x, y, r) => drawPolygon(x, y, r, 6), // 4: 六角形
+  (x, y, r) => drawPolygon(x, y, r, 8), // 5: 八角形
+  (x, y, r) => drawPolygon(x, y, r, 10), // 6: 十角形
+  (x, y, r) => drawStar(x, y, r, r * 0.4, 3), // 7: 三芒星
+  (x, y, r) => drawStar(x, y, r, r * 0.5, 4), // 8: 四芒星
+  (x, y, r) => drawStar(x, y, r, r * 0.4, 5), // 9: 五芒星
+  (x, y, r) => drawStar(x, y, r, r * 0.4, 6), // 10: 六芒星
+  (x, y, r) => drawHeart(x, y, r), // 11: ハート
 ];
 
 /**
- * 現在と異なるランダムな図形インデックスを返す
+ * モーフィング時の相性の良いペア候補
+ * 円↔多角形、多角形↔同辺数の星
+ */
+/** 各図形の相対的な面積（円=1 基準、大きい順にソート用） */
+const shapeArea = {
+  0: 1.0, // 円
+  1: 0.41, // 三角形
+  2: 0.64, // 四角形
+  3: 0.59, // 五角形
+  4: 0.65, // 六角形
+  5: 0.71, // 八角形
+  6: 0.74, // 十角形
+  7: 0.25, // 三芒星
+  8: 0.32, // 四芒星
+  9: 0.28, // 五芒星
+  10: 0.3, // 六芒星
+  11: 0.5, // ハート
+};
+
+/**
+ * モーフィング時の相性の良いペア候補
+ * 円↔多角形、多角形↔同辺数の星のみ（多角形↔多角形は禁止）
+ */
+const morphPairs = {
+  0: [1, 2, 3, 4, 5, 6], // 円 → 任意の多角形
+  1: [0, 7], // 三角形 → 円, 三芒星
+  2: [0, 8], // 四角形 → 円, 四芒星
+  3: [0, 9], // 五角形 → 円, 五芒星
+  4: [0, 10], // 六角形 → 円, 六芒星
+  5: [0], // 八角形 → 円
+  6: [0], // 十角形 → 円
+  7: [1, 0], // 三芒星 → 三角形, 円
+  8: [2, 0], // 四芒星 → 四角形, 円
+  9: [3, 0], // 五芒星 → 五角形, 円
+  10: [4, 0], // 六芒星 → 六角形, 円
+  11: [0], // ハート → 円
+};
+
+/**
+ * 相性の良いモーフ先をランダムに返す
  * @param {number} currentIndex - 現在の図形インデックス
  * @returns {number}
  */
-function randomShapeIndex(currentIndex) {
-  let next = floor(random(shapeDrawers.length));
-  while (next === currentIndex) {
-    next = floor(random(shapeDrawers.length));
-  }
-  return next;
+function randomMorphTarget(currentIndex) {
+  const candidates = morphPairs[currentIndex] || [0];
+  return candidates[floor(random(candidates.length))];
 }
 
 /** タイルデータを生成する */
@@ -108,7 +147,7 @@ function createTiles() {
     const shapeIndex = floor(random(shapeDrawers.length));
     tiles.push({
       shapeIndex,
-      nextShapeIndex: randomShapeIndex(shapeIndex),
+      nextShapeIndex: randomMorphTarget(shapeIndex),
       hueOffset: random(360),
       phase: random(1),
       prevT: 0,
@@ -151,30 +190,47 @@ function draw() {
       const t = (frameCount * params.speed * 0.01 + tile.phase) % 1;
 
       // 色の設定
-      if (params.colorful) {
-        const hue = (tile.hueOffset + frameCount * 0.5) % 360;
-        fill(hue, 70, 60);
-      } else {
-        fill(params.shapeColor);
-      }
+      const shapeHue = (tile.hueOffset + frameCount * 0.5) % 360;
 
-      if (params.showStroke) {
-        stroke(255);
-        strokeWeight(params.strokeWt);
-      } else {
-        noStroke();
-      }
+      // アウトライン（常に表示）
+      stroke(params.strokeColor);
+      strokeWeight(params.strokeWt);
 
-      // lerpShape でモーフィング
+      // 面積で描画順を決定（大きい方が奥＝先に描画）
+      const areaA = shapeArea[tile.shapeIndex] || 0.5;
+      const areaB = shapeArea[tile.nextShapeIndex] || 0.5;
+      const bigIdx = areaA >= areaB ? tile.shapeIndex : tile.nextShapeIndex;
+      const smallIdx = areaA >= areaB ? tile.nextShapeIndex : tile.shapeIndex;
+
+      // lerpShape でモーフィングアニメーション
+      // 奥（面積大）→ 手前（面積小・明度差）の順に描画
       withLerpShape(t, () => {
-        shapeDrawers[tile.shapeIndex](cx, cy, r);
-        shapeDrawers[tile.nextShapeIndex](cx, cy, r);
+        if (params.fill) {
+          if (params.colorful) {
+            fill(shapeHue, 70, 60);
+          } else {
+            fill(params.shapeColor);
+          }
+        } else {
+          noFill();
+        }
+        shapeDrawers[bigIdx](cx, cy, r);
+
+        if (params.fill) {
+          if (params.colorful) {
+            fill(shapeHue, 50, 40);
+          } else {
+            const c = color(params.shapeColor);
+            fill(hue(c), saturation(c) * 0.8, lightness(c) * 0.7);
+          }
+        }
+        shapeDrawers[smallIdx](cx, cy, r);
       });
 
-      // モーフ完了時に次の図形を設定（t が 0 をまたいだら切り替え）
+      // 一定間隔で次の図形に切り替え
       if (t < tile.prevT) {
         tile.shapeIndex = tile.nextShapeIndex;
-        tile.nextShapeIndex = randomShapeIndex(tile.shapeIndex);
+        tile.nextShapeIndex = randomMorphTarget(tile.shapeIndex);
       }
       tile.prevT = t;
     }
@@ -205,10 +261,11 @@ function setupGUI() {
     gui.add(params, 'rows', 2, 8, 1).onChange(() => createTiles());
     gui.add(params, 'speed', 0.1, 3, 0.1);
     gui.addBoolean(params, 'colorful');
+    gui.addBoolean(params, 'fill');
     gui.addColor(params, 'shapeColor');
+    gui.addColor(params, 'strokeColor');
     gui.addColor(params, 'bgColor');
-    gui.add(params, 'strokeWt', 0, 5, 0.5);
-    gui.addBoolean(params, 'showStroke');
+    gui.add(params, 'strokeWt', 0.5, 5, 0.5);
 
     gui.addButton('Random', () => {
       params.cols = floor(random(2, 9));

--- a/public/shapes/main.js
+++ b/public/shapes/main.js
@@ -1,0 +1,268 @@
+// p5.js グローバルモード + p5.lerpShape
+// @ts-check は使わない（p5 グローバル関数が型エラーになるため）
+
+// --- パラメータ ---
+
+const params = {
+  cols: 4,
+  rows: 4,
+  speed: 0.5,
+  colorful: true,
+  bgColor: '#1a1a2e',
+  shapeColor: '#e94560',
+  strokeWt: 0,
+  showStroke: false,
+};
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
+
+// --- タイルデータ ---
+
+/** @type {Array<{shapeIndex: number, nextShapeIndex: number, hueOffset: number, phase: number, prevT: number}>} */
+let tiles = [];
+
+// --- 図形描画関数 ---
+
+/**
+ * 正多角形を描画する汎用関数
+ * @param {number} x - 中心 x
+ * @param {number} y - 中心 y
+ * @param {number} radius - 半径
+ * @param {number} sides - 辺の数
+ */
+function drawPolygon(x, y, radius, sides) {
+  beginShape();
+  for (let i = 0; i < sides; i++) {
+    const angle = (TWO_PI / sides) * i - HALF_PI;
+    vertex(x + cos(angle) * radius, y + sin(angle) * radius);
+  }
+  endShape(CLOSE);
+}
+
+/**
+ * 星形を描画する関数
+ * @param {number} x - 中心 x
+ * @param {number} y - 中心 y
+ * @param {number} outerR - 外側半径
+ * @param {number} innerR - 内側半径
+ * @param {number} points - 頂点数
+ */
+function drawStar(x, y, outerR, innerR, points) {
+  beginShape();
+  for (let i = 0; i < points * 2; i++) {
+    const angle = (TWO_PI / (points * 2)) * i - HALF_PI;
+    const r = i % 2 === 0 ? outerR : innerR;
+    vertex(x + cos(angle) * r, y + sin(angle) * r);
+  }
+  endShape(CLOSE);
+}
+
+/**
+ * ハート形を描画する関数
+ * @param {number} x - 中心 x
+ * @param {number} y - 中心 y
+ * @param {number} size - サイズ
+ */
+function drawHeart(x, y, size) {
+  beginShape();
+  for (let a = 0; a < TWO_PI; a += 0.1) {
+    const r = size * (1 - sin(a)) * 0.5;
+    vertex(x + r * cos(a), y - r * sin(a) + size * 0.3);
+  }
+  endShape(CLOSE);
+}
+
+/** 図形描画関数のリスト */
+const shapeDrawers = [
+  (x, y, r) => drawPolygon(x, y, r, 3), // 三角形
+  (x, y, r) => drawPolygon(x, y, r, 4), // 四角形
+  (x, y, r) => drawPolygon(x, y, r, 5), // 五角形
+  (x, y, r) => drawPolygon(x, y, r, 6), // 六角形
+  (x, y, r) => drawPolygon(x, y, r, 8), // 八角形
+  (x, y, r) => circle(x, y, r * 2), // 円
+  (x, y, r) => drawStar(x, y, r, r * 0.4, 5), // 五芒星
+  (x, y, r) => drawStar(x, y, r, r * 0.5, 4), // 四芒星
+  (x, y, r) => drawHeart(x, y, r), // ハート
+  (x, y, r) => drawPolygon(x, y, r, 10), // 十角形
+];
+
+/**
+ * 現在と異なるランダムな図形インデックスを返す
+ * @param {number} currentIndex - 現在の図形インデックス
+ * @returns {number}
+ */
+function randomShapeIndex(currentIndex) {
+  let next = floor(random(shapeDrawers.length));
+  while (next === currentIndex) {
+    next = floor(random(shapeDrawers.length));
+  }
+  return next;
+}
+
+/** タイルデータを生成する */
+function createTiles() {
+  tiles = [];
+  const total = params.cols * params.rows;
+  for (let i = 0; i < total; i++) {
+    const shapeIndex = floor(random(shapeDrawers.length));
+    tiles.push({
+      shapeIndex,
+      nextShapeIndex: randomShapeIndex(shapeIndex),
+      hueOffset: random(360),
+      phase: random(1),
+      prevT: 0,
+    });
+  }
+}
+
+// --- p5.js セットアップ ---
+
+// biome-ignore lint/correctness/noUnusedVariables: p5.js グローバルモードが呼び出す
+function setup() {
+  const canvas = createCanvas(windowWidth, windowHeight);
+  canvas.parent('canvas-container');
+  colorMode(HSL, 360, 100, 100);
+  createTiles();
+  setupGUI();
+  setupMobileToggle();
+}
+
+// --- 描画ループ ---
+
+// biome-ignore lint/correctness/noUnusedVariables: p5.js グローバルモードが呼び出す
+function draw() {
+  background(params.bgColor);
+
+  const margin = min(width, height) * 0.05;
+  const cellW = (width - margin * 2) / params.cols;
+  const cellH = (height - margin * 2) / params.rows;
+  const r = min(cellW, cellH) * 0.35;
+
+  for (let row = 0; row < params.rows; row++) {
+    for (let col = 0; col < params.cols; col++) {
+      const tile = tiles[row * params.cols + col];
+      if (!tile) continue;
+
+      const cx = margin + cellW * (col + 0.5);
+      const cy = margin + cellH * (row + 0.5);
+
+      // モーフィング進捗（各タイルに位相差を持たせる）
+      const t = (frameCount * params.speed * 0.01 + tile.phase) % 1;
+
+      // 色の設定
+      if (params.colorful) {
+        const hue = (tile.hueOffset + frameCount * 0.5) % 360;
+        fill(hue, 70, 60);
+      } else {
+        fill(params.shapeColor);
+      }
+
+      if (params.showStroke) {
+        stroke(255);
+        strokeWeight(params.strokeWt);
+      } else {
+        noStroke();
+      }
+
+      // lerpShape でモーフィング
+      withLerpShape(t, () => {
+        shapeDrawers[tile.shapeIndex](cx, cy, r);
+        shapeDrawers[tile.nextShapeIndex](cx, cy, r);
+      });
+
+      // モーフ完了時に次の図形を設定（t が 0 をまたいだら切り替え）
+      if (t < tile.prevT) {
+        tile.shapeIndex = tile.nextShapeIndex;
+        tile.nextShapeIndex = randomShapeIndex(tile.shapeIndex);
+      }
+      tile.prevT = t;
+    }
+  }
+}
+
+// --- ウィンドウリサイズ ---
+
+// biome-ignore lint/correctness/noUnusedVariables: p5.js グローバルモードが呼び出す
+function windowResized() {
+  resizeCanvas(windowWidth, windowHeight);
+}
+
+// --- TileUI GUI セットアップ ---
+
+function setupGUI() {
+  import(
+    'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js'
+  ).then((module) => {
+    const TileUI = module.default;
+    const guiContainer = document.getElementById('gui-container');
+    const gui = new TileUI({
+      title: 'シェイプモーフ',
+      container: guiContainer,
+    });
+
+    gui.add(params, 'cols', 2, 8, 1).onChange(() => createTiles());
+    gui.add(params, 'rows', 2, 8, 1).onChange(() => createTiles());
+    gui.add(params, 'speed', 0.1, 3, 0.1);
+    gui.addBoolean(params, 'colorful');
+    gui.addColor(params, 'shapeColor');
+    gui.addColor(params, 'bgColor');
+    gui.add(params, 'strokeWt', 0, 5, 0.5);
+    gui.addBoolean(params, 'showStroke');
+
+    gui.addButton('Random', () => {
+      params.cols = floor(random(2, 9));
+      params.rows = floor(random(2, 9));
+      params.speed = round(random(0.1, 3) * 10) / 10;
+      params.colorful = random() > 0.3;
+      params.shapeColor = randomHexColor();
+      createTiles();
+      gui.updateDisplay();
+    });
+
+    gui.addButton('Reset', () => {
+      Object.assign(params, { ...defaults });
+      createTiles();
+      gui.updateDisplay();
+    });
+  });
+}
+
+/**
+ * ランダムな hex カラーを返す
+ * @returns {string}
+ */
+function randomHexColor() {
+  const r = floor(random(256));
+  const g = floor(random(256));
+  const b = floor(random(256));
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}
+
+// --- モバイル GUI トグル ---
+
+function setupMobileToggle() {
+  const guiWrapper = document.getElementById('gui-wrapper');
+  const guiToggle = document.getElementById('gui-toggle');
+  if (!guiWrapper || !guiToggle) return;
+
+  // モバイルでは初期状態を閉じておく
+  const mql = window.matchMedia('(max-width: 48rem)');
+  if (mql.matches) {
+    guiWrapper.classList.add('collapsed');
+  }
+  mql.addEventListener('change', (e) => {
+    if (e.matches) {
+      guiWrapper.classList.add('collapsed');
+    } else {
+      guiWrapper.classList.remove('collapsed');
+    }
+  });
+
+  guiToggle.addEventListener('click', () => {
+    guiWrapper.classList.toggle('collapsed');
+  });
+}
+
+// p5.js グローバルモードのため setup / draw / windowResized を
+// グローバルスコープに公開（上記の function 宣言で自動的にグローバル）

--- a/public/shapes/style.css
+++ b/public/shapes/style.css
@@ -1,0 +1,139 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #1a1a2e;
+  color: #c8c8d8;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #7a7a9a;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #c8c8d8;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* --- GUI ラッパー（デスクトップ） --- */
+
+#gui-wrapper {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#gui-toggle {
+  display: none;
+}
+
+#gui-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
+  pointer-events: none;
+}
+
+#gui-container > * {
+  pointer-events: auto;
+  width: 100%;
+}
+
+/* TileUI テーマ調整（ダーク系） */
+#gui-container {
+  --tileui-bg: rgba(22, 22, 44, 0.92);
+  --tileui-tile-bg: rgba(40, 40, 70, 0.6);
+  --tileui-tile-bg-hover: rgba(60, 60, 100, 0.8);
+  --tileui-border: rgba(100, 100, 160, 0.25);
+  --tileui-knob-track: rgba(100, 100, 160, 0.25);
+  --tileui-text: #c8c8d8;
+  --tileui-accent: #e94560;
+}
+
+#gui-container .tileui-panel {
+  justify-content: center;
+}
+
+/* --- モバイル: オーバーレイ + トグル --- */
+
+@media (max-width: 48rem) {
+  #gui-wrapper {
+    transition: transform 0.3s ease;
+  }
+
+  /* 閉じた状態: コンテナを画面外に押し下げ、トグルだけ見える */
+  #gui-wrapper.collapsed {
+    transform: translateY(calc(100% - 2.5rem));
+  }
+
+  #gui-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 2.5rem;
+    border: none;
+    background: rgba(22, 22, 44, 0.92);
+    color: #c8c8d8;
+    font-size: 0.75rem;
+    cursor: pointer;
+    border-radius: 0.5rem 0.5rem 0 0;
+    pointer-events: auto;
+    transition: background 0.2s;
+  }
+
+  #gui-toggle:hover {
+    background: rgba(40, 40, 70, 0.95);
+  }
+
+  /* アイコンの回転アニメーション */
+  #gui-toggle-icon {
+    display: inline-block;
+    transition: transform 0.3s ease;
+  }
+
+  #gui-wrapper.collapsed #gui-toggle-icon {
+    transform: rotate(180deg);
+  }
+
+  #gui-container {
+    --tileui-bg: rgba(22, 22, 44, 0.85);
+  }
+}


### PR DESCRIPTION
## 概要
- p5.js + p5.lerpShape を使った図形モーフィング ジェネレーティブアートページを追加

## 変更内容
- `public/shapes/` に HTML/CSS/JS の3ファイル構成でシェイプモーフページを新規作成
- 12種類の図形（正多角形6種、星形4種、ハート、円）間のモーフィングアニメーション
- 相性の良いペアリング（円↔多角形、多角形↔同辺数の星、多角形↔多角形は禁止）
- 面積順の描画（大→奥、小→手前・明度差）
- fill トグルで塗りつぶし/アウトラインのみ切替
- TileUI で cols, rows, speed, colorful, fill, shapeColor, strokeColor 等を GUI 制御
- モバイル対応（GUI トグル）
- トップページにナビゲーションリンク追加

## テスト計画
- [ ] デスクトップでモーフィングアニメーションが動作すること
- [ ] fill ON/OFF で描画モードが切り替わること
- [ ] Random / Reset ボタンが動作すること
- [ ] モバイルでトグルが動作すること
- [ ] トップページから /shapes/ へのリンクが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)