### PR TITLE
feat(rain): Neon Rain ジェネレーティブアートページを追加

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -145,6 +145,14 @@
               >
             </a>
           </li>
+          <li>
+            <a href="/rain/">
+              Neon Rain
+              <span class="nav-description"
+                >雨夜のネオンジェネレーティブアート</span
+              >
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/rain/gui.js
+++ b/public/rain/gui.js
@@ -1,0 +1,182 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+import * as THREE from 'https://esm.sh/three@0.172.0';
+
+/**
+ * @typedef {import('./ripple.js').Ripple} Ripple
+ */
+
+/**
+ * @typedef {{
+ *   rainCount: number,
+ *   rainSpeed: number,
+ *   wind: number,
+ *   fogDensity: number,
+ *   bgColor: string,
+ *   autoRotate: boolean,
+ *   rippleColor: string,
+ *   rippleSpeed: number,
+ *   rippleCount: number,
+ *   waveHeight: number,
+ * }} RainParams
+ */
+
+/**
+ * @typedef {{
+ *   params: RainParams,
+ *   defaults: RainParams,
+ *   isMobile: boolean,
+ *   scene: THREE.Scene,
+ *   pointLight: THREE.PointLight,
+ *   ripplePool: Ripple[],
+ *   createRainParticles: (count: number) => { lines: THREE.LineSegments, positions: Float32Array },
+ *   getRain: () => { rainLines: THREE.LineSegments, rainPositions: Float32Array },
+ *   setRain: (lines: THREE.LineSegments, positions: Float32Array) => void,
+ *   resetTime: () => void,
+ * }} GuiContext
+ */
+
+/**
+ * GUI をセットアップする
+ * @param {GuiContext} ctx
+ */
+export function setupGui(ctx) {
+  const {
+    params,
+    defaults,
+    isMobile,
+    scene,
+    pointLight,
+    ripplePool,
+    createRainParticles,
+    getRain,
+    setRain,
+    resetTime,
+  } = ctx;
+
+  const guiContainer = /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  );
+  const gui = new TileUI({
+    title: 'Neon Rain',
+    container: guiContainer,
+  });
+
+  // 雨粒の数（モバイルは上限500）
+  gui.add(params, 'rainCount', 100, isMobile ? 500 : 3000, 50).onChange(() => {
+    const { rainLines } = getRain();
+    scene.remove(rainLines);
+    const result = createRainParticles(params.rainCount);
+    setRain(result.lines, result.positions);
+    scene.add(result.lines);
+  });
+
+  gui.add(params, 'rainSpeed', 0.5, 5, 0.1);
+  gui.add(params, 'wind', -3, 3, 0.1);
+  gui.add(params, 'rippleSpeed', 0.5, 3, 0.1);
+  gui.add(params, 'waveHeight', 0, 0.5, 0.01);
+  gui.add(params, 'fogDensity', 0, 0.1, 0.005).onChange(() => {
+    if (scene.fog instanceof THREE.FogExp2) {
+      scene.fog.density = params.fogDensity;
+    }
+  });
+
+  gui.addBoolean(params, 'autoRotate');
+
+  gui.addColor(params, 'rippleColor').onChange(() => {
+    syncRippleColor(ripplePool, pointLight, params.rippleColor);
+  });
+
+  gui.addColor(params, 'bgColor').onChange(() => {
+    syncBgColor(scene, params.bgColor);
+  });
+
+  gui.addButton('Random', () => {
+    randomizeParams(params);
+    syncScene(scene, ripplePool, pointLight, params);
+    gui.updateDisplay();
+  });
+
+  gui.addButton('Reset', () => {
+    Object.assign(params, { ...defaults });
+    syncScene(scene, ripplePool, pointLight, params);
+
+    // 雨粒を再生成
+    const { rainLines } = getRain();
+    scene.remove(rainLines);
+    const result = createRainParticles(params.rainCount);
+    setRain(result.lines, result.positions);
+    scene.add(result.lines);
+
+    resetTime();
+    gui.updateDisplay();
+  });
+}
+
+/**
+ * パラメータをランダム化する
+ * @param {RainParams} params
+ */
+function randomizeParams(params) {
+  params.rainSpeed = Math.round((0.5 + Math.random() * 4.5) * 10) / 10;
+  params.wind = Math.round((-3 + Math.random() * 6) * 10) / 10;
+  params.rippleSpeed = Math.round((0.5 + Math.random() * 2.5) * 10) / 10;
+  params.waveHeight = Math.round(Math.random() * 0.5 * 100) / 100;
+  params.fogDensity = Math.round(Math.random() * 0.1 * 1000) / 1000;
+
+  // ランダムなネオンカラーを生成（HSL: H=ランダム, S=80-100%, L=50-60%）
+  const h = Math.floor(Math.random() * 360);
+  const s = 80 + Math.floor(Math.random() * 20);
+  const l = 50 + Math.floor(Math.random() * 10);
+  const c = new THREE.Color();
+  c.setHSL(h / 360, s / 100, l / 100);
+  params.rippleColor = `#${c.getHexString()}`;
+
+  // 背景色はランダムな暗い色
+  const bgC = new THREE.Color();
+  bgC.setHSL(Math.random(), 0.3, 0.06);
+  params.bgColor = `#${bgC.getHexString()}`;
+}
+
+/**
+ * 波紋の色を同期する
+ * @param {Ripple[]} ripplePool
+ * @param {THREE.PointLight} pointLight
+ * @param {string} color
+ */
+function syncRippleColor(ripplePool, pointLight, color) {
+  for (const ripple of ripplePool) {
+    const mat = /** @type {THREE.MeshBasicMaterial} */ (ripple.mesh.material);
+    mat.color.set(color);
+  }
+  pointLight.color.set(color);
+}
+
+/**
+ * 背景色を同期する
+ * @param {THREE.Scene} scene
+ * @param {string} color
+ */
+function syncBgColor(scene, color) {
+  scene.background = new THREE.Color(color);
+  if (scene.fog instanceof THREE.FogExp2) {
+    scene.fog.color.set(color);
+  }
+}
+
+/**
+ * シーン全体を params に同期する
+ * @param {THREE.Scene} scene
+ * @param {Ripple[]} ripplePool
+ * @param {THREE.PointLight} pointLight
+ * @param {RainParams} params
+ */
+function syncScene(scene, ripplePool, pointLight, params) {
+  scene.background = new THREE.Color(params.bgColor);
+  if (scene.fog instanceof THREE.FogExp2) {
+    scene.fog.color.set(params.bgColor);
+    scene.fog.density = params.fogDensity;
+  }
+  syncRippleColor(ripplePool, pointLight, params.rippleColor);
+}

--- a/public/rain/index.html
+++ b/public/rain/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Neon Rain | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; トップに戻る</a>
+    </header>
+    <main>
+      <div id="canvas-container"></div>
+    </main>
+    <div id="gui-wrapper">
+      <button
+        id="gui-toggle"
+        type="button"
+        aria-label="コントロールの表示切替"
+      >
+        <span id="gui-toggle-icon">&#x25B2;</span>
+      </button>
+      <div id="gui-container"></div>
+    </div>
+  </body>
+</html>

--- a/public/rain/main.js
+++ b/public/rain/main.js
@@ -1,0 +1,168 @@
+// @ts-check
+import * as THREE from 'https://esm.sh/three@0.172.0';
+
+// --- パラメータ ---
+
+const params = {
+  rainCount: 1000,
+  rainSpeed: 2,
+  wind: 0.3,
+  fogDensity: 0.03,
+  bgColor: '#0a0a1e',
+  autoRotate: true,
+};
+
+// モバイル判定で雨粒数を制限
+const isMobile = window.innerWidth < 768;
+if (isMobile) {
+  params.rainCount = 500;
+}
+
+// --- Three.js セットアップ ---
+
+const container = /** @type {HTMLElement} */ (
+  document.getElementById('canvas-container')
+);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(params.bgColor);
+scene.fog = new THREE.FogExp2(params.bgColor, params.fogDensity);
+
+const camera = new THREE.PerspectiveCamera(
+  60,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  100,
+);
+camera.position.set(0, 8, 12);
+camera.lookAt(0, 0, 0);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+container.appendChild(renderer.domElement);
+
+// --- リサイズ対応 ---
+
+window.addEventListener('resize', () => {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+  renderer.setSize(width, height);
+});
+
+// --- 雨粒パーティクル ---
+
+/**
+ * 雨粒のジオメトリとマテリアルを生成する
+ * @param {number} count - 雨粒の数
+ * @returns {{ points: THREE.Points, positions: Float32Array }}
+ */
+function createRainParticles(count) {
+  const geometry = new THREE.BufferGeometry();
+  const positions = new Float32Array(count * 3);
+
+  for (let i = 0; i < count; i++) {
+    const i3 = i * 3;
+    // x: -15 ~ 15
+    positions[i3] = (Math.random() - 0.5) * 30;
+    // y: 0 ~ 20
+    positions[i3 + 1] = Math.random() * 20;
+    // z: -15 ~ 15
+    positions[i3 + 2] = (Math.random() - 0.5) * 30;
+  }
+
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+  const material = new THREE.PointsMaterial({
+    color: '#aaccff',
+    size: 0.05,
+    transparent: true,
+    opacity: 0.6,
+    sizeAttenuation: true,
+  });
+
+  const points = new THREE.Points(geometry, material);
+  return { points, positions };
+}
+
+const { points: rainPoints, positions: rainPositions } = createRainParticles(
+  params.rainCount,
+);
+scene.add(rainPoints);
+
+// --- アニメーションループ ---
+
+let cameraAngle = 0;
+/** カメラの原点からの距離 */
+const cameraRadius = Math.sqrt(camera.position.x ** 2 + camera.position.z ** 2);
+/** カメラの初期高さ */
+const cameraHeight = camera.position.y;
+
+/** メインのアニメーションループ */
+function animate() {
+  requestAnimationFrame(animate);
+
+  // --- 雨粒の更新 ---
+  const count = params.rainCount;
+  for (let i = 0; i < count; i++) {
+    const i3 = i * 3;
+
+    // y を下降させる
+    rainPositions[i3 + 1] -= params.rainSpeed * 0.05;
+
+    // x に風を加算
+    rainPositions[i3] += params.wind * 0.01;
+
+    // y < 0 でリセット
+    if (rainPositions[i3 + 1] < 0) {
+      rainPositions[i3 + 1] = 20;
+      rainPositions[i3] = (Math.random() - 0.5) * 30;
+      rainPositions[i3 + 2] = (Math.random() - 0.5) * 30;
+    }
+  }
+
+  // position 属性の更新フラグ
+  const posAttr = rainPoints.geometry.getAttribute('position');
+  posAttr.needsUpdate = true;
+
+  // --- カメラ自動回転 ---
+  if (params.autoRotate) {
+    cameraAngle += 0.002;
+    camera.position.x = Math.sin(cameraAngle) * cameraRadius;
+    camera.position.z = Math.cos(cameraAngle) * cameraRadius;
+    camera.position.y = cameraHeight;
+    camera.lookAt(0, 0, 0);
+  }
+
+  renderer.render(scene, camera);
+}
+
+animate();
+
+// --- GUI トグル（モバイル） ---
+
+const guiWrapper = /** @type {HTMLElement} */ (
+  document.getElementById('gui-wrapper')
+);
+const guiToggle = /** @type {HTMLButtonElement} */ (
+  document.getElementById('gui-toggle')
+);
+
+// モバイルでは初期状態を閉じておく
+const mql = window.matchMedia('(max-width: 48rem)');
+if (mql.matches) {
+  guiWrapper.classList.add('collapsed');
+}
+mql.addEventListener('change', (e) => {
+  if (e.matches) {
+    guiWrapper.classList.add('collapsed');
+  } else {
+    guiWrapper.classList.remove('collapsed');
+  }
+});
+
+guiToggle.addEventListener('click', () => {
+  guiWrapper.classList.toggle('collapsed');
+});

--- a/public/rain/main.js
+++ b/public/rain/main.js
@@ -1,5 +1,6 @@
 // @ts-check
 import * as THREE from 'https://esm.sh/three@0.172.0';
+import { setupGui } from './gui.js';
 import { activateRipple, createRipplePool, updateRipples } from './ripple.js';
 import { createWater, updateWaterSurface } from './water.js';
 
@@ -23,6 +24,9 @@ const isMobile = window.innerWidth < 768;
 if (isMobile) {
   params.rainCount = 500;
 }
+
+/** 初期値（リセット用） */
+const defaults = { ...params };
 
 // --- Three.js セットアップ ---
 
@@ -97,7 +101,7 @@ function createRainParticles(count) {
   return { lines, positions };
 }
 
-const { lines: rainLines, positions: rainPositions } = createRainParticles(
+let { lines: rainLines, positions: rainPositions } = createRainParticles(
   params.rainCount,
 );
 scene.add(rainLines);
@@ -211,4 +215,24 @@ mql.addEventListener('change', (e) => {
 
 guiToggle.addEventListener('click', () => {
   guiWrapper.classList.toggle('collapsed');
+});
+
+// --- GUI セットアップ ---
+
+setupGui({
+  params,
+  defaults,
+  isMobile,
+  scene,
+  pointLight,
+  ripplePool,
+  createRainParticles,
+  getRain: () => ({ rainLines, rainPositions }),
+  setRain: (lines, positions) => {
+    rainLines = lines;
+    rainPositions = positions;
+  },
+  resetTime: () => {
+    time = 0;
+  },
 });

--- a/public/rain/main.js
+++ b/public/rain/main.js
@@ -1,5 +1,7 @@
 // @ts-check
 import * as THREE from 'https://esm.sh/three@0.172.0';
+import { activateRipple, createRipplePool, updateRipples } from './ripple.js';
+import { createWater, updateWaterSurface } from './water.js';
 
 // --- パラメータ ---
 
@@ -10,6 +12,10 @@ const params = {
   fogDensity: 0.03,
   bgColor: '#0a0a1e',
   autoRotate: true,
+  rippleColor: '#00ccff',
+  rippleSpeed: 1,
+  rippleCount: 20,
+  waveHeight: 0.1,
 };
 
 // モバイル判定で雨粒数を制限
@@ -65,11 +71,8 @@ function createRainParticles(count) {
 
   for (let i = 0; i < count; i++) {
     const i3 = i * 3;
-    // x: -15 ~ 15
     positions[i3] = (Math.random() - 0.5) * 30;
-    // y: 0 ~ 20
     positions[i3 + 1] = Math.random() * 20;
-    // z: -15 ~ 15
     positions[i3 + 2] = (Math.random() - 0.5) * 30;
   }
 
@@ -92,40 +95,55 @@ const { points: rainPoints, positions: rainPositions } = createRainParticles(
 );
 scene.add(rainPoints);
 
+// --- 水面 ---
+
+const { geometry: waterGeometry } = createWater(scene);
+
+// --- 波紋プール ---
+
+const ripplePool = createRipplePool(scene, params);
+
 // --- アニメーションループ ---
 
 let cameraAngle = 0;
-/** カメラの原点からの距離 */
 const cameraRadius = Math.sqrt(camera.position.x ** 2 + camera.position.z ** 2);
-/** カメラの初期高さ */
 const cameraHeight = camera.position.y;
+let time = 0;
 
 /** メインのアニメーションループ */
 function animate() {
   requestAnimationFrame(animate);
+  time += 0.016;
 
   // --- 雨粒の更新 ---
   const count = params.rainCount;
   for (let i = 0; i < count; i++) {
     const i3 = i * 3;
 
-    // y を下降させる
     rainPositions[i3 + 1] -= params.rainSpeed * 0.05;
-
-    // x に風を加算
     rainPositions[i3] += params.wind * 0.01;
 
-    // y < 0 でリセット
+    // 着水判定: y < 0 でリセット
     if (rainPositions[i3 + 1] < 0) {
+      // 30% の確率で波紋を発生させる
+      if (Math.random() < 0.3) {
+        activateRipple(ripplePool, rainPositions[i3], rainPositions[i3 + 2]);
+      }
+
       rainPositions[i3 + 1] = 20;
       rainPositions[i3] = (Math.random() - 0.5) * 30;
       rainPositions[i3 + 2] = (Math.random() - 0.5) * 30;
     }
   }
 
-  // position 属性の更新フラグ
   const posAttr = rainPoints.geometry.getAttribute('position');
   posAttr.needsUpdate = true;
+
+  // --- 波紋の更新 ---
+  updateRipples(ripplePool, params);
+
+  // --- 水面の頂点変位 ---
+  updateWaterSurface(waterGeometry, time, ripplePool, params);
 
   // --- カメラ自動回転 ---
   if (params.autoRotate) {
@@ -150,7 +168,6 @@ const guiToggle = /** @type {HTMLButtonElement} */ (
   document.getElementById('gui-toggle')
 );
 
-// モバイルでは初期状態を閉じておく
 const mql = window.matchMedia('(max-width: 48rem)');
 if (mql.matches) {
   guiWrapper.classList.add('collapsed');

--- a/public/rain/main.js
+++ b/public/rain/main.js
@@ -61,43 +61,50 @@ window.addEventListener('resize', () => {
 // --- 雨粒パーティクル ---
 
 /**
- * 雨粒のジオメトリとマテリアルを生成する
+ * 雨粒のジオメトリとマテリアルを生成する（Line ベースのストリーク表現）
  * @param {number} count - 雨粒の数
- * @returns {{ points: THREE.Points, positions: Float32Array }}
+ * @returns {{ lines: THREE.LineSegments, positions: Float32Array }}
  */
 function createRainParticles(count) {
   const geometry = new THREE.BufferGeometry();
-  const positions = new Float32Array(count * 3);
+  // 各雨粒に始点と終点が必要なので count * 2 * 3
+  const positions = new Float32Array(count * 2 * 3);
 
   for (let i = 0; i < count; i++) {
-    const i3 = i * 3;
-    positions[i3] = (Math.random() - 0.5) * 30;
-    positions[i3 + 1] = Math.random() * 20;
-    positions[i3 + 2] = (Math.random() - 0.5) * 30;
+    const i6 = i * 6;
+    const x = (Math.random() - 0.5) * 30;
+    const y = Math.random() * 20;
+    const z = (Math.random() - 0.5) * 30;
+    // 始点
+    positions[i6] = x;
+    positions[i6 + 1] = y;
+    positions[i6 + 2] = z;
+    // 終点（下に少しずらす = ストリーク長）
+    positions[i6 + 3] = x;
+    positions[i6 + 4] = y - 0.3;
+    positions[i6 + 5] = z;
   }
 
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
 
-  const material = new THREE.PointsMaterial({
+  const material = new THREE.LineBasicMaterial({
     color: '#aaccff',
-    size: 0.05,
     transparent: true,
-    opacity: 0.6,
-    sizeAttenuation: true,
+    opacity: 0.4,
   });
 
-  const points = new THREE.Points(geometry, material);
-  return { points, positions };
+  const lines = new THREE.LineSegments(geometry, material);
+  return { lines, positions };
 }
 
-const { points: rainPoints, positions: rainPositions } = createRainParticles(
+const { lines: rainLines, positions: rainPositions } = createRainParticles(
   params.rainCount,
 );
-scene.add(rainPoints);
+scene.add(rainLines);
 
 // --- 水面 ---
 
-const { geometry: waterGeometry } = createWater(scene);
+const { geometry: waterGeometry, pointLight } = createWater(scene);
 
 // --- 波紋プール ---
 
@@ -110,34 +117,56 @@ const cameraRadius = Math.sqrt(camera.position.x ** 2 + camera.position.z ** 2);
 const cameraHeight = camera.position.y;
 let time = 0;
 
+// ライトフラッシュの強度（波紋発生時に増加、毎フレーム減衰）
+let flashIntensity = 0;
+
 /** メインのアニメーションループ */
 function animate() {
   requestAnimationFrame(animate);
   time += 0.016;
 
-  // --- 雨粒の更新 ---
+  // --- 雨粒の更新（LineSegments: 始点・終点ペア） ---
   const count = params.rainCount;
   for (let i = 0; i < count; i++) {
-    const i3 = i * 3;
+    const i6 = i * 6;
+    const speed = params.rainSpeed * 0.05;
+    const windDrift = params.wind * 0.01;
 
-    rainPositions[i3 + 1] -= params.rainSpeed * 0.05;
-    rainPositions[i3] += params.wind * 0.01;
+    // 始点と終点の両方を更新
+    rainPositions[i6 + 1] -= speed;
+    rainPositions[i6 + 4] -= speed;
+    rainPositions[i6] += windDrift;
+    rainPositions[i6 + 3] += windDrift;
+
+    // ストリーク長を速度に応じて伸縮
+    const streakLength = 0.1 + params.rainSpeed * 0.15;
+    rainPositions[i6 + 4] = rainPositions[i6 + 1] - streakLength;
 
     // 着水判定: y < 0 でリセット
-    if (rainPositions[i3 + 1] < 0) {
+    if (rainPositions[i6 + 1] < 0) {
       // 30% の確率で波紋を発生させる
       if (Math.random() < 0.3) {
-        activateRipple(ripplePool, rainPositions[i3], rainPositions[i3 + 2]);
+        activateRipple(ripplePool, rainPositions[i6], rainPositions[i6 + 2]);
+        flashIntensity = 2;
       }
 
-      rainPositions[i3 + 1] = 20;
-      rainPositions[i3] = (Math.random() - 0.5) * 30;
-      rainPositions[i3 + 2] = (Math.random() - 0.5) * 30;
+      const newX = (Math.random() - 0.5) * 30;
+      const newZ = (Math.random() - 0.5) * 30;
+      rainPositions[i6] = newX;
+      rainPositions[i6 + 1] = 20;
+      rainPositions[i6 + 2] = newZ;
+      rainPositions[i6 + 3] = newX;
+      rainPositions[i6 + 4] = 20 - streakLength;
+      rainPositions[i6 + 5] = newZ;
     }
   }
 
-  const posAttr = rainPoints.geometry.getAttribute('position');
+  const posAttr = rainLines.geometry.getAttribute('position');
   posAttr.needsUpdate = true;
+
+  // --- フラッシュの減衰とライト更新 ---
+  flashIntensity *= 0.95;
+  pointLight.intensity = 1 + flashIntensity;
 
   // --- 波紋の更新 ---
   updateRipples(ripplePool, params);

--- a/public/rain/ripple.js
+++ b/public/rain/ripple.js
@@ -1,0 +1,101 @@
+// @ts-check
+import * as THREE from 'https://esm.sh/three@0.172.0';
+
+/**
+ * @typedef {{
+ *   mesh: THREE.Mesh,
+ *   active: boolean,
+ *   age: number,
+ *   maxAge: number,
+ *   x: number,
+ *   z: number,
+ *   maxRadius: number
+ * }} Ripple
+ */
+
+/**
+ * 波紋オブジェクトプールを作成する
+ * @param {THREE.Scene} scene - シーン
+ * @param {{ rippleCount: number, rippleColor: string }} params - パラメータ
+ * @returns {Ripple[]}
+ */
+export function createRipplePool(scene, params) {
+  /** @type {Ripple[]} */
+  const pool = [];
+  const geometry = new THREE.RingGeometry(0.1, 0.3, 32);
+
+  for (let i = 0; i < params.rippleCount; i++) {
+    const material = new THREE.MeshBasicMaterial({
+      color: params.rippleColor,
+      transparent: true,
+      opacity: 0.8,
+      side: THREE.DoubleSide,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.visible = false;
+    scene.add(mesh);
+
+    pool.push({
+      mesh,
+      active: false,
+      age: 0,
+      maxAge: 2,
+      x: 0,
+      z: 0,
+      maxRadius: 2,
+    });
+  }
+
+  return pool;
+}
+
+/**
+ * 指定座標で波紋を発生させる
+ * @param {Ripple[]} pool - 波紋プール
+ * @param {number} x - 着水 x 座標
+ * @param {number} z - 着水 z 座標
+ */
+export function activateRipple(pool, x, z) {
+  const ripple = pool.find((r) => !r.active);
+  if (!ripple) return;
+
+  ripple.mesh.position.set(x, 0.01, z);
+  ripple.mesh.scale.set(1, 1, 1);
+  const mat = /** @type {THREE.MeshBasicMaterial} */ (ripple.mesh.material);
+  mat.opacity = 0.8;
+  ripple.active = true;
+  ripple.age = 0;
+  ripple.maxAge = 2;
+  ripple.x = x;
+  ripple.z = z;
+  ripple.mesh.visible = true;
+}
+
+/**
+ * 波紋プールを更新する
+ * @param {Ripple[]} pool - 波紋プール
+ * @param {{ rippleSpeed: number }} params - パラメータ
+ */
+export function updateRipples(pool, params) {
+  for (const ripple of pool) {
+    if (!ripple.active) continue;
+
+    ripple.age += 0.016 * params.rippleSpeed;
+    const progress = ripple.age / ripple.maxAge;
+
+    // スケーリングでリングを拡大
+    const scale = progress * 5;
+    ripple.mesh.scale.set(scale, scale, 1);
+
+    // フェードアウト
+    const mat = /** @type {THREE.MeshBasicMaterial} */ (ripple.mesh.material);
+    mat.opacity = 0.8 * (1 - progress);
+
+    // 寿命が尽きたら非表示
+    if (ripple.age >= ripple.maxAge) {
+      ripple.active = false;
+      ripple.mesh.visible = false;
+    }
+  }
+}

--- a/public/rain/style.css
+++ b/public/rain/style.css
@@ -1,0 +1,142 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0a1e;
+  color: #c0c8e0;
+  font-family: system-ui, -apple-system, sans-serif;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #6080b0;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #90b0d0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#canvas-container {
+  width: 100%;
+  height: 100%;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* --- GUI ラッパー（デスクトップ） --- */
+
+#gui-wrapper {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#gui-toggle {
+  display: none;
+}
+
+#gui-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
+  pointer-events: none;
+}
+
+#gui-container > * {
+  pointer-events: auto;
+  width: 100%;
+}
+
+/* tileui テーマ調整（ダーク青紫系） */
+#gui-container {
+  --tileui-bg: rgba(10, 10, 30, 0.88);
+  --tileui-tile-bg: rgba(30, 30, 60, 0.6);
+  --tileui-tile-bg-hover: rgba(50, 50, 90, 0.8);
+  --tileui-border: rgba(96, 128, 176, 0.25);
+  --tileui-knob-track: rgba(96, 128, 176, 0.25);
+}
+
+#gui-container .tileui-panel {
+  justify-content: center;
+}
+
+/* --- モバイル: オーバーレイ + トグル --- */
+
+@media (max-width: 48rem) {
+  #gui-wrapper {
+    transition: transform 0.3s ease;
+  }
+
+  /* 閉じた状態: コンテナを画面外に押し下げ、トグルだけ見える */
+  #gui-wrapper.collapsed {
+    transform: translateY(calc(100% - 2.5rem));
+  }
+
+  #gui-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 2.5rem;
+    border: none;
+    background: rgba(10, 10, 30, 0.88);
+    color: #c0c8e0;
+    font-size: 0.75rem;
+    cursor: pointer;
+    border-radius: 0.5rem 0.5rem 0 0;
+    pointer-events: auto;
+    transition: background 0.2s;
+  }
+
+  #gui-toggle:hover {
+    background: rgba(30, 30, 60, 0.95);
+  }
+
+  /* アイコンの回転アニメーション */
+  #gui-toggle-icon {
+    display: inline-block;
+    transition: transform 0.3s ease;
+  }
+
+  #gui-wrapper.collapsed #gui-toggle-icon {
+    transform: rotate(180deg);
+  }
+
+  #gui-container {
+    --tileui-bg: rgba(10, 10, 30, 0.78);
+  }
+}

--- a/public/rain/style.css
+++ b/public/rain/style.css
@@ -88,6 +88,7 @@ canvas {
   --tileui-tile-bg-hover: rgba(50, 50, 90, 0.8);
   --tileui-border: rgba(96, 128, 176, 0.25);
   --tileui-knob-track: rgba(96, 128, 176, 0.25);
+  --tileui-text: #c0c8e0;
 }
 
 #gui-container .tileui-panel {

--- a/public/rain/water.js
+++ b/public/rain/water.js
@@ -4,7 +4,7 @@ import * as THREE from 'https://esm.sh/three@0.172.0';
 /**
  * 水面メッシュを作成してシーンに追加する
  * @param {THREE.Scene} scene - シーン
- * @returns {{ mesh: THREE.Mesh, geometry: THREE.PlaneGeometry }}
+ * @returns {{ mesh: THREE.Mesh, geometry: THREE.PlaneGeometry, pointLight: THREE.PointLight }}
  */
 export function createWater(scene) {
   const geometry = new THREE.PlaneGeometry(30, 30, 50, 50);
@@ -12,8 +12,8 @@ export function createWater(scene) {
     color: '#0a1628',
     transparent: true,
     opacity: 0.7,
-    roughness: 0.3,
-    metalness: 0.5,
+    roughness: 0.2,
+    metalness: 0.6,
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.rotation.x = -Math.PI / 2;
@@ -23,7 +23,12 @@ export function createWater(scene) {
   const ambientLight = new THREE.AmbientLight('#1a1a3e', 0.5);
   scene.add(ambientLight);
 
-  return { mesh, geometry };
+  // 水面を上から照らすポイントライト（ネオンカラー反射用）
+  const pointLight = new THREE.PointLight('#00ccff', 1, 30);
+  pointLight.position.set(0, 5, 0);
+  scene.add(pointLight);
+
+  return { mesh, geometry, pointLight };
 }
 
 /**

--- a/public/rain/water.js
+++ b/public/rain/water.js
@@ -1,0 +1,69 @@
+// @ts-check
+import * as THREE from 'https://esm.sh/three@0.172.0';
+
+/**
+ * 水面メッシュを作成してシーンに追加する
+ * @param {THREE.Scene} scene - シーン
+ * @returns {{ mesh: THREE.Mesh, geometry: THREE.PlaneGeometry }}
+ */
+export function createWater(scene) {
+  const geometry = new THREE.PlaneGeometry(30, 30, 50, 50);
+  const material = new THREE.MeshStandardMaterial({
+    color: '#0a1628',
+    transparent: true,
+    opacity: 0.7,
+    roughness: 0.3,
+    metalness: 0.5,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.rotation.x = -Math.PI / 2;
+  scene.add(mesh);
+
+  // 水面を照らす環境光
+  const ambientLight = new THREE.AmbientLight('#1a1a3e', 0.5);
+  scene.add(ambientLight);
+
+  return { mesh, geometry };
+}
+
+/**
+ * @typedef {import('./ripple.js').Ripple} Ripple
+ */
+
+/**
+ * 水面の頂点を sin 波で変位させる
+ * @param {THREE.PlaneGeometry} geometry - 水面のジオメトリ
+ * @param {number} time - 経過時間
+ * @param {Ripple[]} ripplePool - 波紋プール
+ * @param {{ waveHeight: number }} params - パラメータ
+ */
+export function updateWaterSurface(geometry, time, ripplePool, params) {
+  const posAttr = geometry.getAttribute('position');
+  const count = posAttr.count;
+
+  for (let i = 0; i < count; i++) {
+    const x = posAttr.getX(i);
+    const z = posAttr.getZ(i);
+
+    // 基本の sin 波
+    let y =
+      Math.sin(x * 0.5 + time) * Math.cos(z * 0.5 + time) * params.waveHeight;
+
+    // アクティブな波紋の影響を加算
+    for (const ripple of ripplePool) {
+      if (!ripple.active) continue;
+      const dx = x - ripple.x;
+      const dz = z - ripple.z;
+      const dist = Math.sqrt(dx * dx + dz * dz);
+      const progress = ripple.age / ripple.maxAge;
+      const rippleRadius = ripple.maxRadius * progress;
+      const influence = Math.max(0, 1 - dist / (rippleRadius + 0.1));
+      y += Math.sin(dist * 4 - time * 3) * influence * params.waveHeight * 0.5;
+    }
+
+    posAttr.setY(i, y);
+  }
+
+  posAttr.needsUpdate = true;
+  geometry.computeVertexNormals();
+}


### PR DESCRIPTION
## 概要
- Three.js を使った雨夜のネオン ジェネレーティブアートページを追加

## 変更内容
- `public/rain/` に Three.js ベースの雨粒パーティクルシーンを新規作成
- 水面と波紋エフェクトの実装
- ライティングとビジュアル表現の強化
- TileUI で全パラメータを GUI 制御可能に
- モバイル対応（GUI トグル）
- トップページにナビゲーションリンク追加

## テスト計画
- [ ] デスクトップで雨のアニメーションが表示されること
- [ ] TileUI GUI でパラメータを操作できること
- [ ] モバイルでトグルが動作すること
- [ ] トップページから /rain/ へのリンクが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)