### PR TITLE
feat: Fractal Tree ページを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 | `/wave-interference/` | Wave Interference（複数波源が重なる同心円波の干渉パターン） |
 | `/penrose-tiling/` | Penrose Tiling（黄金比で分割されるペンローズタイル） |
 | `/voronoi-mosaic/` | Voronoi Mosaic（ランダム点群から生成するボロノイ分割モザイク） |
+| `/fractal-tree/` | Fractal Tree（再帰的に枝分かれするフラクタルの木） |
 
 ## トップページ仕様
 

--- a/public/fractal-tree/index.html
+++ b/public/fractal-tree/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Fractal Tree | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/fractal-tree/main.js
+++ b/public/fractal-tree/main.js
@@ -1,0 +1,197 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  depth: 10, // 再帰深さ
+  branches: 2, // 分岐数（2〜4）
+  angle: 24, // 分岐角（度）
+  angleJitter: 6, // 分岐角のばらつき
+  lengthRatio: 0.72, // 子枝の長さ比
+  initialLength: 160, // 根の枝の長さ
+  thickness: 8, // 根の太さ
+  thickDecay: 0.7, // 太さ減衰
+  hueStart: 30, // 幹の色相
+  hueEnd: 120, // 葉の色相
+  sway: 0.35, // 風による揺れ強度
+  swaySpeed: 0.6, // 揺れの速さ
+  leafBloom: 0.6, // 葉の粒の強さ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 乱数（シード固定で構造を安定させる） ---
+
+let seed = 1;
+function setSeed(n) {
+  seed = n >>> 0 || 1;
+}
+function rand01() {
+  // xorshift32
+  seed ^= seed << 13;
+  seed ^= seed >>> 17;
+  seed ^= seed << 5;
+  return ((seed >>> 0) % 100000) / 100000;
+}
+
+let treeSeed = Math.floor(Math.random() * 1e9);
+
+// --- 描画 ---
+
+let time = 0;
+
+/**
+ * 1 本の枝を描く（再帰）
+ * @param {number} x
+ * @param {number} y
+ * @param {number} angle
+ * @param {number} length
+ * @param {number} depthLeft
+ * @param {number} thickness
+ */
+function drawBranch(x, y, angle, length, depthLeft, thickness) {
+  if (depthLeft <= 0 || length < 0.6) return;
+  const swayAmp = params.sway * (1 - depthLeft / params.depth) * 0.35;
+  const swayDelta =
+    Math.sin(time * params.swaySpeed + depthLeft * 0.7) * swayAmp;
+  const a = angle + swayDelta;
+  const nx = x + Math.cos(a) * length;
+  const ny = y + Math.sin(a) * length;
+
+  const t = 1 - depthLeft / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.strokeStyle = `hsla(${hue}, 75%, ${35 + t * 30}%, 0.95)`;
+  ctx.lineWidth = Math.max(0.0625, thickness);
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(nx, ny);
+  ctx.stroke();
+
+  if (depthLeft === 1 && params.leafBloom > 0) {
+    ctx.fillStyle = `hsla(${hue}, 80%, 65%, ${params.leafBloom})`;
+    ctx.beginPath();
+    ctx.arc(nx, ny, thickness * 1.2 + 1.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const branches = Math.max(2, Math.min(4, Math.round(params.branches)));
+  const spread = (params.angle * Math.PI) / 180;
+  for (let i = 0; i < branches; i++) {
+    const fraction = branches === 1 ? 0 : i / (branches - 1) - 0.5;
+    const jitter = ((rand01() - 0.5) * params.angleJitter * Math.PI) / 180;
+    const childAngle = a + fraction * spread * 2 + jitter;
+    const lenFactor = params.lengthRatio * (0.85 + rand01() * 0.3);
+    drawBranch(
+      nx,
+      ny,
+      childAngle,
+      length * lenFactor,
+      depthLeft - 1,
+      thickness * params.thickDecay,
+    );
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.25)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  setSeed(treeSeed);
+  const rootX = canvas.width / 2;
+  const rootY = canvas.height * 0.95;
+  ctx.lineCap = 'round';
+  drawBranch(
+    rootX,
+    rootY,
+    -Math.PI / 2,
+    params.initialLength,
+    Math.round(params.depth),
+    params.thickness,
+  );
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Fractal Tree',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 3, 13, 1);
+gui.add(params, 'branches', 2, 4, 1);
+gui.add(params, 'angle', 5, 80, 1);
+gui.add(params, 'angleJitter', 0, 40, 0.5);
+gui.add(params, 'lengthRatio', 0.4, 0.92, 0.01);
+gui.add(params, 'initialLength', 40, 320, 1);
+gui.add(params, 'thickness', 1, 30, 0.5);
+gui.add(params, 'thickDecay', 0.4, 0.95, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'sway', 0, 1.5, 0.01);
+gui.add(params, 'swaySpeed', 0, 3, 0.01);
+gui.add(params, 'leafBloom', 0, 1, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(7, 12, 1);
+  params.branches = rand(2, 4, 1);
+  params.angle = rand(12, 55, 1);
+  params.angleJitter = rand(0, 20, 0.5);
+  params.lengthRatio = rand(0.6, 0.85, 0.01);
+  params.thickness = rand(4, 14, 0.5);
+  params.thickDecay = rand(0.6, 0.85, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.sway = rand(0.1, 0.7, 0.01);
+  params.leafBloom = rand(0.2, 0.9, 0.01);
+  treeSeed = Math.floor(Math.random() * 1e9);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reseed', () => {
+  treeSeed = Math.floor(Math.random() * 1e9);
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/fractal-tree/style.css
+++ b/public/fractal-tree/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -247,6 +247,12 @@
               <span class="nav-description">ランダム点群から生成するボロノイ分割モザイク</span>
             </a>
           </li>
+          <li>
+            <a href="/fractal-tree/">
+              Fractal Tree
+              <span class="nav-description">再帰的に枝分かれするフラクタルの木</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>


### PR DESCRIPTION
## Summary

- 再帰的に枝分かれするフラクタル木を描画する新規ページ `public/fractal-tree/` を追加
- TileUI で深さ・分岐数・角度・ジッター・長さ比・太さ減衰・色相（根→葉）・風の揺れ・葉の光などを制御（13 コントロール）
- `Random` / `Reseed` / `Reset` ボタン搭載
- トップページのナビ・`docs/README.md` のページ一覧を更新

Closes #61

## Test plan

- [ ] `npm run check` が通る
- [ ] `/fractal-tree/` で木が描画され、風で揺れる
- [ ] depth / angle / 色相等の GUI が反映される