### PR TITLE
feat: Spirograph Engine ページを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 | `/penrose-tiling/` | Penrose Tiling（黄金比で分割されるペンローズタイル） |
 | `/voronoi-mosaic/` | Voronoi Mosaic（ランダム点群から生成するボロノイ分割モザイク） |
 | `/fractal-tree/` | Fractal Tree（再帰的に枝分かれするフラクタルの木） |
+| `/spirograph-engine/` | Spirograph Engine（ハイポ/エピサイクロイドで描くスピログラフ） |
 
 ## トップページ仕様
 

--- a/public/index.html
+++ b/public/index.html
@@ -253,6 +253,12 @@
               <span class="nav-description">再帰的に枝分かれするフラクタルの木</span>
             </a>
           </li>
+          <li>
+            <a href="/spirograph-engine/">
+              Spirograph Engine
+              <span class="nav-description">ハイポ/エピサイクロイドで描くスピログラフ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/spirograph-engine/index.html
+++ b/public/spirograph-engine/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Spirograph Engine | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/spirograph-engine/main.js
+++ b/public/spirograph-engine/main.js
@@ -1,0 +1,181 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  type: 1, // 1: Hypocycloid（内サイクロイド）, 2: Epicycloid（外サイクロイド）
+  R: 180, // 固定円の半径
+  r: 57, // 動円の半径
+  d: 90, // ペン位置（動円中心からの距離）
+  scale: 1.2, // 全体スケール
+  speed: 2, // 回転速度（ラジアン/秒）
+  trailFade: 0.04, // 残像のフェード（小さいほど長い尾）
+  hue: 180, // 色相
+  hueShift: 0.3, // 時間で色相シフト
+  lineWidth: 1.5, // 線の太さ
+  glow: 8, // グローの強さ
+  points: 400, // 1 フレームでの補間点数
+  clearOnChange: true, // パラメータ変更時にクリア
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  clearCanvas();
+}
+
+function clearCanvas() {
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- ペン位置計算 ---
+
+/**
+ * スピログラフの座標を返す
+ * @param {number} t 角度
+ * @returns {[number, number]}
+ */
+function penPosition(t) {
+  const R = params.R;
+  const r = Math.max(1, params.r);
+  const d = params.d;
+  if (params.type === 2) {
+    // Epicycloid
+    const x = (R + r) * Math.cos(t) - d * Math.cos(((R + r) / r) * t);
+    const y = (R + r) * Math.sin(t) - d * Math.sin(((R + r) / r) * t);
+    return [x * params.scale, y * params.scale];
+  }
+  // Hypocycloid
+  const x = (R - r) * Math.cos(t) + d * Math.cos(((R - r) / r) * t);
+  const y = (R - r) * Math.sin(t) - d * Math.sin(((R - r) / r) * t);
+  return [x * params.scale, y * params.scale];
+}
+
+// --- ループ ---
+
+let theta = 0;
+let time = 0;
+
+function step() {
+  time += 1 / 60;
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  // フェード
+  ctx.fillStyle = `rgba(8, 8, 12, ${Math.max(0, Math.min(1, params.trailFade))})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const steps = Math.max(1, Math.round(params.points));
+  const delta = params.speed / 60 / steps;
+  ctx.lineWidth = Math.max(0.0625, params.lineWidth);
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+
+  let [px, py] = penPosition(theta);
+  for (let i = 0; i < steps; i++) {
+    theta += delta;
+    const [nx, ny] = penPosition(theta);
+    const hue = (params.hue + time * params.hueShift * 60) % 360;
+    const stroke = `hsl(${hue}, 85%, 65%)`;
+    ctx.strokeStyle = stroke;
+    ctx.shadowColor = stroke;
+    ctx.beginPath();
+    ctx.moveTo(cx + px, cy + py);
+    ctx.lineTo(cx + nx, cy + ny);
+    ctx.stroke();
+    px = nx;
+    py = ny;
+  }
+  ctx.shadowBlur = 0;
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Spirograph Engine',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+/**
+ * パラメータ変更時のフック
+ */
+function onParamChange() {
+  if (params.clearOnChange) clearCanvas();
+}
+
+gui.add(params, 'type', 1, 2, 1).onChange(onParamChange);
+gui.add(params, 'R', 40, 400, 1).onChange(onParamChange);
+gui.add(params, 'r', 1, 300, 1).onChange(onParamChange);
+gui.add(params, 'd', 0, 300, 1).onChange(onParamChange);
+gui.add(params, 'scale', 0.3, 3, 0.01).onChange(onParamChange);
+gui.add(params, 'speed', 0.1, 10, 0.05);
+gui.add(params, 'trailFade', 0, 0.4, 0.005);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueShift', 0, 2, 0.01);
+gui.add(params, 'lineWidth', 0.25, 6, 0.05);
+gui.add(params, 'glow', 0, 30, 0.5);
+gui.add(params, 'points', 50, 2000, 10);
+gui.add(params, 'clearOnChange');
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.type = rand(1, 2, 1);
+  params.R = rand(120, 260, 1);
+  params.r = rand(20, 150, 1);
+  params.d = rand(30, 180, 1);
+  params.scale = rand(0.8, 1.8, 0.01);
+  params.speed = rand(0.8, 5, 0.05);
+  params.trailFade = rand(0.01, 0.12, 0.005);
+  params.hue = rand(0, 360, 1);
+  params.hueShift = rand(0, 1, 0.01);
+  params.lineWidth = rand(0.6, 2.4, 0.05);
+  params.glow = rand(0, 15, 0.5);
+  clearCanvas();
+  gui.updateDisplay();
+});
+
+gui.addButton('Clear', () => {
+  clearCanvas();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  clearCanvas();
+  gui.updateDisplay();
+});

--- a/public/spirograph-engine/style.css
+++ b/public/spirograph-engine/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

- ハイポサイクロイド / エピサイクロイドで描くスピログラフの新規ページ `public/spirograph-engine/` を追加
- TileUI で曲線種別・R/r/d・スケール・回転速度・残像フェード・色相/色相シフト・線幅・グロー・補間点数などを制御（13 コントロール）
- `Random` / `Clear` / `Reset` ボタン搭載
- トップページのナビ・`docs/README.md` のページ一覧を更新

Closes #49

## Test plan

- [ ] `npm run check` が通る
- [ ] `/spirograph-engine/` で曲線が連続描画される
- [ ] type / R / r / d の変更で曲線の形が変わる