### PR TITLE
feat: Erosion Landscape ページを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 | `/voronoi-mosaic/` | Voronoi Mosaic（ランダム点群から生成するボロノイ分割モザイク） |
 | `/fractal-tree/` | Fractal Tree（再帰的に枝分かれするフラクタルの木） |
 | `/spirograph-engine/` | Spirograph Engine（ハイポ/エピサイクロイドで描くスピログラフ） |
+| `/erosion-landscape/` | Erosion Landscape（雨粒の侵食で変化する地形シミュレーション） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 | `/fractal-tree/` | Fractal Tree（再帰的に枝分かれするフラクタルの木） |
 | `/spirograph-engine/` | Spirograph Engine（ハイポ/エピサイクロイドで描くスピログラフ） |
 | `/erosion-landscape/` | Erosion Landscape（雨粒の侵食で変化する地形シミュレーション） |
+| `/magnetic-field-lines/` | Magnetic Field Lines（N/S 極の配置から描く磁力線ビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 | `/erosion-landscape/` | Erosion Landscape（雨粒の侵食で変化する地形シミュレーション） |
 | `/magnetic-field-lines/` | Magnetic Field Lines（N/S 極の配置から描く磁力線ビジュアル） |
 | `/crystal-growth/` | Crystal Growth（DLA 風に結晶が枝分かれしながら成長する） |
+| `/smoke-plume/` | Smoke Plume（ゆらぎながら立ち昇る煙の流体風シミュレーション） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 | `/spirograph-engine/` | Spirograph Engine（ハイポ/エピサイクロイドで描くスピログラフ） |
 | `/erosion-landscape/` | Erosion Landscape（雨粒の侵食で変化する地形シミュレーション） |
 | `/magnetic-field-lines/` | Magnetic Field Lines（N/S 極の配置から描く磁力線ビジュアル） |
+| `/crystal-growth/` | Crystal Growth（DLA 風に結晶が枝分かれしながら成長する） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 | `/magnetic-field-lines/` | Magnetic Field Lines（N/S 極の配置から描く磁力線ビジュアル） |
 | `/crystal-growth/` | Crystal Growth（DLA 風に結晶が枝分かれしながら成長する） |
 | `/smoke-plume/` | Smoke Plume（ゆらぎながら立ち昇る煙の流体風シミュレーション） |
+| `/tessellation-lab/` | Tessellation Lab（正多角形タイルの敷き詰めパターン生成・変形） |
 
 ## トップページ仕様
 

--- a/public/crystal-growth/index.html
+++ b/public/crystal-growth/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Crystal Growth | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/crystal-growth/main.js
+++ b/public/crystal-growth/main.js
@@ -1,0 +1,210 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  cellSize: 3, // 1 セルの描画サイズ（px）
+  walkersPerFrame: 400, // フレームあたりの拡散粒子数
+  stickiness: 1, // 結晶に付着する確率（0-1）
+  symmetry: 1, // 対称数（1 で対称なし）
+  seedCount: 1, // 初期シード数
+  hueBase: 200, // 基本色相
+  hueShift: 0.6, // 成長に応じた色相変化
+  glow: 8, // グロー強度
+  lineBlend: 0.7, // 近接付着時のブレンド強度
+  stepBias: 0, // 中心への引力 (0-1)
+  showSeeds: true, // シードハイライト
+  animate: true, // 自動成長
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+let gridW = 0;
+let gridH = 0;
+/** @type {Uint16Array} */
+let grid = new Uint16Array(0); // 0: 空, >0: 成長時刻+1
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  reset();
+}
+
+function reset() {
+  const cs = Math.max(1, params.cellSize);
+  gridW = Math.floor(canvas.width / cs);
+  gridH = Math.floor(canvas.height / cs);
+  grid = new Uint16Array(gridW * gridH);
+  const seeds = Math.max(1, Math.round(params.seedCount));
+  for (let i = 0; i < seeds; i++) {
+    const sx = Math.floor(gridW / 2 + (Math.random() - 0.5) * gridW * 0.2);
+    const sy = Math.floor(gridH / 2 + (Math.random() - 0.5) * gridH * 0.2);
+    placeStick(sx, sy, 1);
+  }
+  ctx.fillStyle = '#05070a';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  drawAll();
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- DLA ロジック ---
+
+let tick = 1;
+
+/**
+ * 対称位置にセルを結晶化
+ * @param {number} x
+ * @param {number} y
+ * @param {number} age
+ */
+function placeStick(x, y, age) {
+  const sym = Math.max(1, Math.round(params.symmetry));
+  const cx = gridW / 2;
+  const cy = gridH / 2;
+  const dx = x - cx;
+  const dy = y - cy;
+  const r = Math.hypot(dx, dy);
+  const baseAngle = Math.atan2(dy, dx);
+  for (let s = 0; s < sym; s++) {
+    const a = baseAngle + (Math.PI * 2 * s) / sym;
+    const sx = Math.round(cx + Math.cos(a) * r);
+    const sy = Math.round(cy + Math.sin(a) * r);
+    if (sx < 0 || sx >= gridW || sy < 0 || sy >= gridH) continue;
+    if (grid[sy * gridW + sx] !== 0) continue;
+    grid[sy * gridW + sx] = age;
+    drawCell(sx, sy, age);
+  }
+}
+
+function hasNeighbor(x, y) {
+  if (x > 0 && grid[y * gridW + x - 1]) return true;
+  if (x < gridW - 1 && grid[y * gridW + x + 1]) return true;
+  if (y > 0 && grid[(y - 1) * gridW + x]) return true;
+  if (y < gridH - 1 && grid[(y + 1) * gridW + x]) return true;
+  return false;
+}
+
+function walk() {
+  let x = Math.floor(Math.random() * gridW);
+  let y = Math.floor(Math.random() * gridH);
+  if (grid[y * gridW + x] !== 0) return;
+  for (let i = 0; i < 500; i++) {
+    if (hasNeighbor(x, y)) {
+      if (Math.random() < params.stickiness) {
+        placeStick(x, y, tick++);
+      }
+      return;
+    }
+    const cx = gridW / 2;
+    const cy = gridH / 2;
+    const bx = Math.sign(cx - x) * params.stepBias;
+    const by = Math.sign(cy - y) * params.stepBias;
+    const r = Math.random();
+    if (r < 0.25 + bx * 0.25) x++;
+    else if (r < 0.5) x--;
+    else if (r < 0.75 + by * 0.25) y++;
+    else y--;
+    if (x < 0) x = gridW - 1;
+    if (x >= gridW) x = 0;
+    if (y < 0) y = gridH - 1;
+    if (y >= gridH) y = 0;
+  }
+}
+
+// --- 描画 ---
+
+function drawCell(x, y, age) {
+  const cs = Math.max(1, params.cellSize);
+  const hue = (params.hueBase + age * params.hueShift) % 360;
+  ctx.fillStyle = `hsl(${hue}, 80%, 60%)`;
+  ctx.shadowBlur = params.glow;
+  ctx.shadowColor = ctx.fillStyle;
+  ctx.fillRect(x * cs, y * cs, cs, cs);
+  ctx.shadowBlur = 0;
+}
+
+function drawAll() {
+  for (let y = 0; y < gridH; y++) {
+    for (let x = 0; x < gridW; x++) {
+      const v = grid[y * gridW + x];
+      if (v !== 0) drawCell(x, y, v);
+    }
+  }
+}
+
+function loop() {
+  if (params.animate) {
+    const n = Math.max(0, Math.round(params.walkersPerFrame));
+    for (let i = 0; i < n; i++) walk();
+  }
+  requestAnimationFrame(loop);
+}
+
+loop();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Crystal Growth',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'cellSize', 1, 8, 1).onChange(reset);
+gui.add(params, 'walkersPerFrame', 0, 2000, 50);
+gui.add(params, 'stickiness', 0.05, 1, 0.01);
+gui.add(params, 'symmetry', 1, 12, 1).onChange(reset);
+gui.add(params, 'seedCount', 1, 12, 1).onChange(reset);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueShift', 0, 2, 0.01);
+gui.add(params, 'glow', 0, 20, 0.5);
+gui.add(params, 'lineBlend', 0, 1, 0.01);
+gui.add(params, 'stepBias', 0, 1, 0.01);
+gui.add(params, 'showSeeds');
+gui.add(params, 'animate');
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.symmetry = rand(1, 10, 1);
+  params.seedCount = rand(1, 6, 1);
+  params.stickiness = rand(0.2, 1, 0.05);
+  params.walkersPerFrame = rand(200, 1000, 50);
+  params.hueBase = rand(0, 360, 1);
+  params.hueShift = rand(0, 1.5, 0.05);
+  params.glow = rand(0, 14, 0.5);
+  params.stepBias = rand(0, 0.4, 0.01);
+  reset();
+  gui.updateDisplay();
+});
+
+gui.addButton('Clear', () => reset());
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/crystal-growth/style.css
+++ b/public/crystal-growth/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #05070a;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/erosion-landscape/index.html
+++ b/public/erosion-landscape/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Erosion Landscape | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/erosion-landscape/main.js
+++ b/public/erosion-landscape/main.js
@@ -1,0 +1,319 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  gridSize: 180, // 高さマップの解像度
+  dropsPerFrame: 600, // 1 フレームあたりの雨粒数
+  iterations: 30, // 雨粒 1 つの移動ステップ数
+  inertia: 0.05, // 方向の慣性（0-1）
+  sedimentCapacity: 4, // 堆積容量係数
+  erodeRate: 0.3, // 侵食率
+  depositRate: 0.3, // 堆積率
+  evaporateRate: 0.02, // 蒸発率
+  gravity: 4, // 重力
+  hueLow: 30, // 低地の色相
+  hueHigh: 200, // 高地の色相
+  relief: 1.5, // シェーディング強度
+  waterTint: 0.2, // 水の青み
+  autoRain: true, // 自動で雨を降らせる
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** @type {Float32Array} */
+let heightMap = new Float32Array(0);
+/** @type {Float32Array} */
+let waterMap = new Float32Array(0);
+let gridW = 0;
+let gridH = 0;
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 地形生成 ---
+
+/**
+ * 疑似ランダム値 (シードなし)
+ * @param {number} x
+ * @param {number} y
+ */
+function noise2(x, y) {
+  const s = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+/**
+ * @param {number} x
+ * @param {number} y
+ */
+function fbm(x, y) {
+  let v = 0;
+  let amp = 0.5;
+  let freq = 1;
+  for (let i = 0; i < 5; i++) {
+    const xi = Math.floor(x * freq);
+    const yi = Math.floor(y * freq);
+    const xf = x * freq - xi;
+    const yf = y * freq - yi;
+    const u = xf * xf * (3 - 2 * xf);
+    const w = yf * yf * (3 - 2 * yf);
+    const a = noise2(xi, yi);
+    const b = noise2(xi + 1, yi);
+    const c = noise2(xi, yi + 1);
+    const d = noise2(xi + 1, yi + 1);
+    const mix = a + (b - a) * u + (c - a) * w + (a - b - c + d) * u * w;
+    v += mix * amp;
+    amp *= 0.5;
+    freq *= 2;
+  }
+  return v;
+}
+
+function initTerrain() {
+  gridW = Math.max(32, Math.round(params.gridSize));
+  gridH = Math.max(32, Math.round((gridW * canvas.height) / canvas.width));
+  heightMap = new Float32Array(gridW * gridH);
+  waterMap = new Float32Array(gridW * gridH);
+  const seedX = Math.random() * 1000;
+  const seedY = Math.random() * 1000;
+  for (let y = 0; y < gridH; y++) {
+    for (let x = 0; x < gridW; x++) {
+      const nx = x / gridW;
+      const ny = y / gridH;
+      heightMap[y * gridW + x] = fbm(nx * 4 + seedX, ny * 4 + seedY);
+    }
+  }
+}
+
+initTerrain();
+
+// --- 侵食シミュレーション ---
+
+/**
+ * 地形の高さと勾配をバイリニア補間で取得
+ * @param {number} x
+ * @param {number} y
+ */
+function sampleHeight(x, y) {
+  const xi = Math.floor(x);
+  const yi = Math.floor(y);
+  const xf = x - xi;
+  const yf = y - yi;
+  const i00 = yi * gridW + xi;
+  const i10 = i00 + 1;
+  const i01 = i00 + gridW;
+  const i11 = i01 + 1;
+  const h00 = heightMap[i00];
+  const h10 = heightMap[i10];
+  const h01 = heightMap[i01];
+  const h11 = heightMap[i11];
+  const h =
+    h00 * (1 - xf) * (1 - yf) +
+    h10 * xf * (1 - yf) +
+    h01 * (1 - xf) * yf +
+    h11 * xf * yf;
+  const gx = (h10 - h00) * (1 - yf) + (h11 - h01) * yf;
+  const gy = (h01 - h00) * (1 - xf) + (h11 - h10) * xf;
+  return { h, gx, gy };
+}
+
+function simulateDroplet() {
+  let x = Math.random() * (gridW - 2);
+  let y = Math.random() * (gridH - 2);
+  let dx = 0;
+  let dy = 0;
+  let speed = 1;
+  let water = 1;
+  let sediment = 0;
+  for (let i = 0; i < params.iterations; i++) {
+    const xi = Math.floor(x);
+    const yi = Math.floor(y);
+    if (xi < 0 || xi >= gridW - 1 || yi < 0 || yi >= gridH - 1) break;
+    const { h, gx, gy } = sampleHeight(x, y);
+    dx = dx * params.inertia - gx * (1 - params.inertia);
+    dy = dy * params.inertia - gy * (1 - params.inertia);
+    const len = Math.hypot(dx, dy) || 1;
+    dx /= len;
+    dy /= len;
+    const nx = x + dx;
+    const ny = y + dy;
+    if (nx < 0 || nx >= gridW - 1 || ny < 0 || ny >= gridH - 1) break;
+    const newH = sampleHeight(nx, ny).h;
+    const dh = newH - h;
+    const cap = Math.max(-dh, 0.01) * speed * water * params.sedimentCapacity;
+    if (sediment > cap || dh > 0) {
+      const drop =
+        dh > 0 ? Math.min(dh, sediment) : (sediment - cap) * params.depositRate;
+      sediment -= drop;
+      const offX = x - xi;
+      const offY = y - yi;
+      heightMap[yi * gridW + xi] += drop * (1 - offX) * (1 - offY);
+      heightMap[yi * gridW + xi + 1] += drop * offX * (1 - offY);
+      heightMap[(yi + 1) * gridW + xi] += drop * (1 - offX) * offY;
+      heightMap[(yi + 1) * gridW + xi + 1] += drop * offX * offY;
+    } else {
+      const erode = Math.min((cap - sediment) * params.erodeRate, -dh);
+      heightMap[yi * gridW + xi] -= erode * 0.25;
+      heightMap[yi * gridW + xi + 1] -= erode * 0.25;
+      heightMap[(yi + 1) * gridW + xi] -= erode * 0.25;
+      heightMap[(yi + 1) * gridW + xi + 1] -= erode * 0.25;
+      sediment += erode;
+    }
+    speed = Math.sqrt(Math.max(0, speed * speed + -dh * params.gravity));
+    water *= 1 - params.evaporateRate;
+    waterMap[yi * gridW + xi] = Math.min(1, waterMap[yi * gridW + xi] + 0.05);
+    x = nx;
+    y = ny;
+  }
+}
+
+// --- 描画 ---
+
+function render() {
+  const imgData = ctx.createImageData(canvas.width, canvas.height);
+  const data = imgData.data;
+  const cw = canvas.width;
+  const ch = canvas.height;
+  for (let py = 0; py < ch; py++) {
+    const gy = (py / ch) * (gridH - 1);
+    for (let px = 0; px < cw; px++) {
+      const gx = (px / cw) * (gridW - 1);
+      const { h, gx: sx, gy: sy } = sampleHeight(gx, gy);
+      const wi =
+        Math.min(gridH - 1, Math.floor(gy)) * gridW +
+        Math.min(gridW - 1, Math.floor(gx));
+      const water = waterMap[wi];
+      const light = Math.max(0, 1 - (sx + sy) * params.relief);
+      const hue = params.hueLow + (params.hueHigh - params.hueLow) * h;
+      const sat = 55 + water * 20;
+      const lum = 30 + h * 55 * light;
+      const [r, g, b] = hslToRgb(hue, sat, lum);
+      const tint = params.waterTint * water;
+      const idx = (py * cw + px) * 4;
+      data[idx] = r * (1 - tint) + 40 * tint;
+      data[idx + 1] = g * (1 - tint) + 90 * tint;
+      data[idx + 2] = b * (1 - tint) + 180 * tint;
+      data[idx + 3] = 255;
+    }
+  }
+  ctx.putImageData(imgData, 0, 0);
+}
+
+/**
+ * HSL → RGB (0-255)
+ * @param {number} h
+ * @param {number} s
+ * @param {number} l
+ * @returns {[number, number, number]}
+ */
+function hslToRgb(h, s, l) {
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = ln - c / 2;
+  return [(r + m) * 255, (g + m) * 255, (b + m) * 255];
+}
+
+// --- ループ ---
+
+function step() {
+  if (params.autoRain) {
+    for (let i = 0; i < params.dropsPerFrame; i++) simulateDroplet();
+  }
+  for (let i = 0; i < waterMap.length; i++) waterMap[i] *= 0.95;
+  render();
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Erosion Landscape',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'gridSize', 60, 280, 10).onChange(initTerrain);
+gui.add(params, 'dropsPerFrame', 0, 2000, 50);
+gui.add(params, 'iterations', 5, 80, 1);
+gui.add(params, 'inertia', 0, 0.5, 0.01);
+gui.add(params, 'sedimentCapacity', 1, 10, 0.1);
+gui.add(params, 'erodeRate', 0, 1, 0.01);
+gui.add(params, 'depositRate', 0, 1, 0.01);
+gui.add(params, 'evaporateRate', 0, 0.2, 0.001);
+gui.add(params, 'gravity', 1, 10, 0.1);
+gui.add(params, 'hueLow', 0, 360, 1);
+gui.add(params, 'hueHigh', 0, 360, 1);
+gui.add(params, 'relief', 0, 5, 0.1);
+gui.add(params, 'waterTint', 0, 1, 0.01);
+gui.add(params, 'autoRain');
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.dropsPerFrame = rand(200, 1200, 50);
+  params.iterations = rand(20, 60, 1);
+  params.inertia = rand(0, 0.3, 0.01);
+  params.sedimentCapacity = rand(2, 8, 0.1);
+  params.erodeRate = rand(0.1, 0.6, 0.01);
+  params.depositRate = rand(0.1, 0.6, 0.01);
+  params.hueLow = rand(0, 360, 1);
+  params.hueHigh = rand(0, 360, 1);
+  params.relief = rand(0.5, 3, 0.1);
+  params.waterTint = rand(0, 0.5, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reseed', () => {
+  initTerrain();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initTerrain();
+  gui.updateDisplay();
+});

--- a/public/erosion-landscape/style.css
+++ b/public/erosion-landscape/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -283,6 +283,12 @@
               <span class="nav-description">ゆらぎながら立ち昇る煙の流体風シミュレーション</span>
             </a>
           </li>
+          <li>
+            <a href="/tessellation-lab/">
+              Tessellation Lab
+              <span class="nav-description">正多角形タイルの敷き詰めパターン生成・変形</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -259,6 +259,12 @@
               <span class="nav-description">ハイポ/エピサイクロイドで描くスピログラフ</span>
             </a>
           </li>
+          <li>
+            <a href="/erosion-landscape/">
+              Erosion Landscape
+              <span class="nav-description">雨粒の侵食で変化する地形シミュレーション</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -265,6 +265,12 @@
               <span class="nav-description">雨粒の侵食で変化する地形シミュレーション</span>
             </a>
           </li>
+          <li>
+            <a href="/magnetic-field-lines/">
+              Magnetic Field Lines
+              <span class="nav-description">N/S 極の配置から描く磁力線ビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -277,6 +277,12 @@
               <span class="nav-description">DLA 風に結晶が枝分かれしながら成長する</span>
             </a>
           </li>
+          <li>
+            <a href="/smoke-plume/">
+              Smoke Plume
+              <span class="nav-description">ゆらぎながら立ち昇る煙の流体風シミュレーション</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -271,6 +271,12 @@
               <span class="nav-description">N/S 極の配置から描く磁力線ビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/crystal-growth/">
+              Crystal Growth
+              <span class="nav-description">DLA 風に結晶が枝分かれしながら成長する</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/magnetic-field-lines/index.html
+++ b/public/magnetic-field-lines/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Magnetic Field Lines | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/magnetic-field-lines/main.js
+++ b/public/magnetic-field-lines/main.js
@@ -1,0 +1,239 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  poleCount: 4, // 磁極の総数
+  lineDensity: 40, // 各磁極から出る磁力線の本数
+  stepSize: 4, // 積分ステップ長
+  maxSteps: 500, // 磁力線の最大ステップ数
+  fieldStrength: 1, // 磁場の強さ
+  lineWidth: 1.2, // 線の太さ
+  hueNorth: 0, // N 極側の色相
+  hueSouth: 220, // S 極側の色相
+  glow: 10, // グロー強度
+  trailFade: 0.08, // 残像フェード（0 で軌跡残し）
+  showPoles: true, // 磁極マーカー表示
+  animate: true, // 磁極ゆらぎ
+  driftSpeed: 0.2, // ゆらぎ速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** @type {{x: number, y: number, charge: number, baseX: number, baseY: number, phase: number}[]} */
+let poles = [];
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  clearCanvas();
+}
+
+function clearCanvas() {
+  ctx.fillStyle = '#06060a';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+function initPoles() {
+  const n = Math.max(2, Math.round(params.poleCount));
+  poles = [];
+  for (let i = 0; i < n; i++) {
+    const bx = canvas.width * (0.2 + Math.random() * 0.6);
+    const by = canvas.height * (0.2 + Math.random() * 0.6);
+    poles.push({
+      x: bx,
+      y: by,
+      baseX: bx,
+      baseY: by,
+      charge: i % 2 === 0 ? 1 : -1,
+      phase: Math.random() * Math.PI * 2,
+    });
+  }
+}
+
+initPoles();
+
+// --- 磁場ベクトル ---
+
+/**
+ * 磁場ベクトルを計算
+ * @param {number} x
+ * @param {number} y
+ */
+function field(x, y) {
+  let fx = 0;
+  let fy = 0;
+  for (const p of poles) {
+    const dx = x - p.x;
+    const dy = y - p.y;
+    const r2 = dx * dx + dy * dy + 1;
+    const r = Math.sqrt(r2);
+    const k = (p.charge * params.fieldStrength * 8000) / (r2 * r);
+    fx += dx * k;
+    fy += dy * k;
+  }
+  return { fx, fy };
+}
+
+/**
+ * 1 本の磁力線を N 極から追跡して描画
+ * @param {{x: number, y: number, charge: number}} pole
+ * @param {number} angle
+ */
+function traceLine(pole, angle) {
+  const startR = 6;
+  let x = pole.x + Math.cos(angle) * startR;
+  let y = pole.y + Math.sin(angle) * startR;
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  for (let i = 0; i < params.maxSteps; i++) {
+    const { fx, fy } = field(x, y);
+    const mag = Math.hypot(fx, fy) || 1;
+    const nx = x + (fx / mag) * params.stepSize * pole.charge;
+    const ny = y + (fy / mag) * params.stepSize * pole.charge;
+    if (nx < 0 || nx > canvas.width || ny < 0 || ny > canvas.height) break;
+    // 他極へ到達したら終了
+    let hit = false;
+    for (const p of poles) {
+      if (p === pole) continue;
+      if ((p.x - nx) ** 2 + (p.y - ny) ** 2 < 36) {
+        hit = true;
+        break;
+      }
+    }
+    ctx.lineTo(nx, ny);
+    x = nx;
+    y = ny;
+    if (hit) break;
+  }
+  ctx.stroke();
+}
+
+// --- 描画 ---
+
+let time = 0;
+
+function step() {
+  time += 1 / 60;
+  if (params.animate) {
+    for (const p of poles) {
+      p.x = p.baseX + Math.sin(time * params.driftSpeed + p.phase) * 60;
+      p.y = p.baseY + Math.cos(time * params.driftSpeed * 0.8 + p.phase) * 60;
+    }
+  }
+  ctx.fillStyle = `rgba(6, 6, 10, ${Math.max(0, Math.min(1, params.trailFade))})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+  const lines = Math.max(4, Math.round(params.lineDensity));
+  for (const p of poles) {
+    const hue = p.charge > 0 ? params.hueNorth : params.hueSouth;
+    const stroke = `hsl(${hue}, 85%, 62%)`;
+    ctx.strokeStyle = stroke;
+    ctx.shadowColor = stroke;
+    if (p.charge > 0) {
+      for (let i = 0; i < lines; i++) {
+        traceLine(p, (i / lines) * Math.PI * 2);
+      }
+    }
+  }
+  ctx.shadowBlur = 0;
+  if (params.showPoles) drawPoles();
+}
+
+function drawPoles() {
+  for (const p of poles) {
+    const color =
+      p.charge > 0
+        ? `hsl(${params.hueNorth}, 90%, 60%)`
+        : `hsl(${params.hueSouth}, 90%, 60%)`;
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#fff';
+    ctx.font = '0.75rem sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(p.charge > 0 ? 'N' : 'S', p.x, p.y);
+  }
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Magnetic Field Lines',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'poleCount', 2, 10, 1).onChange(initPoles);
+gui.add(params, 'lineDensity', 4, 120, 1);
+gui.add(params, 'stepSize', 1, 12, 0.5);
+gui.add(params, 'maxSteps', 50, 1500, 10);
+gui.add(params, 'fieldStrength', 0.2, 3, 0.05);
+gui.add(params, 'lineWidth', 0.25, 4, 0.05);
+gui.add(params, 'hueNorth', 0, 360, 1);
+gui.add(params, 'hueSouth', 0, 360, 1);
+gui.add(params, 'glow', 0, 30, 0.5);
+gui.add(params, 'trailFade', 0, 0.5, 0.005);
+gui.add(params, 'driftSpeed', 0, 1.5, 0.01);
+gui.add(params, 'showPoles');
+gui.add(params, 'animate');
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.poleCount = rand(2, 8, 1);
+  params.lineDensity = rand(20, 80, 1);
+  params.fieldStrength = rand(0.5, 2, 0.05);
+  params.hueNorth = rand(0, 360, 1);
+  params.hueSouth = (params.hueNorth + 180) % 360;
+  params.glow = rand(0, 20, 0.5);
+  params.trailFade = rand(0.02, 0.2, 0.005);
+  initPoles();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reposition', () => {
+  initPoles();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initPoles();
+  clearCanvas();
+  gui.updateDisplay();
+});

--- a/public/magnetic-field-lines/style.css
+++ b/public/magnetic-field-lines/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #06060a;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/smoke-plume/index.html
+++ b/public/smoke-plume/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Smoke Plume | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/smoke-plume/main.js
+++ b/public/smoke-plume/main.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  emitRate: 12, // 1 フレームの粒子生成数
+  buoyancy: 1.2, // 上昇の強さ
+  turbulence: 0.8, // 渦の強さ
+  turbScale: 0.005, // 渦のスケール
+  drift: 0, // 横方向の流れ
+  particleSize: 26, // 粒子の描画半径
+  life: 3.0, // 粒子寿命（秒）
+  maxParticles: 1500, // 粒子上限
+  hue: 220, // 色相
+  hueSpread: 30, // 色相のばらつき
+  fadePower: 1.6, // 寿命のフェード曲線
+  opacity: 0.18, // 1 粒子のアルファ
+  glow: 0, // グロー
+  emitterX: 0.5, // エミッター x 位置（正規化）
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- パーティクル ---
+
+/**
+ * @typedef {{x: number, y: number, vx: number, vy: number, age: number, life: number, size: number, hue: number}} Particle
+ */
+
+/** @type {Particle[]} */
+const particles = [];
+
+function spawn() {
+  if (particles.length >= params.maxParticles) return;
+  const x = canvas.width * params.emitterX + (Math.random() - 0.5) * 20;
+  const y = canvas.height - 10;
+  particles.push({
+    x,
+    y,
+    vx: (Math.random() - 0.5) * 10,
+    vy: -20 - Math.random() * 20,
+    age: 0,
+    life: params.life * (0.6 + Math.random() * 0.8),
+    size: params.particleSize * (0.6 + Math.random() * 0.8),
+    hue: params.hue + (Math.random() - 0.5) * params.hueSpread,
+  });
+}
+
+// Simplex 風ではないが、連続感のある疑似ノイズ
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} t
+ */
+function curl(x, y, t) {
+  const s = params.turbScale;
+  const a = Math.sin(x * s + t * 0.7) + Math.cos(y * s * 1.3 - t * 0.5);
+  const b = Math.cos(x * s * 1.1 - t * 0.6) + Math.sin(y * s + t * 0.4);
+  return { x: a, y: b };
+}
+
+let time = 0;
+
+function update(dt) {
+  time += dt;
+  for (let i = 0; i < Math.max(0, Math.round(params.emitRate)); i++) spawn();
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.age += dt;
+    if (p.age >= p.life) {
+      particles.splice(i, 1);
+      continue;
+    }
+    const { x: cx, y: cy } = curl(p.x, p.y, time);
+    p.vx += cx * params.turbulence * 30 * dt + params.drift * 60 * dt;
+    p.vy += cy * params.turbulence * 20 * dt;
+    p.vy -= params.buoyancy * 60 * dt;
+    p.vx *= 0.98;
+    p.vy *= 0.98;
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+  }
+}
+
+function render() {
+  ctx.fillStyle = '#07080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.shadowBlur = params.glow;
+  for (const p of particles) {
+    const t = p.age / p.life;
+    const alpha = params.opacity * (1 - t) ** params.fadePower;
+    const size = p.size * (0.5 + t * 1.2);
+    const color = `hsla(${p.hue}, 50%, 60%, ${alpha})`;
+    const grad = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, size);
+    grad.addColorStop(0, color);
+    grad.addColorStop(1, 'hsla(0, 0%, 0%, 0)');
+    ctx.fillStyle = grad;
+    ctx.shadowColor = color;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.shadowBlur = 0;
+}
+
+let last = performance.now();
+function loop(now) {
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  update(dt);
+  render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Smoke Plume',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'emitRate', 0, 40, 1);
+gui.add(params, 'buoyancy', 0, 4, 0.05);
+gui.add(params, 'turbulence', 0, 3, 0.05);
+gui.add(params, 'turbScale', 0.001, 0.02, 0.0005);
+gui.add(params, 'drift', -1, 1, 0.01);
+gui.add(params, 'particleSize', 4, 80, 1);
+gui.add(params, 'life', 0.5, 8, 0.1);
+gui.add(params, 'maxParticles', 200, 4000, 50);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueSpread', 0, 180, 1);
+gui.add(params, 'fadePower', 0.3, 4, 0.05);
+gui.add(params, 'opacity', 0.02, 0.6, 0.01);
+gui.add(params, 'glow', 0, 30, 0.5);
+gui.add(params, 'emitterX', 0.05, 0.95, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.emitRate = rand(4, 24, 1);
+  params.buoyancy = rand(0.5, 2.5, 0.05);
+  params.turbulence = rand(0.3, 2, 0.05);
+  params.drift = rand(-0.3, 0.3, 0.01);
+  params.hue = rand(0, 360, 1);
+  params.hueSpread = rand(10, 90, 1);
+  params.particleSize = rand(14, 50, 1);
+  params.opacity = rand(0.1, 0.3, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Clear', () => {
+  particles.length = 0;
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  particles.length = 0;
+  gui.updateDisplay();
+});

--- a/public/smoke-plume/style.css
+++ b/public/smoke-plume/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #07080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/tessellation-lab/index.html
+++ b/public/tessellation-lab/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Tessellation Lab | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/tessellation-lab/main.js
+++ b/public/tessellation-lab/main.js
@@ -1,0 +1,280 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  tiling: 1, // 1:三角, 2:四角, 3:六角, 4:三角+六角
+  size: 54, // タイル辺長
+  rotate: 0, // 全体回転（度）
+  warp: 0, // 頂点ゆらぎ量
+  warpSpeed: 0.4, // ゆらぎ速度
+  lineWidth: 1.4, // 線の太さ
+  hueBase: 200, // 基本色相
+  hueSpread: 80, // 色相レンジ
+  saturation: 65, // 彩度
+  lightness: 52, // 明度
+  fillAlpha: 0.8, // 塗り透明度
+  strokeAlpha: 1, // 線透明度
+  showStroke: true, // 線の有無
+  pulse: 0.15, // 明滅強度
+  pulseSpeed: 1, // 明滅速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 敷き詰め生成 ---
+
+/**
+ * @typedef {{points: [number, number][], seed: number}} Tile
+ */
+
+/**
+ * @returns {Tile[]}
+ */
+function buildTiles() {
+  const tiles = [];
+  const s = params.size;
+  const cw = canvas.width;
+  const ch = canvas.height;
+  if (params.tiling === 1) {
+    // 正三角形タイリング
+    const h = (s * Math.sqrt(3)) / 2;
+    const cols = Math.ceil(cw / s) + 4;
+    const rows = Math.ceil(ch / h) + 4;
+    for (let r = -2; r < rows; r++) {
+      for (let c = -2; c < cols; c++) {
+        const x = c * s + (r % 2 ? s / 2 : 0);
+        const y = r * h;
+        tiles.push({
+          points: [
+            [x, y],
+            [x + s, y],
+            [x + s / 2, y + h],
+          ],
+          seed: r * 1000 + c,
+        });
+        tiles.push({
+          points: [
+            [x + s, y],
+            [x + s + s / 2, y + h],
+            [x + s / 2, y + h],
+          ],
+          seed: r * 1000 + c + 500,
+        });
+      }
+    }
+  } else if (params.tiling === 2) {
+    // 正方形
+    const cols = Math.ceil(cw / s) + 2;
+    const rows = Math.ceil(ch / s) + 2;
+    for (let r = -1; r < rows; r++) {
+      for (let c = -1; c < cols; c++) {
+        const x = c * s;
+        const y = r * s;
+        tiles.push({
+          points: [
+            [x, y],
+            [x + s, y],
+            [x + s, y + s],
+            [x, y + s],
+          ],
+          seed: r * 1000 + c,
+        });
+      }
+    }
+  } else if (params.tiling === 3) {
+    // 正六角形
+    const w = s * Math.sqrt(3);
+    const h = s * 1.5;
+    const cols = Math.ceil(cw / w) + 2;
+    const rows = Math.ceil(ch / h) + 2;
+    for (let r = -1; r < rows; r++) {
+      for (let c = -1; c < cols; c++) {
+        const cx = c * w + (r % 2 ? w / 2 : 0);
+        const cy = r * h;
+        /** @type {[number, number][]} */
+        const pts = [];
+        for (let i = 0; i < 6; i++) {
+          const a = (Math.PI / 3) * i - Math.PI / 2;
+          pts.push([cx + Math.cos(a) * s, cy + Math.sin(a) * s]);
+        }
+        tiles.push({ points: pts, seed: r * 1000 + c });
+      }
+    }
+  } else {
+    // 三角+六角（trihexagonal）
+    const w = s * Math.sqrt(3);
+    const h = s * Math.sqrt(3);
+    const cols = Math.ceil(cw / w) + 2;
+    const rows = Math.ceil(ch / h) + 2;
+    for (let r = -1; r < rows; r++) {
+      for (let c = -1; c < cols; c++) {
+        const cx = c * w + (r % 2 ? w / 2 : 0);
+        const cy = r * h;
+        /** @type {[number, number][]} */
+        const hex = [];
+        for (let i = 0; i < 6; i++) {
+          const a = (Math.PI / 3) * i;
+          hex.push([cx + Math.cos(a) * s * 0.6, cy + Math.sin(a) * s * 0.6]);
+        }
+        tiles.push({ points: hex, seed: r * 1000 + c });
+        // 周囲の三角
+        for (let i = 0; i < 6; i++) {
+          const a1 = (Math.PI / 3) * i;
+          const a2 = (Math.PI / 3) * (i + 1);
+          tiles.push({
+            points: [
+              [cx, cy],
+              [cx + Math.cos(a1) * s * 0.6, cy + Math.sin(a1) * s * 0.6],
+              [cx + Math.cos(a2) * s * 0.6, cy + Math.sin(a2) * s * 0.6],
+            ],
+            seed: r * 1000 + c * 10 + i + 999,
+          });
+        }
+      }
+    }
+  }
+  return tiles;
+}
+
+/** @type {Tile[]} */
+let tiles = buildTiles();
+
+// --- 描画 ---
+
+let time = 0;
+
+function warpPoint(x, y, seed, t) {
+  if (params.warp === 0) return [x, y];
+  const ph = seed * 0.11;
+  const dx = Math.sin(t * params.warpSpeed + ph) * params.warp;
+  const dy = Math.cos(t * params.warpSpeed * 0.9 + ph * 1.3) * params.warp;
+  return [x + dx, y + dy];
+}
+
+function render() {
+  ctx.fillStyle = '#0a0a10';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.save();
+  ctx.translate(canvas.width / 2, canvas.height / 2);
+  ctx.rotate((params.rotate * Math.PI) / 180);
+  ctx.translate(-canvas.width / 2, -canvas.height / 2);
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineJoin = 'round';
+  for (const t of tiles) {
+    const h =
+      (params.hueBase + ((t.seed * 37) % 360) * (params.hueSpread / 360)) % 360;
+    const pulse =
+      1 + Math.sin(time * params.pulseSpeed + t.seed) * params.pulse;
+    const l = Math.max(0, Math.min(100, params.lightness * pulse));
+    ctx.fillStyle = `hsla(${h}, ${params.saturation}%, ${l}%, ${params.fillAlpha})`;
+    ctx.strokeStyle = `hsla(${h}, ${params.saturation}%, ${Math.min(100, l + 20)}%, ${params.strokeAlpha})`;
+    ctx.beginPath();
+    const [x0, y0] = warpPoint(t.points[0][0], t.points[0][1], t.seed, time);
+    ctx.moveTo(x0, y0);
+    for (let i = 1; i < t.points.length; i++) {
+      const [x, y] = warpPoint(
+        t.points[i][0],
+        t.points[i][1],
+        t.seed + i,
+        time,
+      );
+      ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fill();
+    if (params.showStroke) ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function loop(now) {
+  time = now / 1000;
+  render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);
+
+function rebuild() {
+  tiles = buildTiles();
+}
+
+window.addEventListener('resize', rebuild);
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Tessellation Lab',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'tiling', 1, 4, 1).onChange(rebuild);
+gui.add(params, 'size', 12, 160, 1).onChange(rebuild);
+gui.add(params, 'rotate', 0, 360, 1);
+gui.add(params, 'warp', 0, 30, 0.5);
+gui.add(params, 'warpSpeed', 0, 3, 0.05);
+gui.add(params, 'lineWidth', 0, 6, 0.1);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueSpread', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 10, 90, 1);
+gui.add(params, 'fillAlpha', 0, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'pulse', 0, 0.5, 0.01);
+gui.add(params, 'pulseSpeed', 0, 5, 0.05);
+gui.add(params, 'showStroke');
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.tiling = rand(1, 4, 1);
+  params.size = rand(24, 100, 1);
+  params.rotate = rand(0, 360, 1);
+  params.warp = rand(0, 15, 0.5);
+  params.hueBase = rand(0, 360, 1);
+  params.hueSpread = rand(30, 300, 1);
+  params.saturation = rand(30, 90, 1);
+  params.lightness = rand(35, 70, 1);
+  params.pulse = rand(0, 0.3, 0.01);
+  rebuild();
+  gui.updateDisplay();
+});
+
+gui.addButton('Rebuild', () => rebuild());
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/tessellation-lab/style.css
+++ b/public/tessellation-lab/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0a10;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

- 雨粒シミュレーションにより地形が侵食・堆積で変化していく新規ページ `public/erosion-landscape/` を追加
- TileUI で 14 コントロール（grid/dropsPerFrame/iterations/inertia/sedimentCapacity/erode/deposit/evaporate/gravity/hue 2 色/relief/waterTint/autoRain）
- `Random` / `Reseed` / `Reset` ボタン搭載
- トップページのナビ・`docs/README.md` のページ一覧を更新

Closes #41

## Test plan

- [ ] `npm run check` が通る
- [ ] `/erosion-landscape/` で地形が描画され、雨粒により徐々に侵食される
- [ ] 各 GUI パラメータが挙動に反映される