### PR TITLE
feat: Smoke Plume ページを追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 | `/erosion-landscape/` | Erosion Landscape（雨粒の侵食で変化する地形シミュレーション） |
 | `/magnetic-field-lines/` | Magnetic Field Lines（N/S 極の配置から描く磁力線ビジュアル） |
 | `/crystal-growth/` | Crystal Growth（DLA 風に結晶が枝分かれしながら成長する） |
+| `/smoke-plume/` | Smoke Plume（ゆらぎながら立ち昇る煙の流体風シミュレーション） |
 
 ## トップページ仕様
 

--- a/public/index.html
+++ b/public/index.html
@@ -277,6 +277,12 @@
               <span class="nav-description">DLA 風に結晶が枝分かれしながら成長する</span>
             </a>
           </li>
+          <li>
+            <a href="/smoke-plume/">
+              Smoke Plume
+              <span class="nav-description">ゆらぎながら立ち昇る煙の流体風シミュレーション</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/smoke-plume/index.html
+++ b/public/smoke-plume/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Smoke Plume | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/smoke-plume/main.js
+++ b/public/smoke-plume/main.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  emitRate: 12, // 1 フレームの粒子生成数
+  buoyancy: 1.2, // 上昇の強さ
+  turbulence: 0.8, // 渦の強さ
+  turbScale: 0.005, // 渦のスケール
+  drift: 0, // 横方向の流れ
+  particleSize: 26, // 粒子の描画半径
+  life: 3.0, // 粒子寿命（秒）
+  maxParticles: 1500, // 粒子上限
+  hue: 220, // 色相
+  hueSpread: 30, // 色相のばらつき
+  fadePower: 1.6, // 寿命のフェード曲線
+  opacity: 0.18, // 1 粒子のアルファ
+  glow: 0, // グロー
+  emitterX: 0.5, // エミッター x 位置（正規化）
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- パーティクル ---
+
+/**
+ * @typedef {{x: number, y: number, vx: number, vy: number, age: number, life: number, size: number, hue: number}} Particle
+ */
+
+/** @type {Particle[]} */
+const particles = [];
+
+function spawn() {
+  if (particles.length >= params.maxParticles) return;
+  const x = canvas.width * params.emitterX + (Math.random() - 0.5) * 20;
+  const y = canvas.height - 10;
+  particles.push({
+    x,
+    y,
+    vx: (Math.random() - 0.5) * 10,
+    vy: -20 - Math.random() * 20,
+    age: 0,
+    life: params.life * (0.6 + Math.random() * 0.8),
+    size: params.particleSize * (0.6 + Math.random() * 0.8),
+    hue: params.hue + (Math.random() - 0.5) * params.hueSpread,
+  });
+}
+
+// Simplex 風ではないが、連続感のある疑似ノイズ
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} t
+ */
+function curl(x, y, t) {
+  const s = params.turbScale;
+  const a = Math.sin(x * s + t * 0.7) + Math.cos(y * s * 1.3 - t * 0.5);
+  const b = Math.cos(x * s * 1.1 - t * 0.6) + Math.sin(y * s + t * 0.4);
+  return { x: a, y: b };
+}
+
+let time = 0;
+
+function update(dt) {
+  time += dt;
+  for (let i = 0; i < Math.max(0, Math.round(params.emitRate)); i++) spawn();
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.age += dt;
+    if (p.age >= p.life) {
+      particles.splice(i, 1);
+      continue;
+    }
+    const { x: cx, y: cy } = curl(p.x, p.y, time);
+    p.vx += cx * params.turbulence * 30 * dt + params.drift * 60 * dt;
+    p.vy += cy * params.turbulence * 20 * dt;
+    p.vy -= params.buoyancy * 60 * dt;
+    p.vx *= 0.98;
+    p.vy *= 0.98;
+    p.x += p.vx * dt;
+    p.y += p.vy * dt;
+  }
+}
+
+function render() {
+  ctx.fillStyle = '#07080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.globalCompositeOperation = 'lighter';
+  ctx.shadowBlur = params.glow;
+  for (const p of particles) {
+    const t = p.age / p.life;
+    const alpha = params.opacity * (1 - t) ** params.fadePower;
+    const size = p.size * (0.5 + t * 1.2);
+    const color = `hsla(${p.hue}, 50%, 60%, ${alpha})`;
+    const grad = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, size);
+    grad.addColorStop(0, color);
+    grad.addColorStop(1, 'hsla(0, 0%, 0%, 0)');
+    ctx.fillStyle = grad;
+    ctx.shadowColor = color;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.shadowBlur = 0;
+}
+
+let last = performance.now();
+function loop(now) {
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  update(dt);
+  render();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Smoke Plume',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'emitRate', 0, 40, 1);
+gui.add(params, 'buoyancy', 0, 4, 0.05);
+gui.add(params, 'turbulence', 0, 3, 0.05);
+gui.add(params, 'turbScale', 0.001, 0.02, 0.0005);
+gui.add(params, 'drift', -1, 1, 0.01);
+gui.add(params, 'particleSize', 4, 80, 1);
+gui.add(params, 'life', 0.5, 8, 0.1);
+gui.add(params, 'maxParticles', 200, 4000, 50);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueSpread', 0, 180, 1);
+gui.add(params, 'fadePower', 0.3, 4, 0.05);
+gui.add(params, 'opacity', 0.02, 0.6, 0.01);
+gui.add(params, 'glow', 0, 30, 0.5);
+gui.add(params, 'emitterX', 0.05, 0.95, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.emitRate = rand(4, 24, 1);
+  params.buoyancy = rand(0.5, 2.5, 0.05);
+  params.turbulence = rand(0.3, 2, 0.05);
+  params.drift = rand(-0.3, 0.3, 0.01);
+  params.hue = rand(0, 360, 1);
+  params.hueSpread = rand(10, 90, 1);
+  params.particleSize = rand(14, 50, 1);
+  params.opacity = rand(0.1, 0.3, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Clear', () => {
+  particles.length = 0;
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  particles.length = 0;
+  gui.updateDisplay();
+});

--- a/public/smoke-plume/style.css
+++ b/public/smoke-plume/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #07080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

- ゆらぎながら立ち昇る煙の流体風シミュレーション新規ページ `public/smoke-plume/` を追加
- カール風ノイズ場で乱流、浮力で上昇、lighter 合成でモクモク感を表現
- TileUI で 14 コントロール（emit/buoyancy/turbulence/scale/drift/size/life/max/hue/spread/fade/opacity/glow/emitterX）
- `Random` / `Clear` / `Reset` ボタン搭載
- トップページのナビ・`docs/README.md` のページ一覧を更新

Closes #45

> Stacked on #82

## Test plan

- [ ] `npm run check` が通る
- [ ] `/smoke-plume/` で煙が立ち昇り、揺らぐ
- [ ] buoyancy / turbulence / drift 等の GUI が反映される