### PR TITLE
ci: 非デフォルトブランチ宛 PR のマージ時に issue を自動クローズする workflow を追加

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,0 +1,38 @@
+name: Close issues on merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-issues:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref != github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close referenced issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$PR_BODY" ]; then
+            echo "PR body is empty, skipping"
+            exit 0
+          fi
+
+          # Closes/Fixes/Resolves #N パターンから issue 番号を抽出
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+')
+
+          if [ -z "$ISSUE_NUMBERS" ]; then
+            echo "No issue references found, skipping"
+            exit 0
+          fi
+
+          for ISSUE in $ISSUE_NUMBERS; do
+            echo "Closing issue #$ISSUE"
+            gh issue close "$ISSUE" --repo "$REPO" --comment "Closed via PR #${{ github.event.pull_request.number }} merge."
+          done


### PR DESCRIPTION
## Summary
- 非デフォルトブランチ宛の PR がマージされた際、本文中の `Closes/Fixes/Resolves #N` から issue 番号を抽出して自動クローズする GitHub Actions workflow を追加
- デフォルトブランチ宛 PR は GitHub 標準の挙動で閉じられるため、本 workflow の対象外（条件で除外）

## Test plan
- [ ] main にマージ後、非デフォルトブランチ宛の PR で `Closes #N` を本文に含めてマージし、該当 issue が閉じられることを確認
- [ ] デフォルトブランチ宛の PR マージ時には workflow が skip されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)