### PR TITLE
fix(ci): close-issues workflow を pull_request_target に変更

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -1,7 +1,7 @@
 name: Close issues on merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
## Summary
- #220 で追加した workflow が stacked PR（PR #215 等）で発火しなかった問題を修正
- `pull_request` イベントは PR のベースブランチ側の workflow 定義で発火するため、main 以外をベースとする PR では workflow 未配置でトリガーされない
- `pull_request_target` に変更することで常にデフォルトブランチ（main）側の定義で発火する

## Test plan
- [ ] main マージ後、非デフォルトブランチ宛の stacked PR をマージし、`Closes #N` の issue が自動クローズされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)