### PR TITLE
feat: TileUI ジェネラティブアート 10 ページ追加 (Phase 2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@
 | `/truchet-tiles/` | Truchet Tiles（ランダムな向きの弧タイルで生まれる迷路模様） |
 | `/harmonograph/` | Harmonograph（減衰する振り子の合成で描くハーモノグラフ） |
 | `/rose-curve/` | Rose Curve（r = cos(kθ) で描く花弁状の薔薇曲線） |
+| `/superellipse/` | Superellipse（指数 n で膨縮するラメ曲線のネストパターン） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@
 | `/superellipse/` | Superellipse（指数 n で膨縮するラメ曲線のネストパターン） |
 | `/spiral-phyllotaxis/` | Spiral Phyllotaxis（黄金角でひまわり状に並ぶ種のフィロタキシス） |
 | `/meteor-shower/` | Meteor Shower（流星が尾を引いて降る夜空の流星群） |
+| `/dragon-curve/` | Dragon Curve（紙を折り畳んで展開するヘイウェイのドラゴン曲線） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@
 | `/rose-curve/` | Rose Curve（r = cos(kθ) で描く花弁状の薔薇曲線） |
 | `/superellipse/` | Superellipse（指数 n で膨縮するラメ曲線のネストパターン） |
 | `/spiral-phyllotaxis/` | Spiral Phyllotaxis（黄金角でひまわり状に並ぶ種のフィロタキシス） |
+| `/meteor-shower/` | Meteor Shower（流星が尾を引いて降る夜空の流星群） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@
 | `/heart-pulse/` | Heart Pulse（心臓曲線を BPM で脈動させるパルス波） |
 | `/error-diffusion/` | Error Diffusion（Floyd-Steinberg 誤差拡散ディザで階調を量子化） |
 | `/soap-film/` | Soap Film（薄膜干渉で揺らぐシャボン膜のイリデッセンス） |
+| `/ripple-pond/` | Ripple Pond（雨滴で広がる同心円波紋の水面ビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@
 | `/ripple-pond/` | Ripple Pond（雨滴で広がる同心円波紋の水面ビジュアル） |
 | `/truchet-tiles/` | Truchet Tiles（ランダムな向きの弧タイルで生まれる迷路模様） |
 | `/harmonograph/` | Harmonograph（減衰する振り子の合成で描くハーモノグラフ） |
+| `/rose-curve/` | Rose Curve（r = cos(kθ) で描く花弁状の薔薇曲線） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@
 | `/harmonograph/` | Harmonograph（減衰する振り子の合成で描くハーモノグラフ） |
 | `/rose-curve/` | Rose Curve（r = cos(kθ) で描く花弁状の薔薇曲線） |
 | `/superellipse/` | Superellipse（指数 n で膨縮するラメ曲線のネストパターン） |
+| `/spiral-phyllotaxis/` | Spiral Phyllotaxis（黄金角でひまわり状に並ぶ種のフィロタキシス） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@
 | `/wolfram-code-explorer/` | Wolfram Code Explorer（1D 初等セルオートマトンをルール番号で探索） |
 | `/heart-pulse/` | Heart Pulse（心臓曲線を BPM で脈動させるパルス波） |
 | `/error-diffusion/` | Error Diffusion（Floyd-Steinberg 誤差拡散ディザで階調を量子化） |
+| `/soap-film/` | Soap Film（薄膜干渉で揺らぐシャボン膜のイリデッセンス） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@
 | `/soap-film/` | Soap Film（薄膜干渉で揺らぐシャボン膜のイリデッセンス） |
 | `/ripple-pond/` | Ripple Pond（雨滴で広がる同心円波紋の水面ビジュアル） |
 | `/truchet-tiles/` | Truchet Tiles（ランダムな向きの弧タイルで生まれる迷路模様） |
+| `/harmonograph/` | Harmonograph（減衰する振り子の合成で描くハーモノグラフ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@
 | `/spiral-phyllotaxis/` | Spiral Phyllotaxis（黄金角でひまわり状に並ぶ種のフィロタキシス） |
 | `/meteor-shower/` | Meteor Shower（流星が尾を引いて降る夜空の流星群） |
 | `/dragon-curve/` | Dragon Curve（紙を折り畳んで展開するヘイウェイのドラゴン曲線） |
+| `/koch-snowflake/` | Koch Snowflake（辺を反復分割して形成するコッホ雪片フラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@
 | `/error-diffusion/` | Error Diffusion（Floyd-Steinberg 誤差拡散ディザで階調を量子化） |
 | `/soap-film/` | Soap Film（薄膜干渉で揺らぐシャボン膜のイリデッセンス） |
 | `/ripple-pond/` | Ripple Pond（雨滴で広がる同心円波紋の水面ビジュアル） |
+| `/truchet-tiles/` | Truchet Tiles（ランダムな向きの弧タイルで生まれる迷路模様） |
 
 ## トップページ仕様
 

--- a/public/dragon-curve/index.html
+++ b/public/dragon-curve/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Dragon Curve | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/dragon-curve/main.js
+++ b/public/dragon-curve/main.js
@@ -1,0 +1,186 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  iterations: 12, // 反復回数
+  angle: 90, // 回転角（度）
+  segLen: 6, // 1 セグメントの長さ
+  rotate: 0, // 全体の回転（度）
+  offsetX: 0, // X オフセット
+  offsetY: 0, // Y オフセット
+  lineWidth: 1.4, // 線の太さ
+  hue: 160, // 色相
+  hueSpan: 180, // 色相の全幅
+  saturation: 85, // 彩度
+  lightness: 65, // 明度
+  glow: 4, // グロー
+  growSpeed: 0.7, // 描画成長速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  regenerate();
+}
+window.addEventListener('resize', resize);
+
+/** @type {number[]} */
+let turns = [];
+/** @type {{x:number, y:number}[]} */
+let points = [];
+let drawnCount = 0;
+
+function buildDragon(iter) {
+  turns = [];
+  for (let i = 0; i < iter; i++) {
+    const rev = turns
+      .slice()
+      .reverse()
+      .map((t) => 1 - t);
+    turns = [...turns, 1, ...rev];
+  }
+}
+
+function regenerate() {
+  const iter = Math.max(1, Math.min(16, Math.floor(params.iterations)));
+  buildDragon(iter);
+  // 座標生成
+  points = [];
+  let x = 0;
+  let y = 0;
+  let dir = 0;
+  const a = (params.angle * Math.PI) / 180;
+  points.push({ x, y });
+  for (const t of turns) {
+    x += Math.cos(dir) * params.segLen;
+    y += Math.sin(dir) * params.segLen;
+    points.push({ x, y });
+    dir += t === 1 ? a : -a;
+  }
+  x += Math.cos(dir) * params.segLen;
+  y += Math.sin(dir) * params.segLen;
+  points.push({ x, y });
+  // フィットする中心オフセット
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of points) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  for (const p of points) {
+    p.x -= cx;
+    p.y -= cy;
+  }
+  drawnCount = 0;
+}
+
+resize();
+
+function draw() {
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.save();
+  ctx.translate(
+    canvas.width / 2 + params.offsetX,
+    canvas.height / 2 + params.offsetY,
+  );
+  ctx.rotate((params.rotate * Math.PI) / 180);
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+  const limit = Math.min(points.length - 1, Math.floor(drawnCount));
+  for (let i = 0; i < limit; i++) {
+    const t = i / Math.max(1, points.length - 2);
+    const hue = (params.hue + t * params.hueSpan) % 360;
+    const stroke = `hsl(${hue}, ${params.saturation}%, ${params.lightness}%)`;
+    ctx.strokeStyle = stroke;
+    ctx.shadowColor = stroke;
+    ctx.beginPath();
+    ctx.moveTo(points[i].x, points[i].y);
+    ctx.lineTo(points[i + 1].x, points[i + 1].y);
+    ctx.stroke();
+  }
+  ctx.restore();
+  ctx.shadowBlur = 0;
+  drawnCount = Math.min(
+    points.length - 1,
+    drawnCount + points.length * params.growSpeed * 0.02,
+  );
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Dragon Curve',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'iterations', 1, 16, 1).onChange(regenerate);
+gui.add(params, 'angle', 30, 150, 1).onChange(regenerate);
+gui.add(params, 'segLen', 1, 20, 0.5).onChange(regenerate);
+gui.add(params, 'rotate', -180, 180, 1);
+gui.add(params, 'offsetX', -400, 400, 1);
+gui.add(params, 'offsetY', -400, 400, 1);
+gui.add(params, 'lineWidth', 0.3, 5, 0.05);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueSpan', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 10, 90, 1);
+gui.add(params, 'glow', 0, 20, 0.5);
+gui.add(params, 'growSpeed', 0, 3, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.iterations = rand(8, 14, 1);
+  params.angle = rand(60, 120, 1);
+  params.segLen = rand(2, 10, 0.5);
+  params.rotate = rand(-180, 180, 1);
+  params.hue = rand(0, 360, 1);
+  params.hueSpan = rand(60, 300, 1);
+  regenerate();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  regenerate();
+  gui.updateDisplay();
+});

--- a/public/dragon-curve/style.css
+++ b/public/dragon-curve/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/harmonograph/index.html
+++ b/public/harmonograph/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Harmonograph | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/harmonograph/main.js
+++ b/public/harmonograph/main.js
@@ -1,0 +1,145 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  fx1: 2.01, // x 成分周波数 1
+  fx2: 3.0, // x 成分周波数 2
+  fy1: 3.0, // y 成分周波数 1
+  fy2: 2.0, // y 成分周波数 2
+  px1: 0, // x 位相 1（度）
+  py1: 90, // y 位相 1（度）
+  damping: 0.002, // 減衰係数
+  scale: 0.38, // 全体スケール（画面短辺に対する比率）
+  speed: 1.0, // 描画速度
+  hue: 210, // 色相
+  hueShift: 0.2, // 色相シフト（時間比例）
+  lineWidth: 1.2, // 線の太さ
+  glow: 6, // グロー
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  clearCanvas();
+}
+function clearCanvas() {
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let t = 0;
+
+function pos(tt) {
+  const e = Math.exp(-params.damping * tt);
+  const rx1 = (params.px1 * Math.PI) / 180;
+  const ry1 = (params.py1 * Math.PI) / 180;
+  const x = e * (Math.sin(tt * params.fx1 + rx1) + Math.sin(tt * params.fx2));
+  const y = e * (Math.sin(tt * params.fy1 + ry1) + Math.sin(tt * params.fy2));
+  return [x, y];
+}
+
+function step() {
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const s = Math.min(canvas.width, canvas.height) * params.scale * 0.5;
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+  const sub = 40;
+  const dt = (0.01 * params.speed) / sub;
+  for (let k = 0; k < sub; k++) {
+    const [x1, y1] = pos(t);
+    t += dt;
+    const [x2, y2] = pos(t);
+    const hue = (params.hue + t * params.hueShift * 20) % 360;
+    const stroke = `hsla(${hue}, 80%, 65%, 0.7)`;
+    ctx.strokeStyle = stroke;
+    ctx.shadowColor = stroke;
+    ctx.beginPath();
+    ctx.moveTo(cx + x1 * s, cy + y1 * s);
+    ctx.lineTo(cx + x2 * s, cy + y2 * s);
+    ctx.stroke();
+  }
+  ctx.shadowBlur = 0;
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Harmonograph',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'fx1', 0.5, 6, 0.01);
+gui.add(params, 'fx2', 0.5, 6, 0.01);
+gui.add(params, 'fy1', 0.5, 6, 0.01);
+gui.add(params, 'fy2', 0.5, 6, 0.01);
+gui.add(params, 'px1', 0, 360, 1);
+gui.add(params, 'py1', 0, 360, 1);
+gui.add(params, 'damping', 0, 0.02, 0.0005);
+gui.add(params, 'scale', 0.1, 0.9, 0.01);
+gui.add(params, 'speed', 0.1, 4, 0.05);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueShift', 0, 2, 0.01);
+gui.add(params, 'lineWidth', 0.3, 4, 0.05);
+gui.add(params, 'glow', 0, 20, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.fx1 = rand(1.5, 4, 0.01);
+  params.fx2 = rand(1.5, 4, 0.01);
+  params.fy1 = rand(1.5, 4, 0.01);
+  params.fy2 = rand(1.5, 4, 0.01);
+  params.px1 = rand(0, 360, 1);
+  params.py1 = rand(0, 360, 1);
+  params.damping = rand(0, 0.005, 0.0005);
+  params.hue = rand(0, 360, 1);
+  t = 0;
+  clearCanvas();
+  gui.updateDisplay();
+});
+
+gui.addButton('Clear', () => {
+  clearCanvas();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  t = 0;
+  clearCanvas();
+  gui.updateDisplay();
+});

--- a/public/harmonograph/style.css
+++ b/public/harmonograph/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -469,6 +469,12 @@
               <span class="nav-description">指数 n で膨縮するラメ曲線のネストパターン</span>
             </a>
           </li>
+          <li>
+            <a href="/spiral-phyllotaxis/">
+              Spiral Phyllotaxis
+              <span class="nav-description">黄金角でひまわり状に並ぶ種のフィロタキシス</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -433,6 +433,12 @@
               <span class="nav-description">Floyd-Steinberg 誤差拡散ディザで階調を量子化</span>
             </a>
           </li>
+          <li>
+            <a href="/soap-film/">
+              Soap Film
+              <span class="nav-description">薄膜干渉で揺らぐシャボン膜のイリデッセンス</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -487,6 +487,12 @@
               <span class="nav-description">紙を折り畳んで展開するヘイウェイのドラゴン曲線</span>
             </a>
           </li>
+          <li>
+            <a href="/koch-snowflake/">
+              Koch Snowflake
+              <span class="nav-description">辺を反復分割して形成するコッホ雪片フラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -445,6 +445,12 @@
               <span class="nav-description">雨滴で広がる同心円波紋の水面ビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/truchet-tiles/">
+              Truchet Tiles
+              <span class="nav-description">ランダムな向きの弧タイルで生まれる迷路模様</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -463,6 +463,12 @@
               <span class="nav-description">r = cos(kθ) で描く花弁状の薔薇曲線</span>
             </a>
           </li>
+          <li>
+            <a href="/superellipse/">
+              Superellipse
+              <span class="nav-description">指数 n で膨縮するラメ曲線のネストパターン</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -481,6 +481,12 @@
               <span class="nav-description">流星が尾を引いて降る夜空の流星群</span>
             </a>
           </li>
+          <li>
+            <a href="/dragon-curve/">
+              Dragon Curve
+              <span class="nav-description">紙を折り畳んで展開するヘイウェイのドラゴン曲線</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -439,6 +439,12 @@
               <span class="nav-description">薄膜干渉で揺らぐシャボン膜のイリデッセンス</span>
             </a>
           </li>
+          <li>
+            <a href="/ripple-pond/">
+              Ripple Pond
+              <span class="nav-description">雨滴で広がる同心円波紋の水面ビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -457,6 +457,12 @@
               <span class="nav-description">減衰する振り子の合成で描くハーモノグラフ</span>
             </a>
           </li>
+          <li>
+            <a href="/rose-curve/">
+              Rose Curve
+              <span class="nav-description">r = cos(kθ) で描く花弁状の薔薇曲線</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -451,6 +451,12 @@
               <span class="nav-description">ランダムな向きの弧タイルで生まれる迷路模様</span>
             </a>
           </li>
+          <li>
+            <a href="/harmonograph/">
+              Harmonograph
+              <span class="nav-description">減衰する振り子の合成で描くハーモノグラフ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -475,6 +475,12 @@
               <span class="nav-description">黄金角でひまわり状に並ぶ種のフィロタキシス</span>
             </a>
           </li>
+          <li>
+            <a href="/meteor-shower/">
+              Meteor Shower
+              <span class="nav-description">流星が尾を引いて降る夜空の流星群</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/koch-snowflake/index.html
+++ b/public/koch-snowflake/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Koch Snowflake | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/koch-snowflake/main.js
+++ b/public/koch-snowflake/main.js
@@ -1,0 +1,203 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  iterations: 5, // 反復回数
+  sides: 3, // 初期多角形の辺数（3 で正三角形）
+  bumpAngle: 60, // 凸部の角度（度, 60 で標準コッホ）
+  scale: 0.75, // 全体スケール
+  rotate: 0, // 全体回転（度）
+  spin: 0.05, // 自動回転速度
+  lineWidth: 1.4, // 線の太さ
+  hue: 210, // 色相
+  hueRange: 120, // 色相レンジ
+  saturation: 70, // 彩度
+  lightness: 70, // 明度
+  glow: 6, // グロー
+  fillAlpha: 0.0, // 塗りつぶしの不透明度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * 1 辺をコッホ分割する
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @param {number} depth
+ * @param {number[][]} out
+ */
+function koch(x1, y1, x2, y2, depth, out) {
+  if (depth === 0) {
+    out.push([x1, y1]);
+    return;
+  }
+  const dx = (x2 - x1) / 3;
+  const dy = (y2 - y1) / 3;
+  const ax = x1 + dx;
+  const ay = y1 + dy;
+  const bx = x1 + 2 * dx;
+  const by = y1 + 2 * dy;
+  const ang = (params.bumpAngle * Math.PI) / 180;
+  const cx = ax + Math.cos(ang) * dx - Math.sin(ang) * dy;
+  const cy = ay + Math.sin(ang) * dx + Math.cos(ang) * dy;
+  koch(x1, y1, ax, ay, depth - 1, out);
+  koch(ax, ay, cx, cy, depth - 1, out);
+  koch(cx, cy, bx, by, depth - 1, out);
+  koch(bx, by, x2, y2, depth - 1, out);
+}
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, w, h);
+
+  const iter = Math.max(0, Math.min(6, Math.floor(params.iterations)));
+  const sides = Math.max(3, Math.min(10, Math.floor(params.sides)));
+  const radius = Math.min(w, h) * 0.4 * params.scale;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  // 初期頂点
+  /** @type {[number, number][]} */
+  const base = [];
+  for (let i = 0; i < sides; i++) {
+    const a = (i / sides) * Math.PI * 2 - Math.PI / 2;
+    base.push([cx + Math.cos(a) * radius, cy + Math.sin(a) * radius]);
+  }
+
+  /** @type {number[][]} */
+  const pts = [];
+  for (let i = 0; i < sides; i++) {
+    const [x1, y1] = base[i];
+    const [x2, y2] = base[(i + 1) % sides];
+    koch(x1, y1, x2, y2, iter, pts);
+  }
+  pts.push(base[0]);
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate((params.rotate * Math.PI) / 180 + time * params.spin);
+  ctx.translate(-cx, -cy);
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.shadowBlur = params.glow;
+
+  ctx.beginPath();
+  for (let i = 0; i < pts.length; i++) {
+    const [x, y] = pts[i];
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  if (params.fillAlpha > 0) {
+    ctx.fillStyle = `hsla(${params.hue}, ${params.saturation}%, ${params.lightness}%, ${params.fillAlpha})`;
+    ctx.fill();
+  }
+  const stroke = `hsl(${params.hue}, ${params.saturation}%, ${params.lightness}%)`;
+  ctx.strokeStyle = stroke;
+  ctx.shadowColor = stroke;
+  ctx.stroke();
+
+  // 二次リング（色相レンジ）
+  if (params.hueRange > 0) {
+    ctx.beginPath();
+    for (let i = 0; i < pts.length; i++) {
+      const [x, y] = pts[i];
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    const hue2 = (params.hue + params.hueRange) % 360;
+    const s2 = `hsl(${hue2}, ${params.saturation}%, ${params.lightness}%)`;
+    ctx.strokeStyle = s2;
+    ctx.shadowColor = s2;
+    ctx.lineWidth = params.lineWidth * 0.5;
+    ctx.globalAlpha = 0.5;
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+  ctx.restore();
+  ctx.shadowBlur = 0;
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Koch Snowflake',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'iterations', 0, 6, 1);
+gui.add(params, 'sides', 3, 10, 1);
+gui.add(params, 'bumpAngle', 0, 120, 1);
+gui.add(params, 'scale', 0.3, 1.2, 0.01);
+gui.add(params, 'rotate', -180, 180, 1);
+gui.add(params, 'spin', -1, 1, 0.01);
+gui.add(params, 'lineWidth', 0.3, 5, 0.05);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 10, 90, 1);
+gui.add(params, 'glow', 0, 20, 0.5);
+gui.add(params, 'fillAlpha', 0, 0.6, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.iterations = rand(3, 5, 1);
+  params.sides = rand(3, 7, 1);
+  params.bumpAngle = rand(30, 80, 1);
+  params.scale = rand(0.5, 1.0, 0.01);
+  params.spin = rand(-0.3, 0.3, 0.01);
+  params.hue = rand(0, 360, 1);
+  params.hueRange = rand(30, 200, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/koch-snowflake/style.css
+++ b/public/koch-snowflake/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/meteor-shower/index.html
+++ b/public/meteor-shower/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Meteor Shower | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/meteor-shower/main.js
+++ b/public/meteor-shower/main.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  rate: 4, // 1 秒あたりの発生数
+  speed: 900, // 落下速度（px/秒）
+  angle: 210, // 進行方向（度, 画面座標系）
+  angleJitter: 10, // 角度ゆらぎ
+  length: 180, // 尾の長さ
+  lineWidth: 1.8, // 線の太さ
+  stars: 400, // 背景の星の数
+  starSize: 1.1, // 星のサイズ
+  hue: 195, // 流星の色相
+  hueJitter: 40, // 色相ゆらぎ
+  trailFade: 0.12, // 残像フェード
+  glow: 10, // グロー
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  regenStars();
+  clearCanvas();
+}
+function clearCanvas() {
+  ctx.fillStyle = '#04040a';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+window.addEventListener('resize', resize);
+
+/** @type {{x:number, y:number, s:number}[]} */
+let starField = [];
+function regenStars() {
+  starField = [];
+  for (let i = 0; i < params.stars; i++) {
+    starField.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      s: Math.random() * params.starSize + 0.2,
+    });
+  }
+}
+
+/** @type {{x:number, y:number, vx:number, vy:number, life:number, hue:number}[]} */
+const meteors = [];
+
+function spawn() {
+  const a =
+    ((params.angle + (Math.random() - 0.5) * params.angleJitter) * Math.PI) /
+    180;
+  const vx = Math.cos(a) * params.speed;
+  const vy = Math.sin(a) * params.speed;
+  // スポーンは画面外上 or 左
+  const w = canvas.width;
+  const x = Math.random() * w * 1.5 - w * 0.25;
+  const y = -20;
+  meteors.push({
+    x,
+    y,
+    vx,
+    vy,
+    life: 0,
+    hue: (params.hue + (Math.random() - 0.5) * params.hueJitter + 360) % 360,
+  });
+}
+
+resize();
+
+let last = performance.now();
+function tick(now) {
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+
+  // フェード
+  ctx.fillStyle = `rgba(4, 4, 10, ${Math.max(0, Math.min(1, params.trailFade))})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // 星
+  ctx.fillStyle = '#d0d8ff';
+  for (const s of starField) {
+    ctx.globalAlpha = 0.3 + 0.7 * Math.random();
+    ctx.fillRect(s.x, s.y, s.s, s.s);
+  }
+  ctx.globalAlpha = 1;
+
+  // スポーン
+  let spawnN = params.rate * dt;
+  while (Math.random() < spawnN) {
+    spawn();
+    spawnN -= 1;
+  }
+
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+
+  for (let i = meteors.length - 1; i >= 0; i--) {
+    const m = meteors[i];
+    m.life += dt;
+    m.x += m.vx * dt;
+    m.y += m.vy * dt;
+    const len = params.length;
+    const tailX = m.x - (m.vx / params.speed) * len;
+    const tailY = m.y - (m.vy / params.speed) * len;
+    const grad = ctx.createLinearGradient(tailX, tailY, m.x, m.y);
+    const col = `hsl(${m.hue}, 90%, 70%)`;
+    grad.addColorStop(0, 'rgba(0,0,0,0)');
+    grad.addColorStop(1, col);
+    ctx.strokeStyle = grad;
+    ctx.shadowColor = col;
+    ctx.beginPath();
+    ctx.moveTo(tailX, tailY);
+    ctx.lineTo(m.x, m.y);
+    ctx.stroke();
+    if (
+      m.x < -200 ||
+      m.x > canvas.width + 200 ||
+      m.y < -200 ||
+      m.y > canvas.height + 200
+    ) {
+      meteors.splice(i, 1);
+    }
+  }
+  ctx.shadowBlur = 0;
+  requestAnimationFrame(tick);
+}
+requestAnimationFrame(tick);
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Meteor Shower',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'rate', 0, 30, 0.1);
+gui.add(params, 'speed', 100, 2000, 10);
+gui.add(params, 'angle', 120, 300, 1);
+gui.add(params, 'angleJitter', 0, 60, 1);
+gui.add(params, 'length', 20, 400, 1);
+gui.add(params, 'lineWidth', 0.5, 6, 0.1);
+gui.add(params, 'stars', 0, 1500, 10).onChange(regenStars);
+gui.add(params, 'starSize', 0.2, 3, 0.1).onChange(regenStars);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueJitter', 0, 180, 1);
+gui.add(params, 'trailFade', 0, 0.5, 0.01);
+gui.add(params, 'glow', 0, 30, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.rate = rand(2, 12, 0.1);
+  params.speed = rand(500, 1500, 10);
+  params.angle = rand(180, 250, 1);
+  params.angleJitter = rand(0, 30, 1);
+  params.length = rand(100, 300, 1);
+  params.hue = rand(0, 360, 1);
+  params.hueJitter = rand(0, 80, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  meteors.length = 0;
+  regenStars();
+  clearCanvas();
+  gui.updateDisplay();
+});

--- a/public/meteor-shower/style.css
+++ b/public/meteor-shower/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/ripple-pond/index.html
+++ b/public/ripple-pond/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Ripple Pond | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/ripple-pond/main.js
+++ b/public/ripple-pond/main.js
@@ -1,0 +1,162 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  dropRate: 0.6, // 1 秒あたりの雨滴数
+  maxRipples: 80, // 同時に存在する最大波紋数
+  speed: 120, // 波の伝播速度
+  decay: 0.6, // 減衰率
+  ringWidth: 2.0, // 波の太さ
+  rings: 4, // 1 波紋あたりのリング数
+  hueBase: 200, // 色相の基準
+  hueRange: 120, // 色相のレンジ
+  saturation: 70, // 彩度
+  trailFade: 0.06, // 残像のフェード
+  glow: 6, // グロー
+  surfaceTint: 0.0, // 水面の色味
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  clearCanvas();
+}
+function clearCanvas() {
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {{x:number, y:number, t:number, hue:number}[]} */
+const ripples = [];
+
+canvas.addEventListener('pointerdown', (e) => {
+  addRipple(e.clientX, e.clientY);
+});
+
+/**
+ * @param {number} x
+ * @param {number} y
+ */
+function addRipple(x, y) {
+  if (ripples.length >= params.maxRipples) ripples.shift();
+  ripples.push({
+    x,
+    y,
+    t: 0,
+    hue: (params.hueBase + (Math.random() - 0.5) * params.hueRange) % 360,
+  });
+}
+
+let last = performance.now();
+function tick(now) {
+  const dt = Math.min(0.05, (now - last) / 1000);
+  last = now;
+  // 雨滴生成
+  if (Math.random() < params.dropRate * dt * 10) {
+    addRipple(Math.random() * canvas.width, Math.random() * canvas.height);
+  }
+  // フェード
+  ctx.fillStyle = `rgba(8, 8, 12, ${Math.max(0, Math.min(1, params.trailFade))})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.lineWidth = params.ringWidth;
+  ctx.shadowBlur = params.glow;
+  for (let i = ripples.length - 1; i >= 0; i--) {
+    const rp = ripples[i];
+    rp.t += dt;
+    const age = rp.t;
+    const alpha = Math.exp(-age * params.decay);
+    if (alpha < 0.01) {
+      ripples.splice(i, 1);
+      continue;
+    }
+    for (let k = 0; k < params.rings; k++) {
+      const r = params.speed * (age - k * 0.18);
+      if (r < 0) continue;
+      const stroke = `hsla(${rp.hue}, ${params.saturation}%, 65%, ${alpha * (1 - k / params.rings)})`;
+      ctx.strokeStyle = stroke;
+      ctx.shadowColor = stroke;
+      ctx.beginPath();
+      ctx.arc(rp.x, rp.y, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+  ctx.shadowBlur = 0;
+
+  // 水面の色味
+  if (params.surfaceTint > 0) {
+    ctx.fillStyle = `hsla(${params.hueBase}, 60%, 30%, ${params.surfaceTint * 0.05})`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  requestAnimationFrame(tick);
+}
+requestAnimationFrame(tick);
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Ripple Pond',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'dropRate', 0, 4, 0.05);
+gui.add(params, 'maxRipples', 10, 300, 1);
+gui.add(params, 'speed', 20, 400, 1);
+gui.add(params, 'decay', 0.05, 2, 0.01);
+gui.add(params, 'ringWidth', 0.5, 6, 0.1);
+gui.add(params, 'rings', 1, 8, 1);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'trailFade', 0, 0.3, 0.005);
+gui.add(params, 'glow', 0, 20, 0.5);
+gui.add(params, 'surfaceTint', 0, 1, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.dropRate = rand(0.3, 2.0, 0.05);
+  params.speed = rand(60, 240, 1);
+  params.decay = rand(0.3, 1.2, 0.01);
+  params.ringWidth = rand(1.0, 4.0, 0.1);
+  params.rings = rand(2, 6, 1);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(40, 260, 1);
+  params.saturation = rand(50, 95, 1);
+  params.trailFade = rand(0.03, 0.15, 0.005);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  ripples.length = 0;
+  clearCanvas();
+  gui.updateDisplay();
+});

--- a/public/ripple-pond/style.css
+++ b/public/ripple-pond/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/rose-curve/index.html
+++ b/public/rose-curve/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Rose Curve | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/rose-curve/main.js
+++ b/public/rose-curve/main.js
@@ -1,0 +1,144 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  n: 5, // 花弁の個数パラメータ
+  d: 4, // 振幅パラメータ
+  amp: 0.42, // 振幅（画面短辺に対する比率）
+  step: 0.01, // 角度ステップ
+  cycles: 8, // 全周期数
+  speed: 1.2, // 描画速度
+  lineWidth: 1.4, // 線の太さ
+  hue: 330, // 色相
+  hueShift: 0.5, // 色相シフト
+  glow: 8, // グロー
+  trailFade: 0.04, // 残像のフェード
+  thickness: 1.0, // 波の太さ変調
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  clearCanvas();
+}
+function clearCanvas() {
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let theta = 0;
+let time = 0;
+
+function step() {
+  time += 1 / 60;
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const r0 = Math.min(canvas.width, canvas.height) * params.amp;
+
+  ctx.fillStyle = `rgba(8, 8, 12, ${Math.max(0, Math.min(1, params.trailFade))})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const sub = 40;
+  const dtheta = params.step * params.speed;
+  ctx.lineWidth = params.lineWidth * params.thickness;
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+  const k = params.n / Math.max(1, params.d);
+
+  for (let i = 0; i < sub; i++) {
+    const a = theta;
+    const b = theta + dtheta;
+    const r1 = r0 * Math.cos(k * a);
+    const r2 = r0 * Math.cos(k * b);
+    const x1 = cx + r1 * Math.cos(a);
+    const y1 = cy + r1 * Math.sin(a);
+    const x2 = cx + r2 * Math.cos(b);
+    const y2 = cy + r2 * Math.sin(b);
+    const hue = (params.hue + time * params.hueShift * 60 + a * 10) % 360;
+    const stroke = `hsla(${hue}, 85%, 65%, 0.85)`;
+    ctx.strokeStyle = stroke;
+    ctx.shadowColor = stroke;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+    theta = b;
+  }
+  ctx.shadowBlur = 0;
+  if (theta > Math.PI * 2 * params.cycles) theta = 0;
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Rose Curve',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'n', 1, 20, 1);
+gui.add(params, 'd', 1, 20, 1);
+gui.add(params, 'amp', 0.1, 0.49, 0.01);
+gui.add(params, 'step', 0.002, 0.05, 0.001);
+gui.add(params, 'cycles', 1, 40, 1);
+gui.add(params, 'speed', 0.1, 4, 0.05);
+gui.add(params, 'lineWidth', 0.3, 5, 0.05);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueShift', 0, 2, 0.01);
+gui.add(params, 'glow', 0, 20, 0.5);
+gui.add(params, 'trailFade', 0, 0.3, 0.005);
+gui.add(params, 'thickness', 0.3, 3, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.n = rand(2, 11, 1);
+  params.d = rand(1, 7, 1);
+  params.amp = rand(0.25, 0.45, 0.01);
+  params.speed = rand(0.4, 2, 0.05);
+  params.hue = rand(0, 360, 1);
+  params.hueShift = rand(0, 1, 0.01);
+  params.lineWidth = rand(0.6, 2.5, 0.05);
+  theta = 0;
+  clearCanvas();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  theta = 0;
+  clearCanvas();
+  gui.updateDisplay();
+});

--- a/public/rose-curve/style.css
+++ b/public/rose-curve/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/soap-film/index.html
+++ b/public/soap-film/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Soap Film | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/soap-film/main.js
+++ b/public/soap-film/main.js
@@ -1,0 +1,179 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  bands: 14, // 干渉縞のバンド数
+  thickness: 1.2, // 膜厚係数
+  turbulence: 0.6, // 乱流の強さ
+  flow: 0.4, // 流れる速さ
+  scale: 220, // 模様のスケール
+  hueBase: 200, // 色相の基準
+  hueRange: 180, // 色相のレンジ
+  saturation: 80, // 彩度
+  lightness: 60, // 明度
+  swirl: 1.2, // 渦の強さ
+  blur: 2, // グロー
+  contrast: 1.0, // コントラスト
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * 疑似 2D ノイズ
+ * @param {number} x
+ * @param {number} y
+ */
+function noise(x, y) {
+  return (
+    Math.sin(x * 0.9 + Math.cos(y * 1.3)) * 0.5 +
+    Math.sin(x * 1.7 - y * 0.8) * 0.3 +
+    Math.cos(x * 0.4 + y * 2.1) * 0.2
+  );
+}
+
+let time = 0;
+
+function draw() {
+  time += 0.01 * params.flow;
+  const w = canvas.width;
+  const h = canvas.height;
+  const img = ctx.createImageData(w, h);
+  const data = img.data;
+  const step = 2;
+  for (let y = 0; y < h; y += step) {
+    for (let x = 0; x < w; x += step) {
+      const nx = (x / params.scale) * 1.0;
+      const ny = (y / params.scale) * 1.0;
+      const n =
+        noise(nx + time, ny) * params.turbulence +
+        noise(nx * params.swirl, ny * params.swirl + time * 0.5) * 0.6;
+      const band = ((n + 1) * 0.5 * params.bands * params.thickness) % 1;
+      const hue = (params.hueBase + band * params.hueRange) % 360;
+      const [r, g, b] = hslToRgb(
+        hue,
+        params.saturation / 100,
+        params.lightness / 100,
+      );
+      const cr = Math.min(255, r * params.contrast);
+      const cg = Math.min(255, g * params.contrast);
+      const cb = Math.min(255, b * params.contrast);
+      for (let dy = 0; dy < step && y + dy < h; dy++) {
+        for (let dx = 0; dx < step && x + dx < w; dx++) {
+          const j = ((y + dy) * w + (x + dx)) * 4;
+          data[j] = cr;
+          data[j + 1] = cg;
+          data[j + 2] = cb;
+          data[j + 3] = 255;
+        }
+      }
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+  if (params.blur > 0) {
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.filter = `blur(${params.blur}px)`;
+    ctx.drawImage(canvas, 0, 0);
+    ctx.restore();
+  }
+}
+
+/**
+ * HSL -> RGB
+ * @param {number} h 0..360
+ * @param {number} s 0..1
+ * @param {number} l 0..1
+ */
+function hslToRgb(h, s, l) {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hh = h / 60;
+  const x = c * (1 - Math.abs((hh % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hh < 1) [r, g, b] = [c, x, 0];
+  else if (hh < 2) [r, g, b] = [x, c, 0];
+  else if (hh < 3) [r, g, b] = [0, c, x];
+  else if (hh < 4) [r, g, b] = [0, x, c];
+  else if (hh < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = l - c / 2;
+  return [(r + m) * 255, (g + m) * 255, (b + m) * 255];
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Soap Film',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'bands', 2, 40, 1);
+gui.add(params, 'thickness', 0.3, 3, 0.05);
+gui.add(params, 'turbulence', 0, 2, 0.05);
+gui.add(params, 'flow', 0, 2, 0.05);
+gui.add(params, 'scale', 60, 600, 1);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 10, 90, 1);
+gui.add(params, 'swirl', 0, 3, 0.05);
+gui.add(params, 'blur', 0, 8, 0.5);
+gui.add(params, 'contrast', 0.5, 1.8, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.bands = rand(6, 24, 1);
+  params.thickness = rand(0.6, 2.0, 0.05);
+  params.turbulence = rand(0.2, 1.2, 0.05);
+  params.flow = rand(0.1, 1.0, 0.05);
+  params.scale = rand(120, 400, 1);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.saturation = rand(60, 95, 1);
+  params.lightness = rand(45, 70, 1);
+  params.swirl = rand(0.4, 2.0, 0.05);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/soap-film/style.css
+++ b/public/soap-film/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/spiral-phyllotaxis/index.html
+++ b/public/spiral-phyllotaxis/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Spiral Phyllotaxis | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/spiral-phyllotaxis/main.js
+++ b/public/spiral-phyllotaxis/main.js
@@ -1,0 +1,124 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  count: 1200, // 種の数
+  angle: 137.508, // 分散角（度）
+  spacing: 6.0, // 距離係数
+  dotSize: 3.2, // 点サイズ
+  sizeGrow: 0.002, // 点サイズ成長係数
+  rotateSpeed: 0.08, // 全体回転速度
+  grow: 0.25, // 表示成長速度
+  hue: 40, // 色相
+  hueShift: 0.35, // 色相シフト（index 比例）
+  saturation: 75, // 彩度
+  lightness: 60, // 明度
+  bg: 8, // 背景明度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+let visible = 0;
+
+function step() {
+  time += 1 / 60;
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.fillStyle = `hsl(0, 0%, ${params.bg}%)`;
+  ctx.fillRect(0, 0, w, h);
+  const cx = w / 2;
+  const cy = h / 2;
+  visible = Math.min(params.count, visible + params.grow * params.count * 0.01);
+  const rot = time * params.rotateSpeed;
+  const a = (params.angle * Math.PI) / 180;
+  const limit = Math.floor(visible);
+  for (let i = 0; i < limit; i++) {
+    const r = params.spacing * Math.sqrt(i);
+    const theta = i * a + rot;
+    const x = cx + r * Math.cos(theta);
+    const y = cy + r * Math.sin(theta);
+    const hue = (params.hue + i * params.hueShift) % 360;
+    const size = params.dotSize + i * params.sizeGrow;
+    ctx.fillStyle = `hsl(${hue}, ${params.saturation}%, ${params.lightness}%)`;
+    ctx.beginPath();
+    ctx.arc(x, y, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Spiral Phyllotaxis',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 50, 4000, 10);
+gui.add(params, 'angle', 130, 145, 0.01);
+gui.add(params, 'spacing', 1, 20, 0.1);
+gui.add(params, 'dotSize', 0.5, 10, 0.1);
+gui.add(params, 'sizeGrow', 0, 0.01, 0.0005);
+gui.add(params, 'rotateSpeed', -1, 1, 0.01);
+gui.add(params, 'grow', 0, 2, 0.01);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueShift', 0, 3, 0.01);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 10, 90, 1);
+gui.add(params, 'bg', 0, 100, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.count = rand(400, 2400, 10);
+  params.angle = rand(135.5, 139, 0.01);
+  params.spacing = rand(3, 12, 0.1);
+  params.dotSize = rand(1.5, 5, 0.1);
+  params.rotateSpeed = rand(-0.3, 0.3, 0.01);
+  params.hue = rand(0, 360, 1);
+  params.hueShift = rand(0.1, 1.2, 0.01);
+  visible = 0;
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  visible = 0;
+  gui.updateDisplay();
+});

--- a/public/spiral-phyllotaxis/style.css
+++ b/public/spiral-phyllotaxis/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/superellipse/index.html
+++ b/public/superellipse/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Superellipse | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/superellipse/main.js
+++ b/public/superellipse/main.js
@@ -1,0 +1,147 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  n: 2.5, // 形状指数 |x|^n + |y|^n = 1
+  a: 0.42, // x 半径（画面短辺比）
+  b: 0.36, // y 半径
+  count: 24, // ネスト数
+  scaleStep: 0.9, // ネストごとの縮小率
+  rotateStep: 6, // ネストごとの回転（度）
+  rotateSpeed: 0.15, // 回転速度
+  morphSpeed: 0.3, // 形状モーフ速度
+  morphAmp: 0.8, // 形状モーフ振幅
+  hue: 280, // 色相
+  hueShift: 8, // ネストごとの色相シフト
+  lineWidth: 1.4, // 線の太さ
+  glow: 6, // グロー
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function step() {
+  time += 1 / 60;
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.fillStyle = '#08080c';
+  ctx.fillRect(0, 0, w, h);
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+
+  const baseR = Math.min(w, h);
+  const cx = w / 2;
+  const cy = h / 2;
+  const n = Math.max(
+    0.3,
+    params.n + Math.sin(time * params.morphSpeed) * params.morphAmp,
+  );
+
+  for (let i = 0; i < params.count; i++) {
+    const scale = params.scaleStep ** i;
+    const rot =
+      time * params.rotateSpeed + (i * params.rotateStep * Math.PI) / 180;
+    const hue = (params.hue + i * params.hueShift) % 360;
+    const stroke = `hsl(${hue}, 85%, 65%)`;
+    ctx.strokeStyle = stroke;
+    ctx.shadowColor = stroke;
+
+    ctx.beginPath();
+    const segs = 240;
+    for (let k = 0; k <= segs; k++) {
+      const t = (k / segs) * Math.PI * 2;
+      const ct = Math.cos(t);
+      const st = Math.sin(t);
+      const x =
+        Math.sign(ct) * Math.abs(ct) ** (2 / n) * params.a * baseR * scale;
+      const y =
+        Math.sign(st) * Math.abs(st) ** (2 / n) * params.b * baseR * scale;
+      const xr = x * Math.cos(rot) - y * Math.sin(rot);
+      const yr = x * Math.sin(rot) + y * Math.cos(rot);
+      if (k === 0) ctx.moveTo(cx + xr, cy + yr);
+      else ctx.lineTo(cx + xr, cy + yr);
+    }
+    ctx.stroke();
+  }
+  ctx.shadowBlur = 0;
+}
+
+function tick() {
+  step();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Superellipse',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'n', 0.3, 8, 0.05);
+gui.add(params, 'a', 0.1, 0.49, 0.01);
+gui.add(params, 'b', 0.1, 0.49, 0.01);
+gui.add(params, 'count', 1, 60, 1);
+gui.add(params, 'scaleStep', 0.5, 0.99, 0.005);
+gui.add(params, 'rotateStep', -30, 30, 0.5);
+gui.add(params, 'rotateSpeed', -2, 2, 0.01);
+gui.add(params, 'morphSpeed', 0, 2, 0.01);
+gui.add(params, 'morphAmp', 0, 3, 0.05);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueShift', 0, 40, 0.5);
+gui.add(params, 'lineWidth', 0.3, 5, 0.05);
+gui.add(params, 'glow', 0, 20, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.n = rand(0.6, 5, 0.05);
+  params.a = rand(0.25, 0.45, 0.01);
+  params.b = rand(0.25, 0.45, 0.01);
+  params.count = rand(12, 40, 1);
+  params.scaleStep = rand(0.82, 0.96, 0.005);
+  params.rotateStep = rand(-15, 15, 0.5);
+  params.rotateSpeed = rand(-1, 1, 0.01);
+  params.morphAmp = rand(0, 1.6, 0.05);
+  params.hue = rand(0, 360, 1);
+  params.hueShift = rand(0, 20, 0.5);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/superellipse/style.css
+++ b/public/superellipse/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/truchet-tiles/index.html
+++ b/public/truchet-tiles/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Truchet Tiles | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/truchet-tiles/main.js
+++ b/public/truchet-tiles/main.js
@@ -1,0 +1,152 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  tileSize: 56, // タイル 1 辺のピクセル数
+  lineWidth: 8, // 曲線の太さ
+  curveRatio: 1.0, // 曲線半径の比率（タイル半径に対する倍率）
+  bias: 0.5, // パターンの向きバイアス（0 or 1）
+  seed: 1, // シード
+  hue: 200, // 色相
+  hueShift: 30, // タイルごとの色相シフト
+  saturation: 50, // 彩度
+  lightness: 65, // 明度
+  bg: 8, // 背景の明度
+  rotate: 0, // 全体回転（度）
+  jitter: 0, // タイル位置ジッター
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  draw();
+}
+window.addEventListener('resize', resize);
+
+// --- 疑似乱数 ---
+let seedState = 1;
+function rng() {
+  seedState = (seedState * 1103515245 + 12345) & 0x7fffffff;
+  return seedState / 0x7fffffff;
+}
+
+function draw() {
+  seedState = Math.max(1, Math.floor(params.seed));
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.fillStyle = `hsl(0, 0%, ${params.bg}%)`;
+  ctx.fillRect(0, 0, w, h);
+
+  ctx.save();
+  ctx.translate(w / 2, h / 2);
+  ctx.rotate((params.rotate * Math.PI) / 180);
+  ctx.translate(-w / 2, -h / 2);
+
+  const ts = Math.max(8, params.tileSize);
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+
+  const cols = Math.ceil(w / ts) + 2;
+  const rows = Math.ceil(h / ts) + 2;
+  for (let j = -1; j < rows; j++) {
+    for (let i = -1; i < cols; i++) {
+      const x = i * ts + (rng() - 0.5) * params.jitter;
+      const y = j * ts + (rng() - 0.5) * params.jitter;
+      const hue = (params.hue + (i + j) * params.hueShift) % 360;
+      ctx.strokeStyle = `hsl(${hue}, ${params.saturation}%, ${params.lightness}%)`;
+      const flip = rng() < params.bias ? 0 : 1;
+      drawTile(x, y, ts, flip);
+    }
+  }
+  ctx.restore();
+}
+
+/**
+ * Truchet 曲線タイル
+ * @param {number} x
+ * @param {number} y
+ * @param {number} s
+ * @param {number} flip
+ */
+function drawTile(x, y, s, flip) {
+  const r = (s / 2) * params.curveRatio;
+  ctx.beginPath();
+  if (flip === 0) {
+    ctx.arc(x, y, r, 0, Math.PI / 2);
+    ctx.moveTo(x + s, y + s);
+    ctx.arc(x + s, y + s, r, Math.PI, (3 * Math.PI) / 2);
+  } else {
+    ctx.arc(x + s, y, r, Math.PI / 2, Math.PI);
+    ctx.moveTo(x, y + s);
+    ctx.arc(x, y + s, r, (3 * Math.PI) / 2, 2 * Math.PI);
+  }
+  ctx.stroke();
+}
+
+resize();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Truchet Tiles',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'tileSize', 16, 180, 1).onChange(draw);
+gui.add(params, 'lineWidth', 1, 30, 0.5).onChange(draw);
+gui.add(params, 'curveRatio', 0.3, 2, 0.05).onChange(draw);
+gui.add(params, 'bias', 0, 1, 0.01).onChange(draw);
+gui.add(params, 'seed', 1, 9999, 1).onChange(draw);
+gui.add(params, 'hue', 0, 360, 1).onChange(draw);
+gui.add(params, 'hueShift', 0, 60, 0.5).onChange(draw);
+gui.add(params, 'saturation', 0, 100, 1).onChange(draw);
+gui.add(params, 'lightness', 10, 90, 1).onChange(draw);
+gui.add(params, 'bg', 0, 100, 1).onChange(draw);
+gui.add(params, 'rotate', -180, 180, 1).onChange(draw);
+gui.add(params, 'jitter', 0, 20, 0.5).onChange(draw);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.tileSize = rand(32, 120, 1);
+  params.lineWidth = rand(2, 16, 0.5);
+  params.curveRatio = rand(0.5, 1.5, 0.05);
+  params.bias = rand(0.2, 0.8, 0.01);
+  params.seed = rand(1, 9999, 1);
+  params.hue = rand(0, 360, 1);
+  params.hueShift = rand(0, 40, 0.5);
+  params.saturation = rand(30, 80, 1);
+  draw();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  draw();
+  gui.updateDisplay();
+});

--- a/public/truchet-tiles/style.css
+++ b/public/truchet-tiles/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #08080c;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

Issue #153 のサブ issue から 10 件を選んで 1 つの PR にまとめました。各ページは TileUI（CDN）の 8〜12 コントロールと Random / Reset ボタンを備えています。

| Issue | ページ | パス |
| --- | --- | --- |
| #99  | Soap Film | `/soap-film/` |
| #103 | Ripple Pond | `/ripple-pond/` |
| #116 | Truchet Tiles | `/truchet-tiles/` |
| #123 | Harmonograph | `/harmonograph/` |
| #124 | Rose Curve | `/rose-curve/` |
| #126 | Superellipse | `/superellipse/` |
| #127 | Spiral Phyllotaxis | `/spiral-phyllotaxis/` |
| #138 | Meteor Shower | `/meteor-shower/` |
| #147 | Dragon Curve | `/dragon-curve/` |
| #148 | Koch Snowflake | `/koch-snowflake/` |

コミットはページ単位で 10 個に分割してあり、ページを外したくなった場合は該当コミットを `git revert` で取り除けます。

## Closes

Closes #99
Closes #103
Closes #116
Closes #123
Closes #124
Closes #126
Closes #127
Closes #138
Closes #147
Closes #148

## Test plan

- [ ] `npm run check` が通る
- [ ] 10 ページそれぞれの描画確認
- [ ] 各ページの TileUI コントロール（スライダー/ボタン）の動作確認
- [ ] Random / Reset ボタンの動作確認
- [ ] トップページのナビから各ページへ遷移できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)