### PR TITLE
feat: TileUI ジェネラティブアート 10 ページ追加 (Phase 2 第 2 弾)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@
 | `/dragon-curve/` | Dragon Curve（紙を折り畳んで展開するヘイウェイのドラゴン曲線） |
 | `/koch-snowflake/` | Koch Snowflake（辺を反復分割して形成するコッホ雪片フラクタル） |
 | `/lightning-strike/` | Lightning Strike（確率的に分岐しながら走る稲妻のジェネラティブアート） |
+| `/sand-dune/` | Sand Dune（風に流されて重なり合う砂丘の稜線ビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@
 | `/lava-flow/` | Lava Flow（メタボールで融合する溶岩流と黒皮のグラデーション） |
 | `/bubble-chamber/` | Bubble Chamber（磁場中の荷電粒子が描く螺旋軌跡の泡箱ビジュアル） |
 | `/convection-cell/` | Convection Cell（熱対流セルで渦を描く粒子のベナール対流ビジュアル） |
+| `/ice-crystal/` | Ice Crystal（6 回対称で再帰成長する雪の結晶フラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@
 | `/convection-cell/` | Convection Cell（熱対流セルで渦を描く粒子のベナール対流ビジュアル） |
 | `/ice-crystal/` | Ice Crystal（6 回対称で再帰成長する雪の結晶フラクタル） |
 | `/rainbow-prism/` | Rainbow Prism（入射光がプリズムで分散して虹色スペクトルになる光学ビジュアル） |
+| `/mirage-heat/` | Mirage Heat（熱気で地平線が揺らぐ蜃気楼のビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,7 @@
 | `/sand-dune/` | Sand Dune（風に流されて重なり合う砂丘の稜線ビジュアル） |
 | `/cloud-formation/` | Cloud Formation（パフの集合で形作る流れる雲のジェネレーティブアート） |
 | `/aurora-borealis/` | Aurora Borealis（夜空を流れるオーロラのリボンと星のビジュアル） |
+| `/lava-flow/` | Lava Flow（メタボールで融合する溶岩流と黒皮のグラデーション） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@
 | `/aurora-borealis/` | Aurora Borealis（夜空を流れるオーロラのリボンと星のビジュアル） |
 | `/lava-flow/` | Lava Flow（メタボールで融合する溶岩流と黒皮のグラデーション） |
 | `/bubble-chamber/` | Bubble Chamber（磁場中の荷電粒子が描く螺旋軌跡の泡箱ビジュアル） |
+| `/convection-cell/` | Convection Cell（熱対流セルで渦を描く粒子のベナール対流ビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,7 @@
 | `/meteor-shower/` | Meteor Shower（流星が尾を引いて降る夜空の流星群） |
 | `/dragon-curve/` | Dragon Curve（紙を折り畳んで展開するヘイウェイのドラゴン曲線） |
 | `/koch-snowflake/` | Koch Snowflake（辺を反復分割して形成するコッホ雪片フラクタル） |
+| `/lightning-strike/` | Lightning Strike（確率的に分岐しながら走る稲妻のジェネラティブアート） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,6 +75,7 @@
 | `/lightning-strike/` | Lightning Strike（確率的に分岐しながら走る稲妻のジェネラティブアート） |
 | `/sand-dune/` | Sand Dune（風に流されて重なり合う砂丘の稜線ビジュアル） |
 | `/cloud-formation/` | Cloud Formation（パフの集合で形作る流れる雲のジェネレーティブアート） |
+| `/aurora-borealis/` | Aurora Borealis（夜空を流れるオーロラのリボンと星のビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,7 @@
 | `/koch-snowflake/` | Koch Snowflake（辺を反復分割して形成するコッホ雪片フラクタル） |
 | `/lightning-strike/` | Lightning Strike（確率的に分岐しながら走る稲妻のジェネラティブアート） |
 | `/sand-dune/` | Sand Dune（風に流されて重なり合う砂丘の稜線ビジュアル） |
+| `/cloud-formation/` | Cloud Formation（パフの集合で形作る流れる雲のジェネレーティブアート） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@
 | `/cloud-formation/` | Cloud Formation（パフの集合で形作る流れる雲のジェネレーティブアート） |
 | `/aurora-borealis/` | Aurora Borealis（夜空を流れるオーロラのリボンと星のビジュアル） |
 | `/lava-flow/` | Lava Flow（メタボールで融合する溶岩流と黒皮のグラデーション） |
+| `/bubble-chamber/` | Bubble Chamber（磁場中の荷電粒子が描く螺旋軌跡の泡箱ビジュアル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@
 | `/bubble-chamber/` | Bubble Chamber（磁場中の荷電粒子が描く螺旋軌跡の泡箱ビジュアル） |
 | `/convection-cell/` | Convection Cell（熱対流セルで渦を描く粒子のベナール対流ビジュアル） |
 | `/ice-crystal/` | Ice Crystal（6 回対称で再帰成長する雪の結晶フラクタル） |
+| `/rainbow-prism/` | Rainbow Prism（入射光がプリズムで分散して虹色スペクトルになる光学ビジュアル） |
 
 ## トップページ仕様
 

--- a/public/aurora-borealis/index.html
+++ b/public/aurora-borealis/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Aurora Borealis | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/aurora-borealis/main.js
+++ b/public/aurora-borealis/main.js
@@ -1,0 +1,211 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  layers: 5, // オーロラ層数
+  ribbonHeight: 240, // リボンの高さ
+  waveAmp: 70, // 波の振幅
+  waveFreq: 0.006, // 波の周波数
+  flowSpeed: 0.5, // 流れの速度
+  hueGreen: 140, // 緑系の色相
+  huePurple: 290, // 紫系の色相
+  saturation: 90, // 彩度
+  intensity: 0.75, // 発光強度
+  starCount: 140, // 星の数
+  starTwinkle: 0.4, // 星の瞬き強度
+  groundDark: 0.85, // 地面の暗さ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  placeStars();
+}
+
+window.addEventListener('resize', resize);
+
+/** @type {Array<{x:number,y:number,r:number,phase:number}>} */
+let stars = [];
+function placeStars() {
+  stars = [];
+  const n = Math.round(params.starCount);
+  for (let i = 0; i < n; i++) {
+    stars.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height * 0.65,
+      r: Math.random() * 1.2 + 0.3,
+      phase: Math.random() * Math.PI * 2,
+    });
+  }
+}
+
+resize();
+
+// --- ノイズ ---
+
+/** @param {number} n */
+function hash(n) {
+  const x = Math.sin(n * 127.1) * 43758.5453123;
+  return x - Math.floor(x);
+}
+
+/** @param {number} x */
+function noise1d(x) {
+  const i = Math.floor(x);
+  const f = x - i;
+  const a = hash(i);
+  const b = hash(i + 1);
+  const u = f * f * (3 - 2 * f);
+  return a * (1 - u) + b * u;
+}
+
+// --- 描画 ---
+
+let time = 0;
+
+function drawSky() {
+  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  grad.addColorStop(0, '#01030d');
+  grad.addColorStop(0.6, '#05102a');
+  grad.addColorStop(1, '#020617');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function drawStars() {
+  for (const s of stars) {
+    const tw = 0.5 + 0.5 * Math.sin(time * 2 + s.phase) * params.starTwinkle;
+    ctx.fillStyle = `rgba(255, 255, 255, ${0.4 + 0.6 * tw})`;
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawAurora() {
+  ctx.globalCompositeOperation = 'lighter';
+  const layers = Math.max(1, Math.round(params.layers));
+  for (let l = 0; l < layers; l++) {
+    const t = l / Math.max(1, layers - 1);
+    const hue = params.hueGreen + (params.huePurple - params.hueGreen) * t;
+    const centerY = canvas.height * (0.3 + t * 0.15);
+    const height = params.ribbonHeight * (0.6 + t * 0.6);
+    const phaseOffset = l * 0.6 + time * params.flowSpeed;
+    // 線形グラデーションの塗り
+    for (let x = 0; x <= canvas.width; x += 3) {
+      const n1 = noise1d((x + phaseOffset * 200) * params.waveFreq + l);
+      const n2 = noise1d(
+        (x + phaseOffset * 400) * params.waveFreq * 0.5 + l * 3,
+      );
+      const waveY =
+        (n1 - 0.5) * params.waveAmp + (n2 - 0.5) * params.waveAmp * 0.6;
+      const top = centerY + waveY;
+      const bottom = top + height;
+      const grad = ctx.createLinearGradient(0, top, 0, bottom);
+      const alpha = params.intensity * (0.4 + 0.6 * n1);
+      grad.addColorStop(0, `hsla(${hue}, ${params.saturation}%, 50%, 0)`);
+      grad.addColorStop(
+        0.4,
+        `hsla(${hue}, ${params.saturation}%, 55%, ${alpha})`,
+      );
+      grad.addColorStop(1, `hsla(${hue + 20}, ${params.saturation}%, 40%, 0)`);
+      ctx.fillStyle = grad;
+      ctx.fillRect(x, top, 4, height);
+    }
+  }
+  ctx.globalCompositeOperation = 'source-over';
+}
+
+function drawGround() {
+  const grad = ctx.createLinearGradient(
+    0,
+    canvas.height * 0.75,
+    0,
+    canvas.height,
+  );
+  grad.addColorStop(0, `rgba(2, 6, 20, ${params.groundDark})`);
+  grad.addColorStop(1, '#000');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, canvas.height * 0.75, canvas.width, canvas.height * 0.25);
+}
+
+function draw() {
+  time += 1 / 60;
+  drawSky();
+  drawStars();
+  drawAurora();
+  drawGround();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Aurora Borealis',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'layers', 1, 10, 1);
+gui.add(params, 'ribbonHeight', 60, 500, 5);
+gui.add(params, 'waveAmp', 10, 200, 1);
+gui.add(params, 'waveFreq', 0.001, 0.02, 0.0005);
+gui.add(params, 'flowSpeed', 0, 2, 0.01);
+gui.add(params, 'hueGreen', 80, 200, 1);
+gui.add(params, 'huePurple', 240, 340, 1);
+gui.add(params, 'saturation', 30, 100, 1);
+gui.add(params, 'intensity', 0.1, 1.5, 0.01);
+gui.add(params, 'starCount', 0, 400, 5).onChange(placeStars);
+gui.add(params, 'starTwinkle', 0, 1, 0.01);
+gui.add(params, 'groundDark', 0, 1, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.layers = rand(3, 7, 1);
+  params.ribbonHeight = rand(120, 350, 5);
+  params.waveAmp = rand(30, 120, 1);
+  params.waveFreq = rand(0.003, 0.012, 0.0005);
+  params.flowSpeed = rand(0.2, 1, 0.01);
+  params.hueGreen = rand(110, 170, 1);
+  params.huePurple = rand(260, 320, 1);
+  params.saturation = rand(70, 100, 1);
+  params.intensity = rand(0.4, 1.1, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  placeStars();
+  gui.updateDisplay();
+});

--- a/public/aurora-borealis/style.css
+++ b/public/aurora-borealis/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #020617;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #aaa;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/bubble-chamber/index.html
+++ b/public/bubble-chamber/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Bubble Chamber | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/bubble-chamber/main.js
+++ b/public/bubble-chamber/main.js
@@ -1,0 +1,198 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  particleCount: 30, // 粒子数
+  fieldStrength: 0.04, // 磁場によるローレンツ力
+  speed: 2.8, // 初速
+  drag: 0.002, // 抵抗（螺旋を縮めていく）
+  lineWidth: 1.2, // 軌跡線幅
+  fadeSpeed: 0.015, // 残像フェード
+  emitRate: 0.4, // 新粒子の発生率
+  hueStart: 200, // 軌跡色相（開始）
+  hueEnd: 320, // 軌跡色相（終端）
+  bubbleSize: 2.0, // 散発する泡サイズ
+  bubbleChance: 0.08, // 泡発生確率
+  glow: 6, // グロー強度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  clearBg();
+}
+
+function clearBg() {
+  ctx.fillStyle = '#04050a';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Array<{x:number,y:number,vx:number,vy:number,charge:number,life:number,maxLife:number,hue:number}>} */
+let particles = [];
+
+function spawn() {
+  const n = Math.max(0, Math.round(params.particleCount));
+  while (particles.length < n) {
+    const ang = Math.random() * Math.PI * 2;
+    const s = params.speed * (0.6 + Math.random() * 0.8);
+    particles.push({
+      x: canvas.width / 2 + (Math.random() - 0.5) * 40,
+      y: canvas.height / 2 + (Math.random() - 0.5) * 40,
+      vx: Math.cos(ang) * s,
+      vy: Math.sin(ang) * s,
+      charge: Math.random() < 0.5 ? 1 : -1,
+      life: 0,
+      maxLife: 400 + Math.random() * 600,
+      hue: params.hueStart + Math.random() * (params.hueEnd - params.hueStart),
+    });
+  }
+}
+
+spawn();
+
+// --- ループ ---
+
+function update() {
+  // 新規発生
+  if (Math.random() < params.emitRate) spawn();
+
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    // ローレンツ力（磁場を画面外向きと仮定: v x B -> 垂直回転）
+    const fx = -p.vy * params.fieldStrength * p.charge;
+    const fy = p.vx * params.fieldStrength * p.charge;
+    p.vx += fx;
+    p.vy += fy;
+    // 抵抗
+    p.vx *= 1 - params.drag;
+    p.vy *= 1 - params.drag;
+    const nx = p.x + p.vx;
+    const ny = p.y + p.vy;
+    // 軌跡描画
+    const t = p.life / p.maxLife;
+    const hue = p.hue + t * 60;
+    const alpha = 1 - t;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 70%, ${alpha})`;
+    ctx.lineWidth = Math.max(0.0625, params.lineWidth);
+    ctx.shadowBlur = params.glow;
+    ctx.shadowColor = `hsla(${hue}, 90%, 70%, ${alpha})`;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(nx, ny);
+    ctx.stroke();
+    // 散発する泡
+    if (Math.random() < params.bubbleChance) {
+      ctx.fillStyle = `hsla(${hue}, 70%, 85%, ${alpha * 0.7})`;
+      ctx.beginPath();
+      ctx.arc(
+        nx,
+        ny,
+        params.bubbleSize * (0.5 + Math.random()),
+        0,
+        Math.PI * 2,
+      );
+      ctx.fill();
+    }
+    p.x = nx;
+    p.y = ny;
+    p.life += 1;
+    // 範囲外または寿命切れ
+    if (
+      p.life > p.maxLife ||
+      nx < -50 ||
+      nx > canvas.width + 50 ||
+      ny < -50 ||
+      ny > canvas.height + 50
+    ) {
+      particles.splice(i, 1);
+    }
+  }
+  ctx.shadowBlur = 0;
+}
+
+function draw() {
+  // 残像フェード
+  ctx.fillStyle = `rgba(4, 5, 10, ${params.fadeSpeed})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  update();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Bubble Chamber',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'particleCount', 5, 120, 1);
+gui.add(params, 'fieldStrength', -0.15, 0.15, 0.002);
+gui.add(params, 'speed', 0.5, 8, 0.1);
+gui.add(params, 'drag', 0, 0.02, 0.001);
+gui.add(params, 'lineWidth', 0.25, 4, 0.05);
+gui.add(params, 'fadeSpeed', 0.002, 0.1, 0.002);
+gui.add(params, 'emitRate', 0, 2, 0.05);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'bubbleSize', 0.5, 6, 0.1);
+gui.add(params, 'bubbleChance', 0, 0.4, 0.01);
+gui.add(params, 'glow', 0, 20, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.particleCount = rand(15, 60, 1);
+  params.fieldStrength = rand(-0.1, 0.1, 0.002);
+  params.speed = rand(1.5, 5, 0.1);
+  params.drag = rand(0.0005, 0.01, 0.001);
+  params.emitRate = rand(0.1, 1, 0.05);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Clear', () => {
+  particles = [];
+  clearBg();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  particles = [];
+  clearBg();
+  gui.updateDisplay();
+});

--- a/public/bubble-chamber/style.css
+++ b/public/bubble-chamber/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #04050a;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #aab;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0ff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/cloud-formation/index.html
+++ b/public/cloud-formation/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Cloud Formation | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/cloud-formation/main.js
+++ b/public/cloud-formation/main.js
@@ -1,0 +1,227 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  puffCount: 120, // 雲を構成する球の数
+  radiusMin: 30, // 最小半径
+  radiusMax: 90, // 最大半径
+  spreadX: 420, // 雲塊の横幅
+  spreadY: 110, // 雲塊の縦幅
+  cloudCount: 4, // 雲の数
+  driftSpeed: 0.25, // 風速
+  morph: 0.6, // 形状の揺らぎ量
+  skyTop: 210, // 空の上部色相
+  skyBottom: 195, // 空の下部色相
+  cloudBright: 92, // 雲の明度
+  shadow: 0.25, // 影の強さ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {Object} Puff
+ * @property {number} ox オフセット X
+ * @property {number} oy オフセット Y
+ * @property {number} r 半径
+ * @property {number} phase フェーズ
+ */
+
+/**
+ * @typedef {Object} Cloud
+ * @property {number} x 中心 X
+ * @property {number} y 中心 Y
+ * @property {number} vx 速度
+ * @property {number} depth 奥行き 0..1
+ * @property {Puff[]} puffs パフ配列
+ */
+
+/** @type {Cloud[]} */
+let clouds = [];
+
+function rebuildClouds() {
+  clouds = [];
+  const n = Math.max(1, Math.round(params.cloudCount));
+  for (let i = 0; i < n; i++) {
+    const depth = Math.random();
+    /** @type {Puff[]} */
+    const puffs = [];
+    const pn = Math.max(3, Math.round(params.puffCount / n));
+    for (let j = 0; j < pn; j++) {
+      puffs.push({
+        ox: (Math.random() - 0.5) * params.spreadX,
+        oy: (Math.random() - 0.5) * params.spreadY,
+        r:
+          params.radiusMin +
+          Math.random() * (params.radiusMax - params.radiusMin),
+        phase: Math.random() * Math.PI * 2,
+      });
+    }
+    clouds.push({
+      x: Math.random() * canvas.width,
+      y: canvas.height * (0.2 + depth * 0.5),
+      vx: (0.3 + depth * 0.7) * (1 + Math.random() * 0.4),
+      depth,
+      puffs,
+    });
+  }
+}
+
+rebuildClouds();
+
+// --- 描画 ---
+
+let time = 0;
+
+function drawSky() {
+  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  grad.addColorStop(0, `hsl(${params.skyTop}, 65%, 45%)`);
+  grad.addColorStop(1, `hsl(${params.skyBottom}, 50%, 75%)`);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+/** @param {Cloud} cloud */
+function drawCloud(cloud) {
+  const scale = 0.5 + cloud.depth * 0.8;
+  const light = params.cloudBright - (1 - cloud.depth) * 15;
+  // 影
+  ctx.fillStyle = `hsla(220, 30%, 40%, ${params.shadow})`;
+  for (const p of cloud.puffs) {
+    const morph = Math.sin(time * 0.8 + p.phase) * params.morph * 6;
+    const r = (p.r + morph) * scale;
+    ctx.beginPath();
+    ctx.arc(
+      cloud.x + p.ox * scale + 6,
+      cloud.y + p.oy * scale + 8,
+      r,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  }
+  // 本体
+  ctx.fillStyle = `hsl(210, 15%, ${light}%)`;
+  for (const p of cloud.puffs) {
+    const morph = Math.sin(time * 0.8 + p.phase) * params.morph * 6;
+    const r = (p.r + morph) * scale;
+    ctx.beginPath();
+    ctx.arc(cloud.x + p.ox * scale, cloud.y + p.oy * scale, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  // ハイライト
+  ctx.fillStyle = `hsla(60, 30%, 98%, 0.4)`;
+  for (const p of cloud.puffs) {
+    const r = p.r * scale * 0.5;
+    ctx.beginPath();
+    ctx.arc(
+      cloud.x + p.ox * scale - 3,
+      cloud.y + p.oy * scale - 4,
+      r,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  }
+}
+
+function update() {
+  time += 1 / 60;
+  for (const cloud of clouds) {
+    cloud.x += cloud.vx * params.driftSpeed;
+    if (cloud.x - params.spreadX > canvas.width) {
+      cloud.x = -params.spreadX;
+      cloud.y = canvas.height * (0.2 + cloud.depth * 0.5);
+    }
+  }
+}
+
+function draw() {
+  drawSky();
+  // 奥から手前へ描画
+  clouds.sort((a, b) => a.depth - b.depth);
+  for (const cloud of clouds) {
+    drawCloud(cloud);
+  }
+}
+
+function tick() {
+  update();
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Cloud Formation',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'puffCount', 20, 400, 1).onChange(rebuildClouds);
+gui.add(params, 'radiusMin', 5, 100, 1).onChange(rebuildClouds);
+gui.add(params, 'radiusMax', 20, 200, 1).onChange(rebuildClouds);
+gui.add(params, 'spreadX', 100, 800, 10).onChange(rebuildClouds);
+gui.add(params, 'spreadY', 30, 300, 5).onChange(rebuildClouds);
+gui.add(params, 'cloudCount', 1, 12, 1).onChange(rebuildClouds);
+gui.add(params, 'driftSpeed', 0, 2, 0.01);
+gui.add(params, 'morph', 0, 2, 0.01);
+gui.add(params, 'skyTop', 150, 260, 1);
+gui.add(params, 'skyBottom', 150, 260, 1);
+gui.add(params, 'cloudBright', 60, 100, 1);
+gui.add(params, 'shadow', 0, 0.6, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.puffCount = rand(60, 200, 1);
+  params.radiusMin = rand(15, 50, 1);
+  params.radiusMax = rand(60, 120, 1);
+  params.spreadX = rand(200, 600, 10);
+  params.spreadY = rand(60, 160, 5);
+  params.cloudCount = rand(3, 8, 1);
+  params.driftSpeed = rand(0.1, 0.8, 0.01);
+  params.morph = rand(0.2, 1.2, 0.01);
+  params.skyTop = rand(190, 240, 1);
+  params.skyBottom = rand(180, 220, 1);
+  rebuildClouds();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuildClouds();
+  gui.updateDisplay();
+});

--- a/public/cloud-formation/style.css
+++ b/public/cloud-formation/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #4a7ea8;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0f0ff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/convection-cell/index.html
+++ b/public/convection-cell/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Convection Cell | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/convection-cell/main.js
+++ b/public/convection-cell/main.js
@@ -1,0 +1,210 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  cellCols: 5, // セル列数
+  cellRows: 3, // セル行数
+  particleCount: 1500, // 粒子数
+  rotationSpeed: 0.8, // 回転速度
+  wobble: 0.3, // ゆらぎ
+  hueHot: 20, // 高温色相（上昇流）
+  hueCold: 210, // 低温色相（下降流）
+  particleSize: 1.5, // 粒子サイズ
+  fade: 0.08, // 残像フェード
+  showCell: 0.15, // セル境界表示
+  turbulence: 0.05, // 乱流量
+  glow: 4, // グロー
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Array<{x:number,y:number,vx:number,vy:number}>} */
+let particles = [];
+
+function initParticles() {
+  particles = [];
+  const n = Math.max(1, Math.round(params.particleCount));
+  for (let i = 0; i < n; i++) {
+    particles.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: 0,
+      vy: 0,
+    });
+  }
+}
+
+initParticles();
+
+// --- 対流ベクトル場 ---
+
+/**
+ * 対流セルのベクトル
+ * @param {number} x
+ * @param {number} y
+ * @returns {[number, number, number]} [vx, vy, temperature]
+ */
+function flowField(x, y) {
+  const cols = Math.max(1, Math.round(params.cellCols));
+  const rows = Math.max(1, Math.round(params.cellRows));
+  const cw = canvas.width / cols;
+  const ch = canvas.height / rows;
+  const cx = Math.floor(x / cw);
+  const cy = Math.floor(y / ch);
+  const lx = (x - cx * cw) / cw; // 0..1
+  const ly = (y - cy * ch) / ch;
+  // セルごとに交互に回転方向
+  const dir = (cx + cy) % 2 === 0 ? 1 : -1;
+  // 中心 (0.5, 0.5) からの角度で渦を作る
+  const dx = lx - 0.5;
+  const dy = ly - 0.5;
+  const vx = -dy * dir * params.rotationSpeed;
+  const vy = dx * dir * params.rotationSpeed;
+  // 温度: 上昇中は高温、下降中は低温
+  const temp = dir > 0 ? 0.5 - dy : 0.5 + dy;
+  return [vx, vy, temp];
+}
+
+// --- ループ ---
+
+let time = 0;
+
+function update() {
+  time += 1 / 60;
+  for (const p of particles) {
+    const [fx, fy, temp] = flowField(p.x, p.y);
+    // ゆらぎ
+    const wob = params.wobble;
+    const wx = Math.sin(time * 0.8 + p.y * 0.01) * wob;
+    const wy = Math.cos(time * 0.9 + p.x * 0.01) * wob;
+    // 乱流
+    const tx = (Math.random() - 0.5) * params.turbulence;
+    const ty = (Math.random() - 0.5) * params.turbulence;
+    p.vx = fx + wx + tx;
+    p.vy = fy + wy + ty;
+    p.x += p.vx;
+    p.y += p.vy;
+    // ループ
+    if (p.x < 0) p.x += canvas.width;
+    if (p.x > canvas.width) p.x -= canvas.width;
+    if (p.y < 0) p.y += canvas.height;
+    if (p.y > canvas.height) p.y -= canvas.height;
+    // 描画
+    const hue = params.hueCold + (params.hueHot - params.hueCold) * temp;
+    ctx.fillStyle = `hsla(${hue}, 85%, 60%, 0.8)`;
+    if (params.glow > 0) {
+      ctx.shadowBlur = params.glow;
+      ctx.shadowColor = `hsla(${hue}, 85%, 60%, 0.8)`;
+    }
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, params.particleSize, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.shadowBlur = 0;
+}
+
+function drawCellGrid() {
+  if (params.showCell <= 0) return;
+  const cols = Math.max(1, Math.round(params.cellCols));
+  const rows = Math.max(1, Math.round(params.cellRows));
+  ctx.strokeStyle = `rgba(255, 200, 180, ${params.showCell})`;
+  ctx.lineWidth = 1;
+  for (let i = 1; i < cols; i++) {
+    const x = (canvas.width / cols) * i;
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, canvas.height);
+    ctx.stroke();
+  }
+  for (let i = 1; i < rows; i++) {
+    const y = (canvas.height / rows) * i;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvas.width, y);
+    ctx.stroke();
+  }
+}
+
+function draw() {
+  ctx.fillStyle = `rgba(10, 5, 8, ${params.fade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  drawCellGrid();
+  update();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Convection Cell',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'cellCols', 1, 10, 1);
+gui.add(params, 'cellRows', 1, 8, 1);
+gui.add(params, 'particleCount', 100, 5000, 50).onChange(initParticles);
+gui.add(params, 'rotationSpeed', 0, 3, 0.05);
+gui.add(params, 'wobble', 0, 1.5, 0.01);
+gui.add(params, 'hueHot', 0, 60, 1);
+gui.add(params, 'hueCold', 180, 260, 1);
+gui.add(params, 'particleSize', 0.5, 4, 0.1);
+gui.add(params, 'fade', 0.02, 0.3, 0.01);
+gui.add(params, 'showCell', 0, 0.5, 0.01);
+gui.add(params, 'turbulence', 0, 0.3, 0.005);
+gui.add(params, 'glow', 0, 15, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.cellCols = rand(3, 8, 1);
+  params.cellRows = rand(2, 5, 1);
+  params.rotationSpeed = rand(0.3, 1.8, 0.05);
+  params.wobble = rand(0.1, 0.8, 0.01);
+  params.hueHot = rand(5, 45, 1);
+  params.hueCold = rand(190, 240, 1);
+  params.turbulence = rand(0.02, 0.15, 0.005);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initParticles();
+  gui.updateDisplay();
+});

--- a/public/convection-cell/style.css
+++ b/public/convection-cell/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0a0508;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #d8b0a0;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #ffcfb8;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/ice-crystal/index.html
+++ b/public/ice-crystal/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Ice Crystal | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/ice-crystal/main.js
+++ b/public/ice-crystal/main.js
@@ -40,28 +40,23 @@ let time = 0;
 let growth = 0; // 0..1
 
 /**
- * 枝を描く（再帰）
+ * 枝を Path に積む（再帰）。層ごとにまとめて 1 回だけ stroke することで
+ * shadowBlur の適用回数を depth 回に抑える。
+ * @param {Path2D[]} paths
  * @param {number} x
  * @param {number} y
  * @param {number} angle
  * @param {number} length
  * @param {number} depthLeft
  */
-function drawBranch(x, y, angle, length, depthLeft) {
+function collectBranch(paths, x, y, angle, length, depthLeft) {
   if (depthLeft <= 0 || length < 1) return;
   const nx = x + Math.cos(angle) * length;
   const ny = y + Math.sin(angle) * length;
   const depthIdx = Math.round(params.depth) - depthLeft;
-  const hue = params.hueBase + depthIdx * params.hueShift;
-  ctx.strokeStyle = `hsla(${hue}, 65%, 80%, ${0.55 + 0.45 * (depthLeft / params.depth)})`;
-  ctx.lineWidth = Math.max(
-    0.0625,
-    params.lineWidth * (depthLeft / params.depth + 0.3),
-  );
-  ctx.beginPath();
-  ctx.moveTo(x, y);
-  ctx.lineTo(nx, ny);
-  ctx.stroke();
+  const path = paths[depthIdx];
+  path.moveTo(x, y);
+  path.lineTo(nx, ny);
 
   // 側枝
   const sideAngRad = (params.sideAngle * Math.PI) / 180;
@@ -71,14 +66,30 @@ function drawBranch(x, y, angle, length, depthLeft) {
     const sx = x + Math.cos(angle) * length * t;
     const sy = y + Math.sin(angle) * length * t;
     const sideLen = length * params.branchRatio * (1 - t * 0.3);
-    drawBranch(sx, sy, angle - sideAngRad, sideLen, depthLeft - 1);
-    drawBranch(sx, sy, angle + sideAngRad, sideLen, depthLeft - 1);
+    collectBranch(paths, sx, sy, angle - sideAngRad, sideLen, depthLeft - 1);
+    collectBranch(paths, sx, sy, angle + sideAngRad, sideLen, depthLeft - 1);
   }
 
-  // 先端の分岐
-  const tipLen = length * params.tipSplit;
-  drawBranch(nx, ny, angle - sideAngRad * 0.4, tipLen, depthLeft - 1);
-  drawBranch(nx, ny, angle + sideAngRad * 0.4, tipLen, depthLeft - 1);
+  // 先端の分岐（先端のみ：再帰爆発を避けるため tipSplit=0 ならスキップ）
+  if (params.tipSplit > 0.01) {
+    const tipLen = length * params.tipSplit;
+    collectBranch(
+      paths,
+      nx,
+      ny,
+      angle - sideAngRad * 0.4,
+      tipLen,
+      depthLeft - 1,
+    );
+    collectBranch(
+      paths,
+      nx,
+      ny,
+      angle + sideAngRad * 0.4,
+      tipLen,
+      depthLeft - 1,
+    );
+  }
 }
 
 function drawBackground() {
@@ -110,10 +121,23 @@ function draw() {
   ctx.lineCap = 'round';
   ctx.shadowBlur = params.glow;
   ctx.shadowColor = `hsl(${params.hueBase}, 70%, 85%)`;
-  // 6 回対称（雪の結晶）
+
+  // 層ごとに Path をまとめ、層単位で 1 回だけ stroke する
+  const depthI = Math.round(params.depth);
+  const paths = Array.from({ length: depthI }, () => new Path2D());
   for (let i = 0; i < 6; i++) {
     const angle = (i / 6) * Math.PI * 2;
-    drawBranch(0, 0, angle, effectiveLen, Math.round(params.depth));
+    collectBranch(paths, 0, 0, angle, effectiveLen, depthI);
+  }
+  for (let d = 0; d < depthI; d++) {
+    const depthLeft = depthI - d;
+    const hue = params.hueBase + d * params.hueShift;
+    ctx.strokeStyle = `hsla(${hue}, 65%, 80%, ${0.55 + 0.45 * (depthLeft / depthI)})`;
+    ctx.lineWidth = Math.max(
+      0.0625,
+      params.lineWidth * (depthLeft / depthI + 0.3),
+    );
+    ctx.stroke(paths[d]);
   }
   ctx.shadowBlur = 0;
   ctx.restore();

--- a/public/ice-crystal/main.js
+++ b/public/ice-crystal/main.js
@@ -1,0 +1,187 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  depth: 5, // 再帰深度
+  branchLength: 160, // 主軸長
+  branchRatio: 0.55, // 枝比率
+  sideAngle: 60, // 側枝角度（度）
+  sideCount: 3, // 片側の側枝数
+  tipSplit: 0.7, // 先端の分岐比
+  growthSpeed: 0.008, // 成長アニメ速度
+  rotation: 0.05, // 緩やかな回転速度
+  hueBase: 200, // 基調色相
+  hueShift: 18, // 層間色相差
+  lineWidth: 1.1, // 線幅
+  glow: 10, // グロー
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画 ---
+
+let time = 0;
+let growth = 0; // 0..1
+
+/**
+ * 枝を描く（再帰）
+ * @param {number} x
+ * @param {number} y
+ * @param {number} angle
+ * @param {number} length
+ * @param {number} depthLeft
+ */
+function drawBranch(x, y, angle, length, depthLeft) {
+  if (depthLeft <= 0 || length < 1) return;
+  const nx = x + Math.cos(angle) * length;
+  const ny = y + Math.sin(angle) * length;
+  const depthIdx = Math.round(params.depth) - depthLeft;
+  const hue = params.hueBase + depthIdx * params.hueShift;
+  ctx.strokeStyle = `hsla(${hue}, 65%, 80%, ${0.55 + 0.45 * (depthLeft / params.depth)})`;
+  ctx.lineWidth = Math.max(
+    0.0625,
+    params.lineWidth * (depthLeft / params.depth + 0.3),
+  );
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(nx, ny);
+  ctx.stroke();
+
+  // 側枝
+  const sideAngRad = (params.sideAngle * Math.PI) / 180;
+  const sides = Math.max(1, Math.round(params.sideCount));
+  for (let i = 1; i <= sides; i++) {
+    const t = i / (sides + 1);
+    const sx = x + Math.cos(angle) * length * t;
+    const sy = y + Math.sin(angle) * length * t;
+    const sideLen = length * params.branchRatio * (1 - t * 0.3);
+    drawBranch(sx, sy, angle - sideAngRad, sideLen, depthLeft - 1);
+    drawBranch(sx, sy, angle + sideAngRad, sideLen, depthLeft - 1);
+  }
+
+  // 先端の分岐
+  const tipLen = length * params.tipSplit;
+  drawBranch(nx, ny, angle - sideAngRad * 0.4, tipLen, depthLeft - 1);
+  drawBranch(nx, ny, angle + sideAngRad * 0.4, tipLen, depthLeft - 1);
+}
+
+function drawBackground() {
+  const grad = ctx.createRadialGradient(
+    canvas.width / 2,
+    canvas.height / 2,
+    0,
+    canvas.width / 2,
+    canvas.height / 2,
+    Math.max(canvas.width, canvas.height) / 2,
+  );
+  grad.addColorStop(0, `hsl(${params.hueBase}, 40%, 16%)`);
+  grad.addColorStop(1, '#030508');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function draw() {
+  time += 1 / 60;
+  growth = Math.min(1, growth + params.growthSpeed);
+
+  drawBackground();
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const effectiveLen = params.branchLength * growth;
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(time * params.rotation);
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+  ctx.shadowColor = `hsl(${params.hueBase}, 70%, 85%)`;
+  // 6 回対称（雪の結晶）
+  for (let i = 0; i < 6; i++) {
+    const angle = (i / 6) * Math.PI * 2;
+    drawBranch(0, 0, angle, effectiveLen, Math.round(params.depth));
+  }
+  ctx.shadowBlur = 0;
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Ice Crystal',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 1, 7, 1);
+gui.add(params, 'branchLength', 40, 320, 2);
+gui.add(params, 'branchRatio', 0.2, 0.85, 0.01);
+gui.add(params, 'sideAngle', 15, 85, 1);
+gui.add(params, 'sideCount', 0, 5, 1);
+gui.add(params, 'tipSplit', 0, 0.95, 0.01);
+gui.add(params, 'growthSpeed', 0.002, 0.05, 0.002);
+gui.add(params, 'rotation', -0.2, 0.2, 0.005);
+gui.add(params, 'hueBase', 160, 260, 1);
+gui.add(params, 'hueShift', -30, 30, 1);
+gui.add(params, 'lineWidth', 0.25, 3, 0.05);
+gui.add(params, 'glow', 0, 30, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(3, 6, 1);
+  params.branchLength = rand(100, 220, 2);
+  params.branchRatio = rand(0.35, 0.7, 0.01);
+  params.sideAngle = rand(30, 75, 1);
+  params.sideCount = rand(1, 4, 1);
+  params.tipSplit = rand(0.3, 0.8, 0.01);
+  params.hueBase = rand(180, 240, 1);
+  params.hueShift = rand(-20, 20, 1);
+  growth = 0;
+  gui.updateDisplay();
+});
+
+gui.addButton('Regrow', () => {
+  growth = 0;
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  growth = 0;
+  gui.updateDisplay();
+});

--- a/public/ice-crystal/style.css
+++ b/public/ice-crystal/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #081018;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #a0c8e0;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #d8f0ff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -601,6 +601,12 @@
               <span class="nav-description">入射光がプリズムで分散して虹色スペクトルになる光学ビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/mirage-heat/">
+              Mirage Heat
+              <span class="nav-description">熱気で地平線が揺らぐ蜃気楼のビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -547,6 +547,12 @@
               <span class="nav-description">辺を反復分割して形成するコッホ雪片フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/lightning-strike/">
+              Lightning Strike
+              <span class="nav-description">確率的に分岐しながら走る稲妻のジェネラティブアート</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -589,6 +589,12 @@
               <span class="nav-description">熱対流セルで渦を描く粒子のベナール対流ビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/ice-crystal/">
+              Ice Crystal
+              <span class="nav-description">6 回対称で再帰成長する雪の結晶フラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -595,6 +595,12 @@
               <span class="nav-description">6 回対称で再帰成長する雪の結晶フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/rainbow-prism/">
+              Rainbow Prism
+              <span class="nav-description">入射光がプリズムで分散して虹色スペクトルになる光学ビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -565,6 +565,12 @@
               <span class="nav-description">パフの集合で形作る流れる雲のジェネレーティブアート</span>
             </a>
           </li>
+          <li>
+            <a href="/aurora-borealis/">
+              Aurora Borealis
+              <span class="nav-description">夜空を流れるオーロラのリボンと星のビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -583,6 +583,12 @@
               <span class="nav-description">磁場中の荷電粒子が描く螺旋軌跡の泡箱ビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/convection-cell/">
+              Convection Cell
+              <span class="nav-description">熱対流セルで渦を描く粒子のベナール対流ビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -559,6 +559,12 @@
               <span class="nav-description">風に流されて重なり合う砂丘の稜線ビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/cloud-formation/">
+              Cloud Formation
+              <span class="nav-description">パフの集合で形作る流れる雲のジェネレーティブアート</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -553,6 +553,12 @@
               <span class="nav-description">確率的に分岐しながら走る稲妻のジェネラティブアート</span>
             </a>
           </li>
+          <li>
+            <a href="/sand-dune/">
+              Sand Dune
+              <span class="nav-description">風に流されて重なり合う砂丘の稜線ビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -571,6 +571,12 @@
               <span class="nav-description">夜空を流れるオーロラのリボンと星のビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/lava-flow/">
+              Lava Flow
+              <span class="nav-description">メタボールで融合する溶岩流と黒皮のグラデーション</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -577,6 +577,12 @@
               <span class="nav-description">メタボールで融合する溶岩流と黒皮のグラデーション</span>
             </a>
           </li>
+          <li>
+            <a href="/bubble-chamber/">
+              Bubble Chamber
+              <span class="nav-description">磁場中の荷電粒子が描く螺旋軌跡の泡箱ビジュアル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/lava-flow/index.html
+++ b/public/lava-flow/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Lava Flow | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/lava-flow/main.js
+++ b/public/lava-flow/main.js
@@ -1,0 +1,251 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  blobCount: 14, // 溶岩ブロブ数
+  radiusMin: 60, // ブロブ最小半径
+  radiusMax: 140, // ブロブ最大半径
+  threshold: 0.55, // メタボール閾値
+  gridSize: 6, // サンプル粒度（小さいほど高精細）
+  flowSpeed: 0.35, // 流れの速さ
+  heatHue: 18, // 高温側色相
+  coolHue: 348, // 低温側色相
+  glow: 18, // グロー強度
+  crust: 0.4, // 黒い皮の厚み
+  pulse: 0.3, // 脈動強度
+  trail: 0.12, // 残像フェード
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Array<{x:number,y:number,vx:number,vy:number,r:number,phase:number}>} */
+let blobs = [];
+
+function initBlobs() {
+  blobs = [];
+  const n = Math.max(1, Math.round(params.blobCount));
+  for (let i = 0; i < n; i++) {
+    blobs.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: (Math.random() - 0.5) * 0.6,
+      vy: (Math.random() - 0.5) * 0.6,
+      r:
+        params.radiusMin +
+        Math.random() * (params.radiusMax - params.radiusMin),
+      phase: Math.random() * Math.PI * 2,
+    });
+  }
+}
+
+initBlobs();
+
+// --- 描画 ---
+
+let time = 0;
+
+function update() {
+  time += 1 / 60;
+  for (const b of blobs) {
+    b.x += b.vx * params.flowSpeed;
+    b.y += b.vy * params.flowSpeed;
+    // 反射
+    if (b.x < -b.r) b.x = canvas.width + b.r;
+    if (b.x > canvas.width + b.r) b.x = -b.r;
+    if (b.y < -b.r) b.y = canvas.height + b.r;
+    if (b.y > canvas.height + b.r) b.y = -b.r;
+  }
+}
+
+function draw() {
+  // 残像
+  ctx.fillStyle = `rgba(26, 5, 5, ${params.trail})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const step = Math.max(2, Math.round(params.gridSize));
+  const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const data = img.data;
+
+  for (let py = 0; py < canvas.height; py += step) {
+    for (let px = 0; px < canvas.width; px += step) {
+      let sum = 0;
+      for (const b of blobs) {
+        const dx = px - b.x;
+        const dy = py - b.y;
+        const d2 = dx * dx + dy * dy;
+        const r = b.r * (1 + Math.sin(time * 2 + b.phase) * params.pulse * 0.1);
+        sum += (r * r) / Math.max(1, d2);
+      }
+      if (sum > params.threshold) {
+        const heat = Math.min(1, (sum - params.threshold) * 1.5);
+        // 黒い皮
+        if (heat < params.crust) {
+          const t = heat / params.crust;
+          const r = Math.round(40 * t);
+          const g = Math.round(10 * t);
+          const b = Math.round(5 * t);
+          fillCell(data, px, py, step, r, g, b);
+        } else {
+          const th = (heat - params.crust) / Math.max(0.01, 1 - params.crust);
+          const hue =
+            params.coolHue +
+            ((params.heatHue - params.coolHue + 360) % 360) * th;
+          const light = 30 + th * 50;
+          const [rr, gg, bb] = hslToRgb(hue, 95, light);
+          fillCell(data, px, py, step, rr, gg, bb);
+        }
+      }
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+
+  // グロー (加算描画)
+  if (params.glow > 0) {
+    ctx.globalCompositeOperation = 'lighter';
+    for (const b of blobs) {
+      const grad = ctx.createRadialGradient(b.x, b.y, 0, b.x, b.y, b.r * 1.8);
+      grad.addColorStop(
+        0,
+        `hsla(${params.heatHue}, 95%, 65%, ${params.glow / 60})`,
+      );
+      grad.addColorStop(1, `hsla(${params.heatHue}, 95%, 30%, 0)`);
+      ctx.fillStyle = grad;
+      ctx.beginPath();
+      ctx.arc(b.x, b.y, b.r * 1.8, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+/**
+ * @param {Uint8ClampedArray} data
+ * @param {number} x
+ * @param {number} y
+ * @param {number} step
+ * @param {number} r
+ * @param {number} g
+ * @param {number} b
+ */
+function fillCell(data, x, y, step, r, g, b) {
+  const w = canvas.width;
+  for (let dy = 0; dy < step; dy++) {
+    for (let dx = 0; dx < step; dx++) {
+      const idx = ((y + dy) * w + (x + dx)) * 4;
+      data[idx] = r;
+      data[idx + 1] = g;
+      data[idx + 2] = b;
+      data[idx + 3] = 255;
+    }
+  }
+}
+
+/**
+ * HSL -> RGB
+ * @param {number} h 0..360
+ * @param {number} s 0..100
+ * @param {number} l 0..100
+ * @returns {[number, number, number]}
+ */
+function hslToRgb(h, s, l) {
+  const S = s / 100;
+  const L = l / 100;
+  const c = (1 - Math.abs(2 * L - 1)) * S;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = L - c / 2;
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ];
+}
+
+function tick() {
+  update();
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Lava Flow',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'blobCount', 3, 30, 1).onChange(initBlobs);
+gui.add(params, 'radiusMin', 20, 150, 1).onChange(initBlobs);
+gui.add(params, 'radiusMax', 40, 250, 1).onChange(initBlobs);
+gui.add(params, 'threshold', 0.2, 1.5, 0.01);
+gui.add(params, 'gridSize', 2, 14, 1);
+gui.add(params, 'flowSpeed', 0, 2, 0.01);
+gui.add(params, 'heatHue', 0, 60, 1);
+gui.add(params, 'coolHue', 300, 360, 1);
+gui.add(params, 'glow', 0, 40, 1);
+gui.add(params, 'crust', 0, 0.9, 0.01);
+gui.add(params, 'pulse', 0, 1, 0.01);
+gui.add(params, 'trail', 0.02, 0.4, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.blobCount = rand(8, 20, 1);
+  params.radiusMin = rand(40, 100, 1);
+  params.radiusMax = rand(100, 180, 1);
+  params.threshold = rand(0.4, 0.9, 0.01);
+  params.flowSpeed = rand(0.15, 0.8, 0.01);
+  params.heatHue = rand(5, 40, 1);
+  params.glow = rand(8, 30, 1);
+  params.crust = rand(0.2, 0.6, 0.01);
+  initBlobs();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initBlobs();
+  gui.updateDisplay();
+});

--- a/public/lava-flow/style.css
+++ b/public/lava-flow/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #1a0505;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #d8a080;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #ffcc99;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/lightning-strike/index.html
+++ b/public/lightning-strike/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Lightning Strike | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/lightning-strike/main.js
+++ b/public/lightning-strike/main.js
@@ -75,7 +75,7 @@ function buildBolt(x, y, angle, amp, depth, segs) {
   }
 }
 
-/** @type {Array<{segs: Array<{x1:number,y1:number,x2:number,y2:number,depth:number}>, life:number}>} */
+/** @type {Array<{path: Path2D, hue: number, life:number}>} */
 const bolts = [];
 
 /** 新しい落雷を発生させる */
@@ -84,7 +84,14 @@ function strike() {
   /** @type {Array<{x1:number,y1:number,x2:number,y2:number,depth:number}>} */
   const segs = [];
   buildBolt(startX, 0, Math.PI / 2, params.jitter, 5, segs);
-  bolts.push({ segs, life: 1 });
+  // bolt 全体を 1 つの Path2D にまとめて 1 回の stroke で描画する
+  const path = new Path2D();
+  for (const s of segs) {
+    path.moveTo(s.x1, s.y1);
+    path.lineTo(s.x2, s.y2);
+  }
+  const boltHue = params.hue + (Math.random() - 0.5) * params.hueSpread;
+  bolts.push({ path, hue: boltHue, life: 1 });
   // フラッシュ
   ctx.fillStyle = `hsla(${params.hue}, 60%, 90%, ${params.flashAlpha})`;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -104,20 +111,14 @@ function tick() {
 
   ctx.lineCap = 'round';
   ctx.shadowBlur = params.glow;
+  ctx.lineWidth = Math.max(0.0625, params.lineWidth);
   for (let i = bolts.length - 1; i >= 0; i--) {
     const bolt = bolts[i];
-    const hue = params.hue + (Math.random() - 0.5) * params.hueSpread;
-    const color = `hsla(${hue}, 90%, 75%, ${bolt.life})`;
+    const color = `hsla(${bolt.hue}, 90%, 75%, ${bolt.life})`;
     ctx.strokeStyle = color;
     ctx.shadowColor = color;
-    ctx.lineWidth = Math.max(0.0625, params.lineWidth);
-    for (const s of bolt.segs) {
-      ctx.beginPath();
-      ctx.moveTo(s.x1, s.y1);
-      ctx.lineTo(s.x2, s.y2);
-      ctx.stroke();
-    }
-    bolt.life -= 0.05;
+    ctx.stroke(bolt.path);
+    bolt.life -= 0.03;
     if (bolt.life <= 0) bolts.splice(i, 1);
   }
   ctx.shadowBlur = 0;

--- a/public/lightning-strike/main.js
+++ b/public/lightning-strike/main.js
@@ -1,0 +1,187 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  strikeRate: 0.8, // 1 秒あたりの落雷頻度
+  maxBranches: 5, // 分岐本数上限
+  branchChance: 0.35, // 分岐確率
+  jitter: 28, // 枝の横ずれ量
+  segmentLen: 22, // 線分長
+  decay: 0.82, // 子枝の振幅減衰
+  lineWidth: 1.8, // 線幅
+  glow: 24, // グロー強度
+  hue: 210, // 雷の色相
+  hueSpread: 30, // 色相のゆらぎ
+  flashAlpha: 0.35, // 発光フラッシュ強度
+  fadeSpeed: 0.18, // 残像のフェード速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * 1 本の雷を作成（再帰）
+ * @param {number} x
+ * @param {number} y
+ * @param {number} angle 進行方向（ラジアン）
+ * @param {number} amp 横ずれ振幅
+ * @param {number} depth 残り深さ
+ * @param {Array<{x1:number,y1:number,x2:number,y2:number,depth:number}>} segs
+ */
+function buildBolt(x, y, angle, amp, depth, segs) {
+  if (depth <= 0) return;
+  const targetY = canvas.height;
+  let cx = x;
+  let cy = y;
+  let ca = angle;
+  let branches = 0;
+  while (cy < targetY && segs.length < 2000) {
+    const jitter = (Math.random() - 0.5) * amp;
+    const nx =
+      cx +
+      Math.cos(ca) * params.segmentLen +
+      Math.cos(ca + Math.PI / 2) * jitter;
+    const ny =
+      cy +
+      Math.sin(ca) * params.segmentLen +
+      Math.sin(ca + Math.PI / 2) * jitter;
+    segs.push({ x1: cx, y1: cy, x2: nx, y2: ny, depth });
+    // 分岐
+    if (branches < params.maxBranches && Math.random() < params.branchChance) {
+      const side = Math.random() < 0.5 ? -1 : 1;
+      const branchAngle = ca + side * (0.4 + Math.random() * 0.4);
+      buildBolt(nx, ny, branchAngle, amp * params.decay, depth - 1, segs);
+      branches += 1;
+    }
+    cx = nx;
+    cy = ny;
+    // 方向を少しずつ揺らす
+    ca += (Math.random() - 0.5) * 0.15;
+  }
+}
+
+/** @type {Array<{segs: Array<{x1:number,y1:number,x2:number,y2:number,depth:number}>, life:number}>} */
+const bolts = [];
+
+/** 新しい落雷を発生させる */
+function strike() {
+  const startX = canvas.width * (0.15 + Math.random() * 0.7);
+  /** @type {Array<{x1:number,y1:number,x2:number,y2:number,depth:number}>} */
+  const segs = [];
+  buildBolt(startX, 0, Math.PI / 2, params.jitter, 5, segs);
+  bolts.push({ segs, life: 1 });
+  // フラッシュ
+  ctx.fillStyle = `hsla(${params.hue}, 60%, 90%, ${params.flashAlpha})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+// --- ループ ---
+
+function tick() {
+  // 残像フェード
+  ctx.fillStyle = `rgba(5, 5, 16, ${params.fadeSpeed})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // 確率的に落雷発生
+  if (Math.random() < params.strikeRate / 60) {
+    strike();
+  }
+
+  ctx.lineCap = 'round';
+  ctx.shadowBlur = params.glow;
+  for (let i = bolts.length - 1; i >= 0; i--) {
+    const bolt = bolts[i];
+    const hue = params.hue + (Math.random() - 0.5) * params.hueSpread;
+    const color = `hsla(${hue}, 90%, 75%, ${bolt.life})`;
+    ctx.strokeStyle = color;
+    ctx.shadowColor = color;
+    ctx.lineWidth = Math.max(0.0625, params.lineWidth);
+    for (const s of bolt.segs) {
+      ctx.beginPath();
+      ctx.moveTo(s.x1, s.y1);
+      ctx.lineTo(s.x2, s.y2);
+      ctx.stroke();
+    }
+    bolt.life -= 0.05;
+    if (bolt.life <= 0) bolts.splice(i, 1);
+  }
+  ctx.shadowBlur = 0;
+
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Lightning Strike',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'strikeRate', 0.05, 3, 0.05);
+gui.add(params, 'maxBranches', 0, 10, 1);
+gui.add(params, 'branchChance', 0, 0.8, 0.01);
+gui.add(params, 'jitter', 0, 80, 1);
+gui.add(params, 'segmentLen', 6, 60, 1);
+gui.add(params, 'decay', 0.4, 0.98, 0.01);
+gui.add(params, 'lineWidth', 0.5, 6, 0.1);
+gui.add(params, 'glow', 0, 60, 1);
+gui.add(params, 'hue', 0, 360, 1);
+gui.add(params, 'hueSpread', 0, 120, 1);
+gui.add(params, 'flashAlpha', 0, 0.8, 0.01);
+gui.add(params, 'fadeSpeed', 0.02, 0.5, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.strikeRate = rand(0.3, 2, 0.05);
+  params.maxBranches = rand(2, 8, 1);
+  params.branchChance = rand(0.15, 0.6, 0.01);
+  params.jitter = rand(10, 50, 1);
+  params.segmentLen = rand(12, 40, 1);
+  params.decay = rand(0.7, 0.95, 0.01);
+  params.hue = rand(180, 280, 1);
+  params.hueSpread = rand(0, 60, 1);
+  params.glow = rand(10, 40, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Strike', () => {
+  strike();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/lightning-strike/style.css
+++ b/public/lightning-strike/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #050510;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/mirage-heat/index.html
+++ b/public/mirage-heat/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Mirage Heat | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/mirage-heat/main.js
+++ b/public/mirage-heat/main.js
@@ -1,0 +1,212 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  rowStep: 6, // サンプリング行間隔（小さいほど高精細）
+  waveAmp: 18, // 揺らぎ振幅
+  waveFreq: 0.02, // 揺らぎの空間周波数
+  waveSpeed: 1.2, // 揺らぎの時間速度
+  heatHorizon: 0.55, // 地平線位置（0..1）
+  heatIntensity: 1.0, // 熱波の強さ
+  skyHueTop: 26, // 空上部色相
+  skyHueBottom: 40, // 空下部色相
+  sandHue: 35, // 砂色相
+  sunRadius: 90, // 太陽半径
+  sunBright: 1.4, // 太陽の明るさ
+  layerCount: 3, // 熱波レイヤー数
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+// オフスクリーン（歪ませる前の元画像）
+const off = document.createElement('canvas');
+const offCtx = /** @type {CanvasRenderingContext2D} */ (off.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  off.width = canvas.width;
+  off.height = canvas.height;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画 ---
+
+let time = 0;
+
+/**
+ * 元画像（砂漠と太陽）をオフスクリーンに描画
+ */
+function drawScene() {
+  const w = off.width;
+  const h = off.height;
+  const horizon = h * params.heatHorizon;
+  // 空
+  const skyGrad = offCtx.createLinearGradient(0, 0, 0, horizon);
+  skyGrad.addColorStop(0, `hsl(${params.skyHueTop}, 75%, 30%)`);
+  skyGrad.addColorStop(1, `hsl(${params.skyHueBottom}, 85%, 65%)`);
+  offCtx.fillStyle = skyGrad;
+  offCtx.fillRect(0, 0, w, horizon);
+
+  // 太陽
+  const sunX = w * 0.5;
+  const sunY = horizon - params.sunRadius * 0.3;
+  const sunGrad = offCtx.createRadialGradient(
+    sunX,
+    sunY,
+    0,
+    sunX,
+    sunY,
+    params.sunRadius,
+  );
+  sunGrad.addColorStop(0, `hsla(50, 100%, 85%, ${params.sunBright})`);
+  sunGrad.addColorStop(0.5, `hsla(35, 100%, 70%, ${params.sunBright * 0.7})`);
+  sunGrad.addColorStop(1, `hsla(20, 95%, 55%, 0)`);
+  offCtx.fillStyle = sunGrad;
+  offCtx.beginPath();
+  offCtx.arc(sunX, sunY, params.sunRadius, 0, Math.PI * 2);
+  offCtx.fill();
+
+  // 砂漠
+  const sandGrad = offCtx.createLinearGradient(0, horizon, 0, h);
+  sandGrad.addColorStop(0, `hsl(${params.sandHue}, 80%, 60%)`);
+  sandGrad.addColorStop(1, `hsl(${params.sandHue - 8}, 70%, 25%)`);
+  offCtx.fillStyle = sandGrad;
+  offCtx.fillRect(0, horizon, w, h - horizon);
+
+  // 砂漠のライン
+  offCtx.strokeStyle = `hsla(${params.sandHue + 10}, 60%, 40%, 0.35)`;
+  offCtx.lineWidth = 1;
+  for (let y = horizon + 10; y < h; y += 14) {
+    offCtx.beginPath();
+    offCtx.moveTo(0, y);
+    offCtx.lineTo(w, y);
+    offCtx.stroke();
+  }
+}
+
+/**
+ * 熱揺らぎを適用して描画
+ */
+function drawMirage() {
+  const w = canvas.width;
+  const h = canvas.height;
+  const horizon = h * params.heatHorizon;
+  const rowStep = Math.max(1, Math.round(params.rowStep));
+
+  // 地平線より上（空と太陽）は素直に
+  ctx.drawImage(off, 0, 0, w, horizon, 0, 0, w, horizon);
+
+  // 地平線付近から下は行単位で横ずらし
+  for (let y = horizon; y < h; y += rowStep) {
+    // 地平線から遠いほど揺らぎが強く、奥ほど弱く
+    const distance = (y - horizon) / Math.max(1, h - horizon);
+    const heatAt =
+      params.heatIntensity * (0.3 + Math.sin(distance * Math.PI) * 0.7);
+    let offsetX = 0;
+    for (let l = 0; l < params.layerCount; l++) {
+      const freq = params.waveFreq * (1 + l * 0.6);
+      const phase = time * params.waveSpeed * (1 + l * 0.5);
+      offsetX +=
+        Math.sin(y * freq + phase + l * 1.7) *
+        params.waveAmp *
+        heatAt *
+        (1 / (l + 1));
+    }
+    // 横反射もあわせて（水面のような歪み）
+    const srcY = y;
+    ctx.drawImage(off, 0, srcY, w, rowStep, offsetX, y, w, rowStep);
+  }
+
+  // 地平線に光るライン（熱気）
+  const horizonGrad = ctx.createLinearGradient(
+    0,
+    horizon - 10,
+    0,
+    horizon + 10,
+  );
+  horizonGrad.addColorStop(0, 'rgba(255, 240, 200, 0)');
+  horizonGrad.addColorStop(0.5, 'rgba(255, 240, 200, 0.5)');
+  horizonGrad.addColorStop(1, 'rgba(255, 240, 200, 0)');
+  ctx.fillStyle = horizonGrad;
+  ctx.fillRect(0, horizon - 10, w, 20);
+}
+
+function draw() {
+  time += 1 / 60;
+  drawScene();
+  drawMirage();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Mirage Heat',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'rowStep', 1, 20, 1);
+gui.add(params, 'waveAmp', 0, 80, 1);
+gui.add(params, 'waveFreq', 0.005, 0.1, 0.001);
+gui.add(params, 'waveSpeed', 0, 4, 0.05);
+gui.add(params, 'heatHorizon', 0.2, 0.85, 0.01);
+gui.add(params, 'heatIntensity', 0, 3, 0.05);
+gui.add(params, 'skyHueTop', 0, 60, 1);
+gui.add(params, 'skyHueBottom', 0, 60, 1);
+gui.add(params, 'sandHue', 10, 60, 1);
+gui.add(params, 'sunRadius', 20, 200, 2);
+gui.add(params, 'sunBright', 0.5, 2, 0.05);
+gui.add(params, 'layerCount', 1, 5, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.waveAmp = rand(8, 35, 1);
+  params.waveFreq = rand(0.01, 0.05, 0.001);
+  params.waveSpeed = rand(0.5, 2.5, 0.05);
+  params.heatHorizon = rand(0.4, 0.7, 0.01);
+  params.heatIntensity = rand(0.6, 1.8, 0.05);
+  params.skyHueTop = rand(10, 40, 1);
+  params.skyHueBottom = rand(25, 55, 1);
+  params.sandHue = rand(25, 45, 1);
+  params.sunRadius = rand(60, 160, 2);
+  params.layerCount = rand(2, 4, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/mirage-heat/style.css
+++ b/public/mirage-heat/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #1a1408;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #e8c890;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff4d8;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/rainbow-prism/index.html
+++ b/public/rainbow-prism/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Rainbow Prism | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/rainbow-prism/main.js
+++ b/public/rainbow-prism/main.js
@@ -1,0 +1,181 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  prismSize: 180, // プリズム三角形の一辺サイズ
+  incidentAngle: 35, // 入射角（度）
+  spectrumCount: 80, // スペクトル線本数
+  spreadAngle: 22, // 分散広がり角（度）
+  beamWidth: 6, // 入射光の太さ
+  beamBright: 1.4, // 入射光の明るさ
+  lineAlpha: 0.35, // スペクトル線のアルファ
+  lineWidth: 1.4, // スペクトル線の太さ
+  rotateSpeed: 0.2, // プリズム回転
+  time: 0, // (内部)
+  backglow: 0.15, // 背景の残光
+  prismAlpha: 0.15, // プリズム本体の不透明度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 描画 ---
+
+let time = 0;
+
+function drawBackground() {
+  ctx.fillStyle = `rgba(5, 7, 10, ${1 - params.backglow})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+/**
+ * 正三角形のプリズム頂点を返す
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} size 一辺
+ * @param {number} rot 回転角（ラジアン）
+ */
+function triangleVerts(cx, cy, rot) {
+  const r = params.prismSize / Math.sqrt(3); // 外接円半径
+  /** @type {[number, number][]} */
+  const verts = [];
+  for (let i = 0; i < 3; i++) {
+    const a = rot + (i / 3) * Math.PI * 2 - Math.PI / 2;
+    verts.push([cx + Math.cos(a) * r, cy + Math.sin(a) * r]);
+  }
+  return verts;
+}
+
+function drawPrism() {
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const rot = time * params.rotateSpeed * 0.3;
+  const verts = triangleVerts(cx, cy, rot);
+  // 入射光
+  const angRad = (params.incidentAngle * Math.PI) / 180 + rot;
+  const beamLen = Math.max(canvas.width, canvas.height);
+  const ix = cx - Math.cos(angRad) * beamLen;
+  const iy = cy - Math.sin(angRad) * beamLen;
+  // 入射光グラデーション
+  const beamGrad = ctx.createLinearGradient(ix, iy, cx, cy);
+  beamGrad.addColorStop(0, `rgba(255, 255, 255, 0)`);
+  beamGrad.addColorStop(1, `rgba(255, 255, 255, ${params.beamBright})`);
+  ctx.strokeStyle = beamGrad;
+  ctx.lineWidth = params.beamWidth;
+  ctx.lineCap = 'round';
+  ctx.beginPath();
+  ctx.moveTo(ix, iy);
+  ctx.lineTo(cx, cy);
+  ctx.stroke();
+
+  // スペクトル線（分散）
+  const spreadRad = (params.spreadAngle * Math.PI) / 180;
+  const nLines = Math.max(2, Math.round(params.spectrumCount));
+  ctx.lineWidth = params.lineWidth;
+  for (let i = 0; i < nLines; i++) {
+    const t = i / (nLines - 1);
+    // 可視光近似: 380(紫) -> 700(赤) を hue 270 -> 0 にマッピング
+    const hue = 270 - t * 270;
+    // 波長で屈折角が変わる（紫ほど曲がる）
+    const refractAngle = angRad + Math.PI - spreadRad * (t - 0.5) * 2;
+    const ox = cx + Math.cos(refractAngle) * beamLen;
+    const oy = cy + Math.sin(refractAngle) * beamLen;
+    ctx.strokeStyle = `hsla(${hue}, 95%, 65%, ${params.lineAlpha})`;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(ox, oy);
+    ctx.stroke();
+  }
+
+  // プリズム本体（半透明）
+  ctx.fillStyle = `rgba(220, 230, 255, ${params.prismAlpha})`;
+  ctx.strokeStyle = `rgba(220, 230, 255, 0.6)`;
+  ctx.lineWidth = 1.2;
+  ctx.beginPath();
+  ctx.moveTo(verts[0][0], verts[0][1]);
+  ctx.lineTo(verts[1][0], verts[1][1]);
+  ctx.lineTo(verts[2][0], verts[2][1]);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+
+function draw() {
+  time += 1 / 60;
+  drawBackground();
+  drawPrism();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Rainbow Prism',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'prismSize', 60, 400, 2);
+gui.add(params, 'incidentAngle', 0, 180, 1);
+gui.add(params, 'spectrumCount', 10, 240, 2);
+gui.add(params, 'spreadAngle', 2, 90, 0.5);
+gui.add(params, 'beamWidth', 1, 20, 0.5);
+gui.add(params, 'beamBright', 0.2, 2, 0.05);
+gui.add(params, 'lineAlpha', 0.05, 1, 0.01);
+gui.add(params, 'lineWidth', 0.25, 4, 0.05);
+gui.add(params, 'rotateSpeed', -2, 2, 0.05);
+gui.add(params, 'backglow', 0, 0.8, 0.01);
+gui.add(params, 'prismAlpha', 0, 0.6, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.prismSize = rand(120, 300, 2);
+  params.incidentAngle = rand(0, 180, 1);
+  params.spectrumCount = rand(40, 160, 2);
+  params.spreadAngle = rand(10, 50, 0.5);
+  params.beamWidth = rand(3, 12, 0.5);
+  params.rotateSpeed = rand(-0.8, 0.8, 0.05);
+  params.lineAlpha = rand(0.2, 0.6, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/rainbow-prism/style.css
+++ b/public/rainbow-prism/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #05070a;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #bbb;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #fff;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/sand-dune/index.html
+++ b/public/sand-dune/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Sand Dune | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/sand-dune/main.js
+++ b/public/sand-dune/main.js
@@ -1,0 +1,203 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  layers: 6, // 砂丘レイヤー数
+  amplitude: 90, // 丘の高さ
+  frequency: 0.004, // 波の細かさ
+  windSpeed: 0.3, // 風（横方向スクロール）速度
+  crestSharpness: 1.4, // 稜線の鋭さ
+  hueBase: 32, // ベース色相
+  hueShift: 8, // レイヤー間色相差
+  satBase: 55, // 彩度
+  lightBase: 62, // 明度（手前）
+  lightBack: 28, // 明度（奥）
+  haze: 0.12, // ヘイズ（霞）強度
+  grain: 0.35, // 砂粒ノイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 値ノイズ（疑似 Perlin） ---
+
+/**
+ * ハッシュ化で 0..1 の擬似乱数
+ * @param {number} n
+ */
+function hash(n) {
+  const x = Math.sin(n * 127.1 + 311.7) * 43758.5453123;
+  return x - Math.floor(x);
+}
+
+/**
+ * 1D スムーズノイズ
+ * @param {number} x
+ */
+function noise1d(x) {
+  const i = Math.floor(x);
+  const f = x - i;
+  const a = hash(i);
+  const b = hash(i + 1);
+  const u = f * f * (3 - 2 * f);
+  return a * (1 - u) + b * u;
+}
+
+/**
+ * フラクタル和
+ * @param {number} x
+ * @param {number} seed
+ */
+function fbm(x, seed) {
+  let sum = 0;
+  let amp = 1;
+  let freq = 1;
+  let norm = 0;
+  for (let i = 0; i < 4; i++) {
+    sum += amp * noise1d(x * freq + seed * 13);
+    norm += amp;
+    amp *= 0.5;
+    freq *= 2;
+  }
+  return sum / norm;
+}
+
+// --- 描画 ---
+
+let time = 0;
+
+function drawSky() {
+  const grad = ctx.createLinearGradient(0, 0, 0, canvas.height * 0.6);
+  grad.addColorStop(0, `hsl(${(params.hueBase + 180) % 360}, 35%, 18%)`);
+  grad.addColorStop(1, `hsl(${params.hueBase}, 40%, 40%)`);
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function drawDunes() {
+  const layers = Math.max(1, Math.round(params.layers));
+  for (let l = 0; l < layers; l++) {
+    const depth = l / Math.max(1, layers - 1); // 0: 奥, 1: 手前
+    const baseY = canvas.height * (0.35 + depth * 0.55);
+    const amp = params.amplitude * (0.5 + depth * 0.8);
+    const freq = params.frequency / (1 + depth * 0.6);
+    const scroll = time * params.windSpeed * 30 * (1 - depth * 0.6);
+    const light =
+      params.lightBack + (params.lightBase - params.lightBack) * depth;
+    const hue = params.hueBase + l * params.hueShift;
+    ctx.fillStyle = `hsl(${hue}, ${params.satBase}%, ${light}%)`;
+    ctx.beginPath();
+    ctx.moveTo(0, canvas.height);
+    for (let x = 0; x <= canvas.width; x += 4) {
+      const n = fbm((x + scroll) * freq, l + 1);
+      // 稜線を鋭くする
+      const sharp = n ** params.crestSharpness;
+      const y = baseY - amp * (sharp * 2 - 1) * 0.5;
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(canvas.width, canvas.height);
+    ctx.closePath();
+    ctx.fill();
+
+    // ヘイズを奥ほど強く
+    ctx.fillStyle = `hsla(${params.hueBase}, 30%, 80%, ${params.haze * (1 - depth)})`;
+    ctx.fillRect(0, baseY - amp, canvas.width, amp * 2);
+  }
+}
+
+function drawGrain() {
+  if (params.grain <= 0) return;
+  const count = Math.floor(
+    canvas.width * canvas.height * 0.00015 * params.grain,
+  );
+  for (let i = 0; i < count; i++) {
+    const x = Math.random() * canvas.width;
+    const y = canvas.height * (0.5 + Math.random() * 0.5);
+    ctx.fillStyle = `hsla(${params.hueBase + 20}, 50%, 80%, ${Math.random() * 0.6})`;
+    ctx.fillRect(x, y, 1, 1);
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  drawSky();
+  drawDunes();
+  drawGrain();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Sand Dune',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'layers', 2, 10, 1);
+gui.add(params, 'amplitude', 20, 200, 1);
+gui.add(params, 'frequency', 0.0005, 0.02, 0.0005);
+gui.add(params, 'windSpeed', 0, 2, 0.01);
+gui.add(params, 'crestSharpness', 0.5, 3, 0.05);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueShift', -20, 20, 1);
+gui.add(params, 'satBase', 0, 100, 1);
+gui.add(params, 'lightBase', 30, 90, 1);
+gui.add(params, 'lightBack', 5, 60, 1);
+gui.add(params, 'haze', 0, 0.5, 0.01);
+gui.add(params, 'grain', 0, 1, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.layers = rand(4, 8, 1);
+  params.amplitude = rand(40, 140, 1);
+  params.frequency = rand(0.002, 0.01, 0.0005);
+  params.windSpeed = rand(0.1, 1, 0.01);
+  params.crestSharpness = rand(0.8, 2.2, 0.05);
+  params.hueBase = rand(15, 45, 1);
+  params.hueShift = rand(-10, 10, 1);
+  params.satBase = rand(35, 75, 1);
+  params.haze = rand(0.05, 0.25, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/sand-dune/style.css
+++ b/public/sand-dune/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #2a1a0a;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #d8c3a0;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #f0e0c0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

Issue #153 (Phase 2) のサブ issue から 10 件を選んで実装しました。各ページは TileUI のコントロール 8〜12 個、Random / Reset ボタン付きのジェネラティブアートです。

## 含まれるページ

| # | Page | Dir |
|---|---|---|
| #100 | Lightning Strike | `/lightning-strike/` |
| #101 | Sand Dune | `/sand-dune/` |
| #102 | Cloud Formation | `/cloud-formation/` |
| #104 | Aurora Borealis | `/aurora-borealis/` |
| #105 | Lava Flow | `/lava-flow/` |
| #106 | Bubble Chamber | `/bubble-chamber/` |
| #107 | Convection Cell | `/convection-cell/` |
| #108 | Ice Crystal | `/ice-crystal/` |
| #109 | Rainbow Prism | `/rainbow-prism/` |
| #110 | Mirage Heat | `/mirage-heat/` |

## Closes

- Closes #100
- Closes #101
- Closes #102
- Closes #104
- Closes #105
- Closes #106
- Closes #107
- Closes #108
- Closes #109
- Closes #110

## Test plan

- [x] `npm run check` が通ること
- [ ] 各ページが表示され Random / Reset が動作すること