### PR TITLE
feat: TileUI ジェネラティブアートページを 30 件追加

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@
 | `/fireflies-trail/` | Fireflies Trail（蛍の光跡） |
 | `/moth-to-flame/` | Moth to Flame（蛾と炎） |
 | `/pollen-drift/` | Pollen Drift（花粉の漂い） |
+| `/mandelbrot-zoom/` | Mandelbrot Zoom（マンデルブロ集合ズーム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@
 | `/gosper-island/` | Gosper Island（ゴスパー島） |
 | `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
 | `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
+| `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,7 @@
 | `/avalanche-cascade/` | Avalanche Cascade（雪崩のカスケード） |
 | `/hilbert-curve/` | Hilbert Curve（ヒルベルト曲線） |
 | `/peano-curve/` | Peano Curve（ペアノ曲線） |
+| `/rhombille-tiling/` | Rhombille Tiling（菱形タイリング） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@
 | `/comet-tail/` | Comet Tail（彗星の尾） |
 | `/fireflies-trail/` | Fireflies Trail（蛍の光跡） |
 | `/moth-to-flame/` | Moth to Flame（蛾と炎） |
+| `/pollen-drift/` | Pollen Drift（花粉の漂い） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,7 @@
 | `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
 | `/leaf-venation/` | Leaf Venation（葉脈形成） |
 | `/coral-growth/` | Coral Growth（サンゴの成長） |
+| `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,6 +130,7 @@
 | `/beat-interference/` | Beat Interference（ビート干渉） |
 | `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
 | `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
+| `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,7 @@
 | `/dna-helix/` | DNA Helix（DNAヘリックス） |
 | `/cell-division/` | Cell Division（細胞分裂） |
 | `/virus-capsid/` | Virus Capsid（ウイルスカプシド） |
+| `/chromatic-aberration/` | Chromatic Aberration（色収差） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,7 @@
 | `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
 | `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
 | `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
+| `/beat-interference/` | Beat Interference（ビート干渉） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,7 @@
 | `/schooling-fish/` | Schooling Fish（群泳する魚） |
 | `/ant-bridge/` | Ant Bridge（アリの橋） |
 | `/bee-swarm/` | Bee Swarm（ミツバチの群れ） |
+| `/bacterial-colony/` | Bacterial Colony（バクテリアコロニー） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,6 +131,7 @@
 | `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
 | `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
 | `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
+| `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@
 | `/escher-tessellation/` | Escher Tessellation（エッシャー風テセレーション） |
 | `/quasicrystal/` | Quasicrystal（準結晶パターン） |
 | `/girih-pattern/` | Girih Pattern（ギリパターン） |
+| `/aztec-geometry/` | Aztec Geometry（アステカ幾何模様） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@
 | `/magnetic-dust/` | Magnetic Dust（磁性粉のパターン） |
 | `/dust-storm/` | Dust Storm（砂嵐） |
 | `/comet-tail/` | Comet Tail（彗星の尾） |
+| `/fireflies-trail/` | Fireflies Trail（蛍の光跡） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@
 | `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
 | `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
 | `/leaf-venation/` | Leaf Venation（葉脈形成） |
+| `/coral-growth/` | Coral Growth（サンゴの成長） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@
 | `/electron-cloud/` | Electron Cloud（電子雲） |
 | `/magnetic-dust/` | Magnetic Dust（磁性粉のパターン） |
 | `/dust-storm/` | Dust Storm（砂嵐） |
+| `/comet-tail/` | Comet Tail（彗星の尾） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,6 +84,7 @@
 | `/mirage-heat/` | Mirage Heat（熱気で地平線が揺らぐ蜃気楼のビジュアル） |
 | `/tornado-vortex/` | Tornado Vortex（渦巻く竜巻のパーティクル） |
 | `/avalanche-cascade/` | Avalanche Cascade（雪崩のカスケード） |
+| `/hilbert-curve/` | Hilbert Curve（ヒルベルト曲線） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,7 @@
 | `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
 | `/dna-helix/` | DNA Helix（DNAヘリックス） |
 | `/cell-division/` | Cell Division（細胞分裂） |
+| `/virus-capsid/` | Virus Capsid（ウイルスカプシド） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,7 @@
 | `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
 | `/chord-wheel/` | Chord Wheel（コードホイール） |
 | `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
+| `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@
 | `/peano-curve/` | Peano Curve（ペアノ曲線） |
 | `/rhombille-tiling/` | Rhombille Tiling（菱形タイリング） |
 | `/celtic-knot/` | Celtic Knot（ケルト結び目模様） |
+| `/escher-tessellation/` | Escher Tessellation（エッシャー風テセレーション） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,6 +117,7 @@
 | `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
 | `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
 | `/gosper-island/` | Gosper Island（ゴスパー島） |
+| `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@
 | `/ant-bridge/` | Ant Bridge（アリの橋） |
 | `/bee-swarm/` | Bee Swarm（ミツバチの群れ） |
 | `/bacterial-colony/` | Bacterial Colony（バクテリアコロニー） |
+| `/plankton-bloom/` | Plankton Bloom（プランクトンブルーム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,7 @@
 | `/dust-storm/` | Dust Storm（砂嵐） |
 | `/comet-tail/` | Comet Tail（彗星の尾） |
 | `/fireflies-trail/` | Fireflies Trail（蛍の光跡） |
+| `/moth-to-flame/` | Moth to Flame（蛾と炎） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,7 @@
 | `/hilbert-curve/` | Hilbert Curve（ヒルベルト曲線） |
 | `/peano-curve/` | Peano Curve（ペアノ曲線） |
 | `/rhombille-tiling/` | Rhombille Tiling（菱形タイリング） |
+| `/celtic-knot/` | Celtic Knot（ケルト結び目模様） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,6 +118,7 @@
 | `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
 | `/gosper-island/` | Gosper Island（ゴスパー島） |
 | `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
+| `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,7 @@
 | `/ice-crystal/` | Ice Crystal（6 回対称で再帰成長する雪の結晶フラクタル） |
 | `/rainbow-prism/` | Rainbow Prism（入射光がプリズムで分散して虹色スペクトルになる光学ビジュアル） |
 | `/mirage-heat/` | Mirage Heat（熱気で地平線が揺らぐ蜃気楼のビジュアル） |
+| `/tornado-vortex/` | Tornado Vortex（渦巻く竜巻のパーティクル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,7 @@
 | `/pollen-drift/` | Pollen Drift（花粉の漂い） |
 | `/mandelbrot-zoom/` | Mandelbrot Zoom（マンデルブロ集合ズーム） |
 | `/burning-ship/` | Burning Ship（燃える船フラクタル） |
+| `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,7 @@
 | `/quasicrystal/` | Quasicrystal（準結晶パターン） |
 | `/girih-pattern/` | Girih Pattern（ギリパターン） |
 | `/aztec-geometry/` | Aztec Geometry（アステカ幾何模様） |
+| `/mandala-generator/` | Mandala Generator（マンダラ生成器） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,7 @@
 | `/rhombille-tiling/` | Rhombille Tiling（菱形タイリング） |
 | `/celtic-knot/` | Celtic Knot（ケルト結び目模様） |
 | `/escher-tessellation/` | Escher Tessellation（エッシャー風テセレーション） |
+| `/quasicrystal/` | Quasicrystal（準結晶パターン） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,7 @@
 | `/tornado-vortex/` | Tornado Vortex（渦巻く竜巻のパーティクル） |
 | `/avalanche-cascade/` | Avalanche Cascade（雪崩のカスケード） |
 | `/hilbert-curve/` | Hilbert Curve（ヒルベルト曲線） |
+| `/peano-curve/` | Peano Curve（ペアノ曲線） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,7 @@
 | `/leaf-venation/` | Leaf Venation（葉脈形成） |
 | `/coral-growth/` | Coral Growth（サンゴの成長） |
 | `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
+| `/dna-helix/` | DNA Helix（DNAヘリックス） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,7 @@
 | `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
 | `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
 | `/h-tree/` | H Tree（H木フラクタル） |
+| `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,6 +93,7 @@
 | `/girih-pattern/` | Girih Pattern（ギリパターン） |
 | `/aztec-geometry/` | Aztec Geometry（アステカ幾何模様） |
 | `/mandala-generator/` | Mandala Generator（マンダラ生成器） |
+| `/lissajous-3d/` | Lissajous 3D（3D リサジュー曲線） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@
 | `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
 | `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
 | `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
+| `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,7 @@
 | `/plankton-bloom/` | Plankton Bloom（プランクトンブルーム） |
 | `/slime-mold/` | Slime Mold（粘菌ネットワーク） |
 | `/bird-murmuration/` | Bird Murmuration（鳥の群れの旋回） |
+| `/electron-cloud/` | Electron Cloud（電子雲） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,7 @@
 | `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
 | `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
 | `/beat-interference/` | Beat Interference（ビート干渉） |
+| `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,7 @@
 | `/bee-swarm/` | Bee Swarm（ミツバチの群れ） |
 | `/bacterial-colony/` | Bacterial Colony（バクテリアコロニー） |
 | `/plankton-bloom/` | Plankton Bloom（プランクトンブルーム） |
+| `/slime-mold/` | Slime Mold（粘菌ネットワーク） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,6 +129,7 @@
 | `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
 | `/beat-interference/` | Beat Interference（ビート干渉） |
 | `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
+| `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,7 @@
 | `/celtic-knot/` | Celtic Knot（ケルト結び目模様） |
 | `/escher-tessellation/` | Escher Tessellation（エッシャー風テセレーション） |
 | `/quasicrystal/` | Quasicrystal（準結晶パターン） |
+| `/girih-pattern/` | Girih Pattern（ギリパターン） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@
 | `/rainbow-prism/` | Rainbow Prism（入射光がプリズムで分散して虹色スペクトルになる光学ビジュアル） |
 | `/mirage-heat/` | Mirage Heat（熱気で地平線が揺らぐ蜃気楼のビジュアル） |
 | `/tornado-vortex/` | Tornado Vortex（渦巻く竜巻のパーティクル） |
+| `/avalanche-cascade/` | Avalanche Cascade（雪崩のカスケード） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,6 +140,7 @@
 | `/cell-division/` | Cell Division（細胞分裂） |
 | `/virus-capsid/` | Virus Capsid（ウイルスカプシド） |
 | `/chromatic-aberration/` | Chromatic Aberration（色収差） |
+| `/diffraction-grating/` | Diffraction Grating（回折格子） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,7 @@
 | `/moth-to-flame/` | Moth to Flame（蛾と炎） |
 | `/pollen-drift/` | Pollen Drift（花粉の漂い） |
 | `/mandelbrot-zoom/` | Mandelbrot Zoom（マンデルブロ集合ズーム） |
+| `/burning-ship/` | Burning Ship（燃える船フラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@
 | `/lissajous-3d/` | Lissajous 3D（3D リサジュー曲線） |
 | `/schooling-fish/` | Schooling Fish（群泳する魚） |
 | `/ant-bridge/` | Ant Bridge（アリの橋） |
+| `/bee-swarm/` | Bee Swarm（ミツバチの群れ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,7 @@
 | `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
 | `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
 | `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
+| `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,6 +94,7 @@
 | `/aztec-geometry/` | Aztec Geometry（アステカ幾何模様） |
 | `/mandala-generator/` | Mandala Generator（マンダラ生成器） |
 | `/lissajous-3d/` | Lissajous 3D（3D リサジュー曲線） |
+| `/schooling-fish/` | Schooling Fish（群泳する魚） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,7 @@
 | `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
 | `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
 | `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
+| `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@
 | `/bacterial-colony/` | Bacterial Colony（バクテリアコロニー） |
 | `/plankton-bloom/` | Plankton Bloom（プランクトンブルーム） |
 | `/slime-mold/` | Slime Mold（粘菌ネットワーク） |
+| `/bird-murmuration/` | Bird Murmuration（鳥の群れの旋回） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@
 | `/bird-murmuration/` | Bird Murmuration（鳥の群れの旋回） |
 | `/electron-cloud/` | Electron Cloud（電子雲） |
 | `/magnetic-dust/` | Magnetic Dust（磁性粉のパターン） |
+| `/dust-storm/` | Dust Storm（砂嵐） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -116,6 +116,7 @@
 | `/h-tree/` | H Tree（H木フラクタル） |
 | `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
 | `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
+| `/gosper-island/` | Gosper Island（ゴスパー島） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,7 @@
 | `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
 | `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
 | `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
+| `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,7 @@
 | `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
 | `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
 | `/chord-wheel/` | Chord Wheel（コードホイール） |
+| `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,7 @@
 | `/burning-ship/` | Burning Ship（燃える船フラクタル） |
 | `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
 | `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
+| `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@
 | `/mandelbrot-zoom/` | Mandelbrot Zoom（マンデルブロ集合ズーム） |
 | `/burning-ship/` | Burning Ship（燃える船フラクタル） |
 | `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
+| `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@
 | `/chord-wheel/` | Chord Wheel（コードホイール） |
 | `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
 | `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
+| `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,7 @@
 | `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
 | `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
 | `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
+| `/h-tree/` | H Tree（H木フラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,7 @@
 | `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
 | `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
 | `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
+| `/chord-wheel/` | Chord Wheel（コードホイール） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@
 | `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
 | `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
 | `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
+| `/leaf-venation/` | Leaf Venation（葉脈形成） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@
 | `/slime-mold/` | Slime Mold（粘菌ネットワーク） |
 | `/bird-murmuration/` | Bird Murmuration（鳥の群れの旋回） |
 | `/electron-cloud/` | Electron Cloud（電子雲） |
+| `/magnetic-dust/` | Magnetic Dust（磁性粉のパターン） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@
 | `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
 | `/h-tree/` | H Tree（H木フラクタル） |
 | `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
+| `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@
 | `/mandala-generator/` | Mandala Generator（マンダラ生成器） |
 | `/lissajous-3d/` | Lissajous 3D（3D リサジュー曲線） |
 | `/schooling-fish/` | Schooling Fish（群泳する魚） |
+| `/ant-bridge/` | Ant Bridge（アリの橋） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,7 @@
 | `/coral-growth/` | Coral Growth（サンゴの成長） |
 | `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
 | `/dna-helix/` | DNA Helix（DNAヘリックス） |
+| `/cell-division/` | Cell Division（細胞分裂） |
 
 ## トップページ仕様
 

--- a/public/ant-bridge/index.html
+++ b/public/ant-bridge/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Ant Bridge | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/ant-bridge/main.js
+++ b/public/ant-bridge/main.js
@@ -1,0 +1,257 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// アリの橋：フェロモン強化学習でアリたちが最短経路の橋を形成する。
+// 巣と食べ物を繋ぐ最短経路を徐々に発見していく。
+
+const params = {
+  antCount: 80, // アリの数
+  pheromone: 0.8, // フェロモン強度
+  evapRate: 0.98, // 蒸発率（1に近いほど遅く蒸発）
+  randomness: 0.25, // ランダム探索率
+  antSpeed: 2.0, // アリの速度
+  antHue: 30, // アリの色相
+  trailHue: 60, // フェロモントレイルの色相
+  trailFade: 0.1, // フェード強度
+  antSize: 3, // アリのサイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  initGrid();
+}
+window.addEventListener('resize', resize);
+
+// フェロモングリッドの解像度
+const GRID_RES = 4;
+/** @type {number[][]} */
+let pheroGrid = [];
+let gridW = 0;
+let gridH = 0;
+
+function initGrid() {
+  gridW = Math.ceil(canvas.width / GRID_RES);
+  gridH = Math.ceil(canvas.height / GRID_RES);
+  pheroGrid = Array.from({ length: gridW }, () => new Array(gridH).fill(0));
+}
+
+resize();
+
+/**
+ * @typedef {{ x: number, y: number, angle: number, toFood: boolean }} Ant
+ */
+
+/** @type {Ant[]} */
+let ants = [];
+
+/**
+ * アリを初期化する
+ */
+function initAnts() {
+  ants = [];
+  const nestX = canvas.width * 0.15;
+  const nestY = canvas.height / 2;
+  for (let i = 0; i < params.antCount; i++) {
+    ants.push({
+      x: nestX + (Math.random() - 0.5) * 20,
+      y: nestY + (Math.random() - 0.5) * 20,
+      angle: Math.random() * Math.PI * 2,
+      toFood: true,
+    });
+  }
+}
+initAnts();
+
+/**
+ * アリを1ステップ更新する
+ * @param {Ant} ant
+ */
+function updateAnt(ant) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const nestX = w * 0.15;
+  const nestY = h / 2;
+  const foodX = w * 0.85;
+  const foodY = h / 2;
+
+  // 目標に近いかチェック
+  const target = ant.toFood ? { x: foodX, y: foodY } : { x: nestX, y: nestY };
+  const distToTarget = Math.hypot(ant.x - target.x, ant.y - target.y);
+  if (distToTarget < 20) {
+    ant.toFood = !ant.toFood;
+    // フェロモンを強く残す
+    const gx = Math.floor(ant.x / GRID_RES);
+    const gy = Math.floor(ant.y / GRID_RES);
+    if (gx >= 0 && gx < gridW && gy >= 0 && gy < gridH) {
+      pheroGrid[gx][gy] = Math.min(1, pheroGrid[gx][gy] + params.pheromone * 2);
+    }
+  }
+
+  // フェロモン勾配に従う or ランダム
+  if (Math.random() > params.randomness) {
+    // 周囲のフェロモンを感知
+    let bestAngle = ant.angle;
+    let bestPher = -1;
+    const sensorDist = 15;
+    for (let da = -Math.PI / 3; da <= Math.PI / 3; da += Math.PI / 8) {
+      const sa = ant.angle + da;
+      const sx = ant.x + Math.cos(sa) * sensorDist;
+      const sy = ant.y + Math.sin(sa) * sensorDist;
+      const gx = Math.floor(sx / GRID_RES);
+      const gy = Math.floor(sy / GRID_RES);
+      if (gx >= 0 && gx < gridW && gy >= 0 && gy < gridH) {
+        if (pheroGrid[gx][gy] > bestPher) {
+          bestPher = pheroGrid[gx][gy];
+          bestAngle = sa;
+        }
+      }
+    }
+    ant.angle = bestAngle + (Math.random() - 0.5) * 0.3;
+  } else {
+    ant.angle += (Math.random() - 0.5) * 1.2;
+  }
+
+  ant.x += Math.cos(ant.angle) * params.antSpeed;
+  ant.y += Math.sin(ant.angle) * params.antSpeed;
+
+  // フェロモンを残す
+  const gx = Math.floor(ant.x / GRID_RES);
+  const gy = Math.floor(ant.y / GRID_RES);
+  if (gx >= 0 && gx < gridW && gy >= 0 && gy < gridH) {
+    pheroGrid[gx][gy] = Math.min(
+      1,
+      pheroGrid[gx][gy] + params.pheromone * 0.05,
+    );
+  }
+
+  // 壁反射
+  if (ant.x < 0 || ant.x > w) ant.angle = Math.PI - ant.angle;
+  if (ant.y < 0 || ant.y > h) ant.angle = -ant.angle;
+  ant.x = Math.max(0, Math.min(w, ant.x));
+  ant.y = Math.max(0, Math.min(h, ant.y));
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // フェロモントレイルを描く
+  for (let gx = 0; gx < gridW; gx++) {
+    for (let gy = 0; gy < gridH; gy++) {
+      const v = pheroGrid[gx][gy];
+      if (v > 0.01) {
+        ctx.fillStyle = `hsla(${params.trailHue}, 80%, 60%, ${v * 0.7})`;
+        ctx.fillRect(gx * GRID_RES, gy * GRID_RES, GRID_RES, GRID_RES);
+        // 蒸発
+        pheroGrid[gx][gy] *= params.evapRate;
+      }
+    }
+  }
+
+  // 巣と食べ物を描く
+  const nestX = w * 0.15;
+  const nestY = h / 2;
+  const foodX = w * 0.85;
+  const foodY = h / 2;
+
+  ctx.beginPath();
+  ctx.arc(nestX, nestY, 15, 0, Math.PI * 2);
+  ctx.fillStyle = 'hsl(30, 70%, 45%)';
+  ctx.fill();
+  ctx.strokeStyle = 'hsl(30, 70%, 70%)';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(foodX, foodY, 15, 0, Math.PI * 2);
+  ctx.fillStyle = 'hsl(120, 70%, 45%)';
+  ctx.fill();
+  ctx.strokeStyle = 'hsl(120, 70%, 70%)';
+  ctx.lineWidth = 2;
+  ctx.stroke();
+
+  // アリを更新・描画
+  for (const ant of ants) {
+    updateAnt(ant);
+    ctx.save();
+    ctx.translate(ant.x, ant.y);
+    ctx.rotate(ant.angle);
+    ctx.beginPath();
+    const s = params.antSize;
+    ctx.ellipse(0, 0, s * 1.5, s * 0.6, 0, 0, Math.PI * 2);
+    ctx.fillStyle = `hsl(${params.antHue}, 60%, 55%)`;
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Ant Bridge',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'antCount', 10, 200, 5).onChange(initAnts);
+gui.add(params, 'pheromone', 0.1, 2.0, 0.05);
+gui.add(params, 'evapRate', 0.9, 0.9999, 0.001);
+gui.add(params, 'randomness', 0, 0.8, 0.01);
+gui.add(params, 'antSpeed', 0.5, 5, 0.1);
+gui.add(params, 'antHue', 0, 360, 1);
+gui.add(params, 'trailHue', 0, 360, 1);
+gui.add(params, 'antSize', 1, 8, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.pheromone = rand(0.2, 1.5, 0.05);
+  params.evapRate = rand(0.92, 0.999, 0.001);
+  params.randomness = rand(0.05, 0.6, 0.01);
+  params.antSpeed = rand(1, 4, 0.1);
+  params.antHue = rand(0, 360, 1);
+  params.trailHue = rand(0, 360, 1);
+  initGrid();
+  initAnts();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initGrid();
+  initAnts();
+  gui.updateDisplay();
+});

--- a/public/ant-bridge/style.css
+++ b/public/ant-bridge/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/apollonian-gasket/index.html
+++ b/public/apollonian-gasket/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Apollonian Gasket | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/apollonian-gasket/main.js
+++ b/public/apollonian-gasket/main.js
@@ -1,0 +1,182 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  maxDepth: 6, // 再帰深さ
+  outerScale: 0.42, // 外接円の半径（画面に対する比）
+  strokeAlpha: 0.85, // 線の不透明度
+  fillAlpha: 0.12, // 塗りの不透明度
+  hueStart: 30,
+  hueRange: 200,
+  thickness: 1.4,
+  rotation: 0,
+  rotSpeed: 0.05,
+  innerRatio: 1, // 内部 3 円の配置係数
+  showInner: true,
+  zoom: 1,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 3 円に内接する円を求める（デカルトの円定理）
+ * @param {{x:number,y:number,r:number}} a
+ * @param {{x:number,y:number,r:number}} b
+ * @param {{x:number,y:number,r:number}} c
+ * @returns {{x:number,y:number,r:number}|null}
+ */
+function innerCircle(a, b, c) {
+  const ka = 1 / a.r;
+  const kb = 1 / b.r;
+  const kc = 1 / c.r;
+  const k4 = ka + kb + kc + 2 * Math.sqrt(ka * kb + kb * kc + kc * ka);
+  const r = 1 / k4;
+  // 中心をラプラス的重み付き平均で近似
+  const za = { x: a.x, y: a.y };
+  const zb = { x: b.x, y: b.y };
+  const zc = { x: c.x, y: c.y };
+  const wa = ka;
+  const wb = kb;
+  const wc = kc;
+  const ws = wa + wb + wc;
+  const cx = (za.x * wa + zb.x * wb + zc.x * wc) / ws;
+  const cy = (za.y * wa + zb.y * wb + zc.y * wc) / ws;
+  // 近似した中心から 3 円への距離を元に微調整
+  const dx = cx - a.x;
+  const dy = cy - a.y;
+  const dist = Math.hypot(dx, dy);
+  if (dist === 0) return null;
+  const nx = a.x + (dx / dist) * (a.r - r);
+  const ny = a.y + (dy / dist) * (a.r - r);
+  return { x: nx, y: ny, r };
+}
+
+/**
+ * @param {{x:number,y:number,r:number}} c
+ * @param {number} hue
+ */
+function drawCircle(c, hue) {
+  if (c.r < 0.5) return;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.strokeAlpha})`;
+  ctx.fillStyle = `hsla(${hue}, 70%, 50%, ${params.fillAlpha})`;
+  ctx.lineWidth = params.thickness;
+  ctx.beginPath();
+  ctx.arc(c.x, c.y, c.r, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+}
+
+/**
+ * @param {{x:number,y:number,r:number}} a
+ * @param {{x:number,y:number,r:number}} b
+ * @param {{x:number,y:number,r:number}} c
+ * @param {number} depth
+ */
+function recurse(a, b, c, depth) {
+  if (depth <= 0) return;
+  const inner = innerCircle(a, b, c);
+  if (!inner || inner.r < 1) return;
+  const hue =
+    (params.hueStart + (params.maxDepth - depth) * params.hueRange) % 360;
+  drawCircle(inner, hue);
+  recurse(a, b, inner, depth - 1);
+  recurse(b, c, inner, depth - 1);
+  recurse(a, c, inner, depth - 1);
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.15)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const R =
+    Math.min(canvas.width, canvas.height) * params.outerScale * params.zoom;
+  const ang = params.rotation + time * params.rotSpeed;
+
+  const outer = { x: cx, y: cy, r: R };
+  drawCircle(outer, params.hueStart);
+
+  // 外側の円の内部に 3 つの等しい円（三つ葉配置）
+  const r3 = (R / (2 + 2 / Math.sqrt(3))) * params.innerRatio;
+  const d = R - r3;
+  /** @type {{x:number,y:number,r:number}[]} */
+  const inner3 = [];
+  for (let i = 0; i < 3; i++) {
+    const a = ang + (i * 2 * Math.PI) / 3;
+    inner3.push({ x: cx + Math.cos(a) * d, y: cy + Math.sin(a) * d, r: r3 });
+  }
+  if (params.showInner) {
+    for (let i = 0; i < 3; i++) {
+      drawCircle(inner3[i], params.hueStart + 30 + i * 20);
+    }
+  }
+
+  // 外接円と内側 2 円で再帰（境界は半径が負の円として扱うと正確だが、ここでは簡易近似）
+  recurse(inner3[0], inner3[1], inner3[2], params.maxDepth);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Apollonian Gasket',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'maxDepth', 1, 8, 1);
+gui.add(params, 'outerScale', 0.2, 0.55, 0.01);
+gui.add(params, 'innerRatio', 0.8, 1.1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'fillAlpha', 0, 0.5, 0.01);
+gui.add(params, 'thickness', 0.2, 4, 0.1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -1, 1, 0.01);
+gui.add(params, 'zoom', 0.5, 1.5, 0.01);
+gui.add(params, 'showInner');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.maxDepth = rand(4, 7, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(30, 240, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  params.innerRatio = rand(0.9, 1.05, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/apollonian-gasket/style.css
+++ b/public/apollonian-gasket/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/avalanche-cascade/index.html
+++ b/public/avalanche-cascade/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Avalanche Cascade | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/avalanche-cascade/main.js
+++ b/public/avalanche-cascade/main.js
@@ -1,0 +1,189 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 雪崩のカスケードをパーティクルで表現する。
+// 上部から粒子が生まれ、斜面を流れ落ちながら分岐・衝突する。
+
+const params = {
+  spawnRate: 8, // 1フレームの生成数
+  gravity: 0.25, // 重力加速度
+  bounce: 0.35, // 反発係数
+  spread: 1.2, // 横への広がり
+  slopeAngle: 35, // 斜面角度（度）
+  snowHue: 210, // 雪の色相
+  trailFade: 0.12, // 軌跡フェード
+  maxParticles: 2000, // 最大パーティクル数
+  windStrength: 0.3, // 風の強さ
+  snowSize: 2.0, // 雪粒サイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, life: number, size: number }} Snowflake */
+
+/** @type {Snowflake[]} */
+let flakes = [];
+
+let time = 0;
+
+/**
+ * 新しい雪粒を生成する
+ */
+function spawnFlake() {
+  const w = canvas.width;
+  const x = w * 0.2 + Math.random() * w * 0.3;
+  const angle = (params.slopeAngle * Math.PI) / 180;
+  const speed = 1 + Math.random() * 2;
+  flakes.push({
+    x,
+    y: canvas.height * 0.08 + Math.random() * canvas.height * 0.05,
+    vx: Math.cos(angle) * speed * (Math.random() - 0.3),
+    vy: Math.sin(angle) * speed,
+    life: 1.0,
+    size: params.snowSize * (0.5 + Math.random() * 0.8),
+  });
+}
+
+/**
+ * 雪粒を1ステップ更新する
+ * @param {Snowflake} f
+ * @returns {boolean} 生存していればtrue
+ */
+function updateFlake(f) {
+  // 風の揺れ
+  const wind = Math.sin(time * 1.3 + f.x * 0.01) * params.windStrength * 0.02;
+  f.vx += wind + (Math.random() - 0.5) * params.spread * 0.05;
+  f.vy += params.gravity * 0.05;
+
+  f.x += f.vx;
+  f.y += f.vy;
+
+  // 斜面との反発（斜面=Y方向に傾いた面）
+  const angle = (params.slopeAngle * Math.PI) / 180;
+  const slopeY =
+    canvas.height * 0.15 + Math.tan(angle) * (f.x - canvas.width * 0.2);
+  if (f.y > slopeY) {
+    f.y = slopeY;
+    // 斜面法線で反発
+    const nx = -Math.sin(angle);
+    const ny = Math.cos(angle);
+    const dot = f.vx * nx + f.vy * ny;
+    f.vx = (f.vx - 2 * dot * nx) * params.bounce + (Math.random() - 0.5) * 0.5;
+    f.vy = (f.vy - 2 * dot * ny) * params.bounce;
+  }
+
+  f.life -= 0.004;
+  return f.life > 0 && f.y < canvas.height + 20;
+}
+
+function draw() {
+  time += 0.016;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 斜面ライン描画
+  const angle = (params.slopeAngle * Math.PI) / 180;
+  const slopeStartX = w * 0.05;
+  const slopeStartY = h * 0.12;
+  const slopeEndX = w * 0.75;
+  const slopeEndY = slopeStartY + Math.tan(angle) * (slopeEndX - slopeStartX);
+  ctx.strokeStyle = 'rgba(150, 180, 220, 0.2)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(slopeStartX, slopeStartY);
+  ctx.lineTo(slopeEndX, slopeEndY);
+  ctx.stroke();
+
+  // 雪粒スポーン
+  for (let i = 0; i < params.spawnRate; i++) {
+    if (flakes.length < params.maxParticles) spawnFlake();
+  }
+
+  // 更新と描画
+  flakes = flakes.filter((f) => {
+    const alive = updateFlake(f);
+    if (alive) {
+      const brightness = 70 + f.life * 25;
+      ctx.fillStyle = `hsla(${params.snowHue}, 30%, ${brightness}%, ${f.life})`;
+      ctx.beginPath();
+      ctx.arc(f.x, f.y, f.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    return alive;
+  });
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Avalanche Cascade',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'spawnRate', 1, 30, 1);
+gui.add(params, 'gravity', 0.05, 1.0, 0.01);
+gui.add(params, 'bounce', 0.0, 0.9, 0.01);
+gui.add(params, 'spread', 0, 3.0, 0.05);
+gui.add(params, 'slopeAngle', 10, 70, 1);
+gui.add(params, 'snowHue', 0, 360, 1);
+gui.add(params, 'trailFade', 0.02, 0.5, 0.01);
+gui.add(params, 'windStrength', 0, 2.0, 0.05);
+gui.add(params, 'snowSize', 0.5, 5.0, 0.1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.gravity = rand(0.1, 0.8, 0.01);
+  params.bounce = rand(0.1, 0.8, 0.01);
+  params.spread = rand(0.2, 2.5, 0.05);
+  params.slopeAngle = rand(15, 60, 1);
+  params.snowHue = rand(180, 240, 1);
+  params.windStrength = rand(0.1, 1.5, 0.05);
+  params.snowSize = rand(0.8, 3.5, 0.1);
+  flakes = [];
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  flakes = [];
+  gui.updateDisplay();
+});

--- a/public/avalanche-cascade/style.css
+++ b/public/avalanche-cascade/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/aztec-geometry/index.html
+++ b/public/aztec-geometry/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Aztec Geometry | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/aztec-geometry/main.js
+++ b/public/aztec-geometry/main.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// アステカ幾何模様：段階的に縮小する正方形グリッドを回転させた
+// 入れ子構造のパターン。アステカ暦石の幾何学模様に着想。
+
+const params = {
+  layers: 8, // 入れ子レイヤー数
+  rotAngle: 15, // 各層の回転角（度）
+  hueStart: 30, // 開始色相（金）
+  hueEnd: 0, // 終了色相（赤）
+  saturation: 75, // 彩度
+  lightStart: 65, // 外側明度
+  lightEnd: 25, // 内側明度
+  strokeWidth: 1.5, // 枠線幅
+  sizeRatio: 0.85, // 縮小比率
+  animSpeed: 0.4, // アニメーション速度
+  pulseAmp: 0.05, // 脈動幅
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 回転した正方形を描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} size サイズ
+ * @param {number} angle 回転角（rad）
+ * @param {string} fillColor 塗り色
+ * @param {string} strokeColor 枠線色
+ */
+function drawSquare(cx, cy, size, angle, fillColor, strokeColor) {
+  const h = size / 2;
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(angle);
+  ctx.beginPath();
+  ctx.rect(-h, -h, size, size);
+  ctx.fillStyle = fillColor;
+  ctx.fill();
+  if (params.strokeWidth > 0) {
+    ctx.strokeStyle = strokeColor;
+    ctx.lineWidth = params.strokeWidth;
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+/**
+ * 装飾的なトライアングルを描く
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} size
+ * @param {number} angle
+ * @param {string} color
+ */
+function drawTriDecor(cx, cy, size, angle, color) {
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(angle);
+  ctx.beginPath();
+  ctx.moveTo(0, -size * 0.5);
+  ctx.lineTo(size * 0.3, size * 0.3);
+  ctx.lineTo(-size * 0.3, size * 0.3);
+  ctx.closePath();
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.restore();
+}
+
+function draw() {
+  time += params.animSpeed * 0.01;
+  const w = canvas.width;
+  const h = canvas.height;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, w, h);
+
+  const n = Math.max(2, Math.round(params.layers));
+  const maxSize = Math.min(w, h) * 0.92;
+  const pulse = 1 + Math.sin(time * 2) * params.pulseAmp;
+
+  for (let i = n - 1; i >= 0; i--) {
+    const t = i / (n - 1);
+    const size = maxSize * params.sizeRatio ** i * pulse;
+    const angle = (i * params.rotAngle * Math.PI) / 180 + time * 0.2;
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * (1 - t);
+    const lig =
+      params.lightStart + (params.lightEnd - params.lightStart) * (1 - t);
+    const sat = params.saturation;
+
+    drawSquare(
+      cx,
+      cy,
+      size,
+      angle,
+      `hsl(${hue}, ${sat}%, ${lig}%)`,
+      `hsl(0, 0%, 15%)`,
+    );
+
+    // 各角に装飾トライアングル
+    const corners = 4;
+    for (let k = 0; k < corners; k++) {
+      const a = angle + (k * Math.PI * 2) / corners;
+      const decX = cx + Math.cos(a + Math.PI / 4) * size * 0.42;
+      const decY = cy + Math.sin(a + Math.PI / 4) * size * 0.42;
+      const decHue = (hue + 60) % 360;
+      drawTriDecor(
+        decX,
+        decY,
+        size * 0.12,
+        a,
+        `hsl(${decHue}, ${sat}%, ${lig + 10}%)`,
+      );
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Aztec Geometry',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'layers', 2, 16, 1);
+gui.add(params, 'rotAngle', 0, 90, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightStart', 20, 90, 1);
+gui.add(params, 'lightEnd', 5, 60, 1);
+gui.add(params, 'sizeRatio', 0.5, 0.97, 0.01);
+gui.add(params, 'animSpeed', 0, 3, 0.05);
+gui.add(params, 'pulseAmp', 0, 0.3, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.layers = rand(4, 14, 1);
+  params.rotAngle = rand(5, 60, 0.5);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.saturation = rand(40, 90, 1);
+  params.sizeRatio = rand(0.7, 0.94, 0.01);
+  params.animSpeed = rand(0.1, 2, 0.05);
+  params.pulseAmp = rand(0, 0.2, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/aztec-geometry/style.css
+++ b/public/aztec-geometry/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/bacterial-colony/index.html
+++ b/public/bacterial-colony/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Bacterial Colony | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/bacterial-colony/main.js
+++ b/public/bacterial-colony/main.js
@@ -1,0 +1,210 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// バクテリアコロニー：DLA（拡散律速凝集）+ 分裂で成長するコロニー。
+// バクテリアがランダムウォークで集まり、接触すると固着・増殖する。
+
+const params = {
+  maxBacteria: 2000, // 最大バクテリア数
+  spawnRate: 3, // 1フレームの新規発生数
+  divisionRate: 0.003, // 分裂確率/フレーム
+  walkSpeed: 2.0, // ランダムウォーク速度
+  stickDist: 6, // 付着距離
+  hueStart: 120, // コロニー色相（緑）
+  hueEnd: 60, // 成長後の色相（黄）
+  brightness: 55, // 明度
+  fadeAlpha: 0.03, // フェード強度
+  bacteriaSize: 3, // バクテリアサイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  initColony();
+}
+window.addEventListener('resize', resize);
+
+/** @typedef {{ x: number, y: number, fixed: boolean, age: number }} Bacterium */
+
+/** @type {Bacterium[]} */
+let colony = [];
+/** @type {Bacterium[]} */
+let walkers = [];
+
+/**
+ * コロニーを初期化する（中心に核を配置）
+ */
+function initColony() {
+  colony = [{ x: canvas.width / 2, y: canvas.height / 2, fixed: true, age: 0 }];
+  walkers = [];
+}
+
+resize();
+
+/**
+ * 画面外からランダムウォーカーを発生させる
+ */
+function spawnWalker() {
+  const w = canvas.width;
+  const h = canvas.height;
+  const side = Math.floor(Math.random() * 4);
+  let x = 0;
+  let y = 0;
+  if (side === 0) {
+    x = Math.random() * w;
+    y = 0;
+  } else if (side === 1) {
+    x = w;
+    y = Math.random() * h;
+  } else if (side === 2) {
+    x = Math.random() * w;
+    y = h;
+  } else {
+    x = 0;
+    y = Math.random() * h;
+  }
+  walkers.push({ x, y, fixed: false, age: 0 });
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 新規ウォーカーを発生
+  for (
+    let i = 0;
+    i < params.spawnRate && colony.length + walkers.length < params.maxBacteria;
+    i++
+  ) {
+    spawnWalker();
+  }
+
+  // ウォーカーを更新
+  const toFix = /** @type {Bacterium[]} */ ([]);
+  walkers = walkers.filter((w2) => {
+    w2.x += (Math.random() - 0.5) * params.walkSpeed * 2;
+    w2.y += (Math.random() - 0.5) * params.walkSpeed * 2;
+    w2.age++;
+
+    // コロニーに近いか確認
+    for (const c of colony) {
+      const d = Math.hypot(w2.x - c.x, w2.y - c.y);
+      if (d < params.stickDist) {
+        w2.fixed = true;
+        toFix.push(w2);
+        return false;
+      }
+    }
+    // 画面外チェック
+    return w2.x >= -20 && w2.x <= w + 20 && w2.y >= -20 && w2.y <= h + 20;
+  });
+
+  for (const b of toFix) colony.push(b);
+
+  // 分裂
+  const newBacteria = /** @type {Bacterium[]} */ ([]);
+  for (const b of colony) {
+    b.age++;
+    if (
+      Math.random() < params.divisionRate &&
+      colony.length + newBacteria.length < params.maxBacteria
+    ) {
+      newBacteria.push({
+        x: b.x + (Math.random() - 0.5) * params.stickDist * 2,
+        y: b.y + (Math.random() - 0.5) * params.stickDist * 2,
+        fixed: true,
+        age: 0,
+      });
+    }
+  }
+  for (const b of newBacteria) colony.push(b);
+
+  // コロニーを描画
+  const s = params.bacteriaSize;
+  for (const b of colony) {
+    const t = Math.min(1, b.age / 300);
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+    ctx.fillStyle = `hsl(${hue}, 70%, ${params.brightness}%)`;
+    ctx.beginPath();
+    ctx.ellipse(b.x, b.y, s, s * 0.55, Math.random() * Math.PI, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // ウォーカーを描画
+  for (const w2 of walkers) {
+    ctx.fillStyle = `hsla(${params.hueStart}, 50%, 70%, 0.5)`;
+    ctx.beginPath();
+    ctx.arc(w2.x, w2.y, s * 0.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Bacterial Colony',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'spawnRate', 1, 15, 1);
+gui.add(params, 'divisionRate', 0, 0.02, 0.001);
+gui.add(params, 'walkSpeed', 0.5, 6, 0.1);
+gui.add(params, 'stickDist', 2, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'brightness', 20, 80, 1);
+gui.add(params, 'fadeAlpha', 0.005, 0.3, 0.005);
+gui.add(params, 'bacteriaSize', 1, 8, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.spawnRate = rand(1, 10, 1);
+  params.divisionRate = rand(0.001, 0.015, 0.001);
+  params.walkSpeed = rand(0.5, 4, 0.1);
+  params.stickDist = rand(3, 12, 0.5);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.brightness = rand(30, 70, 1);
+  initColony();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initColony();
+  gui.updateDisplay();
+});

--- a/public/bacterial-colony/style.css
+++ b/public/bacterial-colony/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/barnsley-fern/index.html
+++ b/public/barnsley-fern/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Barnsley Fern | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/barnsley-fern/main.js
+++ b/public/barnsley-fern/main.js
@@ -1,0 +1,160 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  pointsPerFrame: 2000, // 1 フレームで描く点の数
+  scale: 60, // 拡大率
+  offsetX: 0, // 水平オフセット
+  offsetY: 0.05, // 垂直オフセット（下寄せ）
+  hueBase: 120, // 色相ベース
+  hueRange: 40, // 色相レンジ
+  saturation: 70, // 彩度
+  pointAlpha: 0.35, // 点の不透明度
+  pointSize: 0.8, // 点サイズ
+  fadeAlpha: 0.02, // 残像フェード
+  probF2: 85, // 主葉の確率（%）
+  variation: 0, // ゆらぎ（0:標準 Barnsley / 1〜: アレンジ）
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 状態 ---
+
+let px = 0;
+let py = 0;
+let count = 0;
+
+function reset() {
+  px = 0;
+  py = 0;
+  count = 0;
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+// --- 反復関数系（バーンズリー） ---
+
+function step() {
+  const r = Math.random() * 100;
+  const v = params.variation * 0.02;
+  let nx;
+  let ny;
+  const p1 = 1;
+  const p2 = params.probF2;
+  const p3 = (100 - p2) / 2 + p2;
+  if (r < p1) {
+    nx = 0;
+    ny = 0.16 * py;
+  } else if (r < p2) {
+    nx = (0.85 + v) * px + 0.04 * py;
+    ny = -0.04 * px + (0.85 - v) * py + 1.6;
+  } else if (r < p3) {
+    nx = 0.2 * px - 0.26 * py;
+    ny = 0.23 * px + 0.22 * py + 1.6;
+  } else {
+    nx = -0.15 * px + 0.28 * py;
+    ny = 0.26 * px + 0.24 * py + 0.44;
+  }
+  px = nx;
+  py = ny;
+}
+
+function draw() {
+  // 残像フェード
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width * (0.5 + params.offsetX);
+  const cy = canvas.height * (1 - params.offsetY);
+  const s = params.scale;
+
+  for (let i = 0; i < params.pointsPerFrame; i++) {
+    step();
+    const sx = cx + px * s;
+    const sy = cy - py * s;
+    const hue = params.hueBase + Math.sin(count * 0.0001) * params.hueRange;
+    ctx.fillStyle = `hsla(${hue}, ${params.saturation}%, 55%, ${params.pointAlpha})`;
+    ctx.fillRect(sx, sy, params.pointSize, params.pointSize);
+    count++;
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Barnsley Fern',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'pointsPerFrame', 200, 8000, 100);
+gui.add(params, 'scale', 20, 140, 1);
+gui.add(params, 'offsetX', -0.4, 0.4, 0.01);
+gui.add(params, 'offsetY', -0.2, 0.3, 0.01);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 120, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'pointAlpha', 0.05, 1, 0.01);
+gui.add(params, 'pointSize', 0.3, 3, 0.1);
+gui.add(params, 'fadeAlpha', 0, 0.1, 0.005);
+gui.add(params, 'probF2', 60, 95, 1);
+gui.add(params, 'variation', 0, 3, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.scale = rand(40, 110, 1);
+  params.hueBase = rand(60, 200, 1);
+  params.hueRange = rand(10, 80, 1);
+  params.saturation = rand(40, 90, 1);
+  params.pointAlpha = rand(0.2, 0.6, 0.01);
+  params.probF2 = rand(70, 90, 1);
+  params.variation = rand(0, 2, 0.01);
+  gui.updateDisplay();
+  reset();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+  reset();
+});

--- a/public/barnsley-fern/style.css
+++ b/public/barnsley-fern/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/beat-interference/index.html
+++ b/public/beat-interference/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Beat Interference | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/beat-interference/main.js
+++ b/public/beat-interference/main.js
@@ -1,0 +1,166 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 周波数の近い 2 つのサイン波の重ね合わせでうなり（beat）を視覚化
+const params = {
+  freqA: 4,
+  freqB: 4.3,
+  freqC: 0,
+  amplitudeA: 80,
+  amplitudeB: 80,
+  amplitudeC: 0,
+  waveSpeed: 1.2,
+  lineDensity: 3, // 1px あたりのサンプル数
+  hueA: 200,
+  hueB: 40,
+  hueC: 280,
+  sumHue: 120,
+  glow: 0.7,
+  showEnvelope: true,
+  lineWidth: 1.2,
+  trailFade: 0.15,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function waveY(phase, freq, amp) {
+  return Math.sin(phase * freq) * amp;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const W = canvas.width;
+  const H = canvas.height;
+  const baseY = H * 0.3;
+  const midY = H * 0.62;
+
+  const xs = Math.max(1, Math.round(params.lineDensity));
+  // 各波を上に並べる
+  const waves = [
+    { f: params.freqA, a: params.amplitudeA, hue: params.hueA, y: baseY },
+    { f: params.freqB, a: params.amplitudeB, hue: params.hueB, y: baseY + 100 },
+    { f: params.freqC, a: params.amplitudeC, hue: params.hueC, y: baseY + 200 },
+  ];
+  for (const w of waves) {
+    ctx.strokeStyle = `hsla(${w.hue}, 80%, 65%, 0.85)`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += xs) {
+      const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+      const y = w.y + waveY(phase, w.f, w.a);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+
+  // 合成波（+エンベロープ）
+  ctx.strokeStyle = `hsla(${params.sumHue}, 90%, 70%, ${params.glow})`;
+  ctx.lineWidth = params.lineWidth + 0.6;
+  ctx.beginPath();
+  for (let x = 0; x <= W; x += xs) {
+    const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+    const y =
+      midY +
+      waveY(phase, params.freqA, params.amplitudeA) +
+      waveY(phase, params.freqB, params.amplitudeB) +
+      waveY(phase, params.freqC, params.amplitudeC);
+    if (x === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // エンベロープ
+  if (params.showEnvelope) {
+    const beatFreq = Math.abs(params.freqA - params.freqB);
+    const beatAmp = Math.min(params.amplitudeA, params.amplitudeB) * 2;
+    ctx.strokeStyle = `hsla(${params.sumHue + 30}, 90%, 80%, 0.5)`;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += xs) {
+      const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+      const env = beatAmp * Math.abs(Math.cos(phase * beatFreq * 0.5));
+      if (x === 0) {
+        ctx.moveTo(x, midY + env);
+      } else ctx.lineTo(x, midY + env);
+    }
+    ctx.stroke();
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += xs) {
+      const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+      const env = beatAmp * Math.abs(Math.cos(phase * beatFreq * 0.5));
+      if (x === 0) ctx.moveTo(x, midY - env);
+      else ctx.lineTo(x, midY - env);
+    }
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Beat Interference',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'freqA', 0.5, 20, 0.05);
+gui.add(params, 'freqB', 0.5, 20, 0.05);
+gui.add(params, 'freqC', 0, 20, 0.05);
+gui.add(params, 'amplitudeA', 10, 200, 1);
+gui.add(params, 'amplitudeB', 10, 200, 1);
+gui.add(params, 'amplitudeC', 0, 200, 1);
+gui.add(params, 'waveSpeed', 0, 3, 0.01);
+gui.add(params, 'hueA', 0, 360, 1);
+gui.add(params, 'hueB', 0, 360, 1);
+gui.add(params, 'hueC', 0, 360, 1);
+gui.add(params, 'sumHue', 0, 360, 1);
+gui.add(params, 'glow', 0.2, 1, 0.01);
+gui.add(params, 'showEnvelope');
+gui.add(params, 'lineWidth', 0.3, 3, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.5, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  const f = rand(2, 8, 0.05);
+  params.freqA = f;
+  params.freqB = f + rand(-0.5, 0.5, 0.01);
+  params.freqC = f * 2 + rand(-0.3, 0.3, 0.01);
+  params.hueA = rand(0, 360, 1);
+  params.hueB = (params.hueA + 180) % 360;
+  params.hueC = rand(0, 360, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/beat-interference/style.css
+++ b/public/beat-interference/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/bee-swarm/index.html
+++ b/public/bee-swarm/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Bee Swarm | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/bee-swarm/main.js
+++ b/public/bee-swarm/main.js
@@ -1,0 +1,286 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// ミツバチの群れ：花の蜜を探して飛び回るミツバチの群れ。
+// 各ミツバチは最も近い花に向かいながら群れを保つ。
+
+const params = {
+  beeCount: 120, // ミツバチの数
+  flowerCount: 5, // 花の数
+  attractForce: 0.04, // 花への引力
+  swarmForce: 0.02, // 群れへの引力
+  maxSpeed: 3.0, // 最高速度
+  beeHue: 55, // ミツバチの色相（黄色）
+  trailFade: 0.2, // フェード強度
+  beeSize: 4, // ミツバチのサイズ
+  wingFlap: 8, // 羽ばたき速度
+  turbulence: 0.3, // 乱気流
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, target: number, phase: number }} Bee */
+/** @typedef {{ x: number, y: number, nectar: number }} Flower */
+
+/** @type {Bee[]} */
+let bees = [];
+/** @type {Flower[]} */
+let flowers = [];
+
+/**
+ * 花を初期化する
+ */
+function initFlowers() {
+  flowers = [];
+  const n = Math.max(1, Math.round(params.flowerCount));
+  for (let i = 0; i < n; i++) {
+    flowers.push({
+      x: canvas.width * 0.1 + Math.random() * canvas.width * 0.8,
+      y: canvas.height * 0.1 + Math.random() * canvas.height * 0.8,
+      nectar: 0.5 + Math.random() * 0.5,
+    });
+  }
+}
+
+/**
+ * ミツバチを初期化する
+ */
+function initBees() {
+  bees = [];
+  for (let i = 0; i < params.beeCount; i++) {
+    bees.push({
+      x: canvas.width / 2 + (Math.random() - 0.5) * 200,
+      y: canvas.height / 2 + (Math.random() - 0.5) * 200,
+      vx: (Math.random() - 0.5) * 2,
+      vy: (Math.random() - 0.5) * 2,
+      target: Math.floor(Math.random() * Math.max(1, params.flowerCount)),
+      phase: Math.random() * Math.PI * 2,
+    });
+  }
+}
+
+initFlowers();
+initBees();
+
+let time = 0;
+
+/**
+ * ミツバチを1ステップ更新する
+ * @param {Bee} bee
+ */
+function updateBee(bee) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const flowerCount = flowers.length;
+  if (flowerCount === 0) return;
+
+  bee.target = Math.min(bee.target, flowerCount - 1);
+  const target = flowers[bee.target];
+
+  // 花への引力
+  bee.vx += (target.x - bee.x) * params.attractForce * 0.01;
+  bee.vy += (target.y - bee.y) * params.attractForce * 0.01;
+
+  // 群れへの引力（重心）
+  let cx = 0;
+  let cy = 0;
+  for (const b of bees) {
+    cx += b.x;
+    cy += b.y;
+  }
+  cx /= bees.length;
+  cy /= bees.length;
+  bee.vx += (cx - bee.x) * params.swarmForce * 0.005;
+  bee.vy += (cy - bee.y) * params.swarmForce * 0.005;
+
+  // 乱気流
+  bee.vx += (Math.random() - 0.5) * params.turbulence * 0.2;
+  bee.vy += (Math.random() - 0.5) * params.turbulence * 0.2;
+
+  // 速度制限
+  const speed = Math.hypot(bee.vx, bee.vy);
+  if (speed > params.maxSpeed) {
+    bee.vx = (bee.vx / speed) * params.maxSpeed;
+    bee.vy = (bee.vy / speed) * params.maxSpeed;
+  }
+
+  bee.x += bee.vx;
+  bee.y += bee.vy;
+  bee.phase += params.wingFlap * 0.1;
+
+  // 花に到達したら次の花へ
+  if (Math.hypot(bee.x - target.x, bee.y - target.y) < 15) {
+    bee.target = Math.floor(Math.random() * flowerCount);
+  }
+
+  // 画面折り返し
+  if (bee.x < 0) bee.x += w;
+  if (bee.x > w) bee.x -= w;
+  if (bee.y < 0) bee.y += h;
+  if (bee.y > h) bee.y -= h;
+}
+
+/**
+ * ミツバチを描く
+ * @param {Bee} bee
+ */
+function drawBee(bee) {
+  const angle = Math.atan2(bee.vy, bee.vx);
+  const s = params.beeSize;
+  ctx.save();
+  ctx.translate(bee.x, bee.y);
+  ctx.rotate(angle);
+
+  // 羽
+  const wingSpread = Math.sin(bee.phase) * s * 1.5;
+  ctx.fillStyle = 'rgba(200, 230, 255, 0.5)';
+  ctx.beginPath();
+  ctx.ellipse(
+    0,
+    -s * 0.5,
+    s * 1.2,
+    s * 0.5 + Math.abs(wingSpread) * 0.3,
+    0.4,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+  ctx.beginPath();
+  ctx.ellipse(
+    0,
+    s * 0.5,
+    s * 1.2,
+    s * 0.5 + Math.abs(wingSpread) * 0.3,
+    -0.4,
+    0,
+    Math.PI * 2,
+  );
+  ctx.fill();
+
+  // 胴体（縞模様）
+  ctx.beginPath();
+  ctx.ellipse(0, 0, s * 1.5, s * 0.7, 0, 0, Math.PI * 2);
+  ctx.fillStyle = `hsl(${params.beeHue}, 85%, 55%)`;
+  ctx.fill();
+
+  ctx.restore();
+}
+
+/**
+ * 花を描く
+ * @param {Flower} flower
+ * @param {number} t 時間
+ */
+function drawFlower(flower, t) {
+  const r = 12 + flower.nectar * 8;
+  const petals = 6;
+  ctx.save();
+  ctx.translate(flower.x, flower.y);
+  ctx.rotate(t * 0.3);
+  for (let i = 0; i < petals; i++) {
+    const a = (i * Math.PI * 2) / petals;
+    const px = Math.cos(a) * r;
+    const py = Math.sin(a) * r;
+    ctx.beginPath();
+    ctx.ellipse(px, py, r * 0.5, r * 0.25, a, 0, Math.PI * 2);
+    ctx.fillStyle = `hsl(${(t * 50 + i * 60) % 360}, 80%, 65%)`;
+    ctx.fill();
+  }
+  ctx.beginPath();
+  ctx.arc(0, 0, r * 0.4, 0, Math.PI * 2);
+  ctx.fillStyle = 'hsl(55, 90%, 70%)';
+  ctx.fill();
+  ctx.restore();
+}
+
+function draw() {
+  time += 0.016;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, w, h);
+
+  for (const flower of flowers) drawFlower(flower, time);
+  for (const bee of bees) {
+    updateBee(bee);
+    drawBee(bee);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Bee Swarm',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'beeCount', 20, 300, 10).onChange(initBees);
+gui.add(params, 'flowerCount', 1, 15, 1).onChange(() => {
+  initFlowers();
+  initBees();
+});
+gui.add(params, 'attractForce', 0.005, 0.2, 0.005);
+gui.add(params, 'swarmForce', 0, 0.15, 0.005);
+gui.add(params, 'maxSpeed', 0.5, 8, 0.1);
+gui.add(params, 'beeHue', 0, 360, 1);
+gui.add(params, 'turbulence', 0, 2, 0.05);
+gui.add(params, 'wingFlap', 1, 20, 0.5);
+gui.add(params, 'beeSize', 1, 12, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.beeCount = rand(40, 200, 10);
+  params.flowerCount = rand(2, 10, 1);
+  params.attractForce = rand(0.01, 0.15, 0.005);
+  params.swarmForce = rand(0, 0.1, 0.005);
+  params.maxSpeed = rand(1, 6, 0.1);
+  params.beeHue = rand(0, 360, 1);
+  params.turbulence = rand(0, 1.5, 0.05);
+  initFlowers();
+  initBees();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initFlowers();
+  initBees();
+  gui.updateDisplay();
+});

--- a/public/bee-swarm/style.css
+++ b/public/bee-swarm/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/bird-murmuration/index.html
+++ b/public/bird-murmuration/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Bird Murmuration | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/bird-murmuration/main.js
+++ b/public/bird-murmuration/main.js
@@ -1,0 +1,252 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 鳥の群れの旋回（マーマレーション）：椋鳥の大群が夕暮れに旋回する現象。
+// 3D空間でBoidルールを適用し、波のように変形する群れを表現する。
+
+const params = {
+  count: 300, // 鳥の数
+  separateDist: 15, // 分離距離
+  alignDist: 40, // 整列距離
+  cohesionDist: 60, // 結合距離
+  separateForce: 2.0, // 分離力
+  alignForce: 1.2, // 整列力
+  cohesionForce: 0.8, // 結合力
+  maxSpeed: 4.0, // 最高速度
+  birdHue: 220, // 鳥の色相
+  trailFade: 0.2, // フェード強度
+  rotSpeed: 0.2, // 視点回転速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, z: number, vx: number, vy: number, vz: number }} Bird */
+
+/** @type {Bird[]} */
+let birds = [];
+
+/**
+ * 鳥の群れを初期化する
+ */
+function initBirds() {
+  birds = [];
+  const spread = 200;
+  for (let i = 0; i < params.count; i++) {
+    birds.push({
+      x: (Math.random() - 0.5) * spread,
+      y: (Math.random() - 0.5) * spread,
+      z: (Math.random() - 0.5) * spread,
+      vx: (Math.random() - 0.5) * params.maxSpeed,
+      vy: (Math.random() - 0.5) * params.maxSpeed,
+      vz: (Math.random() - 0.5) * params.maxSpeed,
+    });
+  }
+}
+initBirds();
+
+let rotAngle = 0;
+
+/**
+ * Boidルールを適用して鳥の速度を更新する
+ */
+function updateBirds() {
+  for (const bird of birds) {
+    let sepX = 0,
+      sepY = 0,
+      sepZ = 0;
+    let aliVx = 0,
+      aliVy = 0,
+      aliVz = 0;
+    let cohX = 0,
+      cohY = 0,
+      cohZ = 0;
+    let sepN = 0,
+      aliN = 0,
+      cohN = 0;
+
+    for (const other of birds) {
+      if (other === bird) continue;
+      const d = Math.hypot(
+        bird.x - other.x,
+        bird.y - other.y,
+        bird.z - other.z,
+      );
+      if (d < params.separateDist && d > 0) {
+        sepX += (bird.x - other.x) / d;
+        sepY += (bird.y - other.y) / d;
+        sepZ += (bird.z - other.z) / d;
+        sepN++;
+      }
+      if (d < params.alignDist) {
+        aliVx += other.vx;
+        aliVy += other.vy;
+        aliVz += other.vz;
+        aliN++;
+      }
+      if (d < params.cohesionDist) {
+        cohX += other.x;
+        cohY += other.y;
+        cohZ += other.z;
+        cohN++;
+      }
+    }
+
+    if (sepN > 0) {
+      bird.vx += (sepX / sepN) * params.separateForce * 0.05;
+      bird.vy += (sepY / sepN) * params.separateForce * 0.05;
+      bird.vz += (sepZ / sepN) * params.separateForce * 0.05;
+    }
+    if (aliN > 0) {
+      bird.vx += (aliVx / aliN - bird.vx) * params.alignForce * 0.04;
+      bird.vy += (aliVy / aliN - bird.vy) * params.alignForce * 0.04;
+      bird.vz += (aliVz / aliN - bird.vz) * params.alignForce * 0.04;
+    }
+    if (cohN > 0) {
+      bird.vx += (cohX / cohN - bird.x) * params.cohesionForce * 0.001;
+      bird.vy += (cohY / cohN - bird.y) * params.cohesionForce * 0.001;
+      bird.vz += (cohZ / cohN - bird.z) * params.cohesionForce * 0.001;
+    }
+
+    // 中心への引力（群れが離散しないよう）
+    bird.vx -= bird.x * 0.002;
+    bird.vy -= bird.y * 0.002;
+    bird.vz -= bird.z * 0.002;
+
+    const speed = Math.hypot(bird.vx, bird.vy, bird.vz);
+    if (speed > params.maxSpeed) {
+      bird.vx = (bird.vx / speed) * params.maxSpeed;
+      bird.vy = (bird.vy / speed) * params.maxSpeed;
+      bird.vz = (bird.vz / speed) * params.maxSpeed;
+    }
+
+    bird.x += bird.vx;
+    bird.y += bird.vy;
+    bird.z += bird.vz;
+  }
+}
+
+/**
+ * 3D点を2D投影する
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @returns {{sx: number, sy: number, sz: number}}
+ */
+function project(x, y, z) {
+  const cosA = Math.cos(rotAngle);
+  const sinA = Math.sin(rotAngle);
+  const x2 = x * cosA - z * sinA;
+  const z2 = x * sinA + z * cosA;
+  const fov = 600;
+  const depth = z2 + 600;
+  const scale = fov / depth;
+  return {
+    sx: canvas.width / 2 + x2 * scale,
+    sy: canvas.height / 2 + y * scale,
+    sz: z2,
+  };
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+  rotAngle += params.rotSpeed * 0.005;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, w, h);
+
+  updateBirds();
+
+  // 奥から手前の順にソートして描画
+  const sorted = birds.slice().sort((a, b) => {
+    const pa = project(a.x, a.y, a.z);
+    const pb = project(b.x, b.y, b.z);
+    return pb.sz - pa.sz;
+  });
+
+  for (const bird of sorted) {
+    const { sx, sy, sz } = project(bird.x, bird.y, bird.z);
+    const depth = (sz + 500) / 1000;
+    const size = Math.max(0.5, depth * 5);
+    const alpha = Math.max(0.2, depth);
+    const hue = params.birdHue + (1 - depth) * 30;
+    ctx.fillStyle = `hsla(${hue}, 65%, ${40 + depth * 30}%, ${alpha})`;
+    ctx.beginPath();
+    ctx.arc(sx, sy, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Bird Murmuration',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 50, 600, 25).onChange(initBirds);
+gui.add(params, 'separateDist', 5, 50, 1);
+gui.add(params, 'alignDist', 15, 100, 1);
+gui.add(params, 'cohesionDist', 20, 150, 1);
+gui.add(params, 'separateForce', 0, 5, 0.1);
+gui.add(params, 'alignForce', 0, 3, 0.05);
+gui.add(params, 'cohesionForce', 0, 3, 0.05);
+gui.add(params, 'maxSpeed', 1, 10, 0.1);
+gui.add(params, 'birdHue', 0, 360, 1);
+gui.add(params, 'rotSpeed', 0, 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.separateDist = rand(5, 30, 1);
+  params.alignDist = rand(20, 80, 1);
+  params.cohesionDist = rand(30, 120, 1);
+  params.separateForce = rand(0.5, 4, 0.1);
+  params.alignForce = rand(0.3, 2.5, 0.05);
+  params.cohesionForce = rand(0.2, 2, 0.05);
+  params.maxSpeed = rand(2, 8, 0.1);
+  params.birdHue = rand(0, 360, 1);
+  initBirds();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initBirds();
+  gui.updateDisplay();
+});

--- a/public/bird-murmuration/style.css
+++ b/public/bird-murmuration/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/burning-ship/index.html
+++ b/public/burning-ship/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Burning Ship | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/burning-ship/main.js
+++ b/public/burning-ship/main.js
@@ -1,0 +1,202 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 燃える船フラクタル：マンデルブロ変形。
+// z^2 + c の代わりに (|Re(z)| + i|Im(z)|)^2 + c を使い、
+// 船が燃えているような不思議なフラクタルを生成する。
+
+const params = {
+  centerX: -1.75, // 中心X
+  centerY: -0.04, // 中心Y
+  scale: 3.5, // 表示スケール
+  maxIter: 150, // 最大反復回数
+  hueOffset: 20, // 色相オフセット（橙・炎色）
+  hueScale: 4.0, // 色相スケール
+  brightness: 65, // 明度
+  saturation: 85, // 彩度
+  zoomSpeed: 0.003, // ズーム速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+const SCALE = 0.35;
+const offscreen = document.createElement('canvas');
+const offCtx = /** @type {CanvasRenderingContext2D} */ (
+  offscreen.getContext('2d')
+);
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  offscreen.width = Math.round(canvas.width * SCALE);
+  offscreen.height = Math.round(canvas.height * SCALE);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let zoom = 1;
+
+/**
+ * Burning Ship フラクタルの反復回数を計算する
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} maxIter
+ * @returns {number}
+ */
+function burningShip(cx, cy, maxIter) {
+  let zx = 0;
+  let zy = 0;
+  let iter = 0;
+  while (iter < maxIter && zx * zx + zy * zy <= 4) {
+    const absZx = Math.abs(zx);
+    const absZy = Math.abs(zy);
+    const tmp = absZx * absZx - absZy * absZy + cx;
+    zy = 2 * absZx * absZy + cy;
+    zx = tmp;
+    iter++;
+  }
+  if (iter < maxIter) {
+    const logZn = Math.log(zx * zx + zy * zy) / 2;
+    const nu = Math.log(logZn / Math.log(2)) / Math.log(2);
+    return iter + 1 - nu;
+  }
+  return iter;
+}
+
+/**
+ * 反復回数を色に変換する（炎の色調）
+ * @param {number} iter
+ * @param {number} maxIter
+ * @returns {{r: number, g: number, b: number}}
+ */
+function iterToColor(iter, maxIter) {
+  if (iter >= maxIter) return { r: 0, g: 0, b: 0 };
+  const t = iter / maxIter;
+  const hue = (params.hueOffset + t * 360 * params.hueScale) % 360;
+  const sat = params.saturation / 100;
+  const lig = (params.brightness / 100) * t ** 0.25;
+
+  const h0 = hue / 60;
+  const c0 = (1 - Math.abs(2 * lig - 1)) * sat;
+  const x0 = c0 * (1 - Math.abs((h0 % 2) - 1));
+  const m0 = lig - c0 / 2;
+  let r0 = 0,
+    g0 = 0,
+    b0 = 0;
+  if (h0 < 1) {
+    r0 = c0;
+    g0 = x0;
+  } else if (h0 < 2) {
+    r0 = x0;
+    g0 = c0;
+  } else if (h0 < 3) {
+    g0 = c0;
+    b0 = x0;
+  } else if (h0 < 4) {
+    g0 = x0;
+    b0 = c0;
+  } else if (h0 < 5) {
+    r0 = x0;
+    b0 = c0;
+  } else {
+    r0 = c0;
+    b0 = x0;
+  }
+
+  return {
+    r: Math.round((r0 + m0) * 255),
+    g: Math.round((g0 + m0) * 255),
+    b: Math.round((b0 + m0) * 255),
+  };
+}
+
+function draw() {
+  zoom *= 1 + params.zoomSpeed;
+
+  const ow = offscreen.width;
+  const oh = offscreen.height;
+  const imgData = offCtx.createImageData(ow, oh);
+  const data = imgData.data;
+
+  const viewScale = params.scale / (ow * zoom);
+  const maxIter = Math.round(params.maxIter);
+
+  for (let py = 0; py < oh; py++) {
+    for (let px = 0; px < ow; px++) {
+      const x = (px - ow / 2) * viewScale + params.centerX;
+      const y = (py - oh / 2) * viewScale + params.centerY;
+      const iter = burningShip(x, y, maxIter);
+      const { r, g, b } = iterToColor(iter, maxIter);
+      const idx = (py * ow + px) * 4;
+      data[idx] = r;
+      data[idx + 1] = g;
+      data[idx + 2] = b;
+      data[idx + 3] = 255;
+    }
+  }
+  offCtx.putImageData(imgData, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(offscreen, 0, 0, canvas.width, canvas.height);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Burning Ship',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'centerX', -3, 2, 0.0001);
+gui.add(params, 'centerY', -2, 2, 0.0001);
+gui.add(params, 'scale', 0.5, 10, 0.1);
+gui.add(params, 'maxIter', 50, 500, 10);
+gui.add(params, 'zoomSpeed', 0, 0.03, 0.001);
+gui.add(params, 'hueOffset', 0, 360, 1);
+gui.add(params, 'hueScale', 0.5, 10, 0.1);
+gui.add(params, 'brightness', 20, 90, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.hueOffset = rand(0, 360, 1);
+  params.hueScale = rand(1, 8, 0.1);
+  params.brightness = rand(40, 80, 1);
+  params.saturation = rand(60, 100, 1);
+  zoom = 1;
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  zoom = 1;
+  gui.updateDisplay();
+});

--- a/public/burning-ship/style.css
+++ b/public/burning-ship/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/cell-division/index.html
+++ b/public/cell-division/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Cell Division | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/cell-division/main.js
+++ b/public/cell-division/main.js
@@ -1,0 +1,215 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 細胞分裂アニメーション: 一定時間ごとに分裂して増え、重なり合う。
+const params = {
+  divisionInterval: 3.5,
+  maxCells: 200,
+  startRadius: 28,
+  shrinkPerGeneration: 0.85,
+  drift: 10,
+  wobble: 0.4,
+  hueStart: 280,
+  hueRange: 200,
+  fillAlpha: 0.5,
+  strokeAlpha: 0.8,
+  trailFade: 0.1,
+  autoReset: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Cell
+ * @property {number} x
+ * @property {number} y
+ * @property {number} r
+ * @property {number} vx
+ * @property {number} vy
+ * @property {number} gen
+ * @property {number} phase // 0..1  分裂アニメ進捗
+ * @property {boolean} dividing
+ * @property {number} hue
+ */
+
+/** @type {Cell[]} */
+let cells = [];
+let time = 0;
+let lastDivision = 0;
+
+function reset() {
+  cells = [
+    {
+      x: canvas.width / 2,
+      y: canvas.height / 2,
+      r: params.startRadius,
+      vx: 0,
+      vy: 0,
+      gen: 0,
+      phase: 0,
+      dividing: false,
+      hue: params.hueStart,
+    },
+  ];
+}
+reset();
+
+function divide() {
+  /** @type {Cell[]} */
+  const next = [];
+  for (const c of cells) {
+    if (cells.length + next.length >= params.maxCells) {
+      next.push(c);
+      continue;
+    }
+    const a = Math.random() * Math.PI * 2;
+    const sep = c.r * 1.1;
+    const newR = c.r * params.shrinkPerGeneration;
+    const newHue = c.hue + (Math.random() - 0.5) * 30;
+    next.push({
+      x: c.x + Math.cos(a) * sep,
+      y: c.y + Math.sin(a) * sep,
+      r: newR,
+      vx: c.vx + Math.cos(a) * params.drift,
+      vy: c.vy + Math.sin(a) * params.drift,
+      gen: c.gen + 1,
+      phase: 0,
+      dividing: false,
+      hue: newHue,
+    });
+    next.push({
+      x: c.x - Math.cos(a) * sep,
+      y: c.y - Math.sin(a) * sep,
+      r: newR,
+      vx: c.vx - Math.cos(a) * params.drift,
+      vy: c.vy - Math.sin(a) * params.drift,
+      gen: c.gen + 1,
+      phase: 0,
+      dividing: false,
+      hue: newHue + params.hueRange / 6,
+    });
+  }
+  cells = next;
+}
+
+function draw() {
+  const dt = 1 / 60;
+  time += dt;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (time - lastDivision > params.divisionInterval) {
+    lastDivision = time;
+    if (cells.length < params.maxCells) divide();
+    else if (params.autoReset) reset();
+  }
+
+  for (const c of cells) {
+    // 移動
+    c.x += c.vx * dt;
+    c.y += c.vy * dt;
+    c.vx *= 0.985;
+    c.vy *= 0.985;
+    // 壁
+    if (c.x < c.r) {
+      c.x = c.r;
+      c.vx = Math.abs(c.vx);
+    }
+    if (c.x > canvas.width - c.r) {
+      c.x = canvas.width - c.r;
+      c.vx = -Math.abs(c.vx);
+    }
+    if (c.y < c.r) {
+      c.y = c.r;
+      c.vy = Math.abs(c.vy);
+    }
+    if (c.y > canvas.height - c.r) {
+      c.y = canvas.height - c.r;
+      c.vy = -Math.abs(c.vy);
+    }
+    const wob = Math.sin(time * 3 + c.x * 0.01) * params.wobble;
+    ctx.fillStyle = `hsla(${c.hue}, 80%, 60%, ${params.fillAlpha})`;
+    ctx.strokeStyle = `hsla(${c.hue}, 90%, 80%, ${params.strokeAlpha})`;
+    ctx.lineWidth = 1.4;
+    ctx.beginPath();
+    const segs = 24;
+    for (let i = 0; i <= segs; i++) {
+      const a = (i / segs) * Math.PI * 2;
+      const r = c.r * (1 + Math.sin(a * 3 + time * 2) * wob * 0.15);
+      const px = c.x + Math.cos(a) * r;
+      const py = c.y + Math.sin(a) * r;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+    // 核
+    ctx.fillStyle = `hsla(${c.hue}, 95%, 75%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(c.x, c.y, c.r * 0.2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Cell Division',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'divisionInterval', 1, 10, 0.1);
+gui.add(params, 'maxCells', 20, 400, 5);
+gui.add(params, 'startRadius', 10, 60, 1);
+gui.add(params, 'shrinkPerGeneration', 0.6, 1, 0.01);
+gui.add(params, 'drift', 0, 40, 0.5);
+gui.add(params, 'wobble', 0, 1, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'fillAlpha', 0.1, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'autoReset');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Divide', () => divide());
+gui.addButton('Random', () => {
+  params.divisionInterval = rand(2, 6, 0.1);
+  params.shrinkPerGeneration = rand(0.78, 0.95, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.drift = rand(5, 25, 0.5);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/cell-division/style.css
+++ b/public/cell-division/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/celtic-knot/index.html
+++ b/public/celtic-knot/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Celtic Knot | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/celtic-knot/main.js
+++ b/public/celtic-knot/main.js
@@ -1,0 +1,189 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// ケルト結び目模様：交差する帯が上下に交互に組み合わさるパターン。
+// グリッドベースで交差点を生成し、スプライン曲線で結ぶ。
+
+const params = {
+  gridSize: 5, // グリッド分割数
+  strandWidth: 12, // 帯の幅
+  gapWidth: 4, // 交差部のギャップ
+  hueStrand1: 30, // 帯1の色相（金色）
+  hueStrand2: 200, // 帯2の色相（青）
+  saturation: 70, // 彩度
+  lightness: 55, // 明度
+  bgHue: 30, // 背景色相
+  bgSat: 40, // 背景彩度
+  bgLight: 8, // 背景明度
+  animSpeed: 0.3, // アニメーション速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 1本のストランドセグメント（曲線帯）を描く
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @param {string} color
+ * @param {number} width
+ */
+function drawStrand(x1, y1, x2, y2, color, width) {
+  const mx = (x1 + x2) / 2;
+  const my = (y1 + y2) / 2;
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.quadraticCurveTo(mx, my, x2, y2);
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+  ctx.lineCap = 'round';
+  ctx.stroke();
+}
+
+/**
+ * 交差点を描く（上下の帯を表現）
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} cellSize
+ * @param {boolean} overH 水平が上か
+ */
+function drawCrossing(cx, cy, cellSize, overH) {
+  const h = params.strandWidth;
+  const gap = params.gapWidth;
+  const c1 = `hsl(${params.hueStrand1}, ${params.saturation}%, ${params.lightness}%)`;
+  const c2 = `hsl(${params.hueStrand2}, ${params.saturation}%, ${params.lightness}%)`;
+  const shadow = `hsl(${params.bgHue}, ${params.bgSat}%, ${params.bgLight}%)`;
+
+  const half = cellSize / 2;
+
+  if (overH) {
+    // 垂直ストランドを先に描く（下）
+    drawStrand(cx, cy - half, cx, cy + half, c2, h);
+    // 水平ストランドのギャップ部分（影で隠す）
+    drawStrand(cx - half, cy, cx + half, cy, shadow, h + gap * 2);
+    // 水平ストランドを上に描く
+    drawStrand(cx - half, cy, cx + half, cy, c1, h);
+  } else {
+    drawStrand(cx - half, cy, cx + half, cy, c1, h);
+    drawStrand(cx, cy - half, cx, cy + half, shadow, h + gap * 2);
+    drawStrand(cx, cy - half, cx, cy + half, c2, h);
+  }
+}
+
+function draw() {
+  time += params.animSpeed * 0.01;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `hsl(${params.bgHue}, ${params.bgSat}%, ${params.bgLight}%)`;
+  ctx.fillRect(0, 0, w, h);
+
+  const n = Math.max(2, Math.round(params.gridSize));
+  const size = Math.min(w, h) * 0.85;
+  const cellSize = size / n;
+  const ox = (w - size) / 2 + cellSize / 2;
+  const oy = (h - size) / 2 + cellSize / 2;
+
+  // ストランドの直線部分を先に描く
+  const c1 = `hsl(${params.hueStrand1}, ${params.saturation}%, ${params.lightness}%)`;
+  const c2 = `hsl(${params.hueStrand2}, ${params.saturation}%, ${params.lightness}%)`;
+  const sw = params.strandWidth;
+
+  for (let row = 0; row < n; row++) {
+    for (let col = 0; col < n; col++) {
+      const cx = ox + col * cellSize;
+      const cy = oy + row * cellSize;
+      // 水平ストランド
+      if (col < n - 1) {
+        drawStrand(cx, cy, cx + cellSize, cy, c1, sw);
+      }
+      // 垂直ストランド
+      if (row < n - 1) {
+        drawStrand(cx, cy, cx, cy + cellSize, c2, sw);
+      }
+    }
+  }
+
+  // 交差点を描く（アニメーション付き）
+  for (let row = 0; row < n - 1; row++) {
+    for (let col = 0; col < n - 1; col++) {
+      const cx = ox + col * cellSize + cellSize / 2;
+      const cy = oy + row * cellSize + cellSize / 2;
+      const overH = (row + col + Math.floor(time)) % 2 === 0;
+      drawCrossing(cx, cy, cellSize, overH);
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Celtic Knot',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'gridSize', 2, 12, 1);
+gui.add(params, 'strandWidth', 4, 30, 1);
+gui.add(params, 'gapWidth', 1, 12, 1);
+gui.add(params, 'hueStrand1', 0, 360, 1);
+gui.add(params, 'hueStrand2', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 20, 90, 1);
+gui.add(params, 'animSpeed', 0, 3, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.gridSize = rand(3, 10, 1);
+  params.strandWidth = rand(6, 22, 1);
+  params.gapWidth = rand(2, 8, 1);
+  params.hueStrand1 = rand(0, 360, 1);
+  params.hueStrand2 = rand(0, 360, 1);
+  params.saturation = rand(40, 90, 1);
+  params.lightness = rand(35, 75, 1);
+  params.animSpeed = rand(0.1, 2, 0.05);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/celtic-knot/style.css
+++ b/public/celtic-knot/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/chord-wheel/index.html
+++ b/public/chord-wheel/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Chord Wheel | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/chord-wheel/main.js
+++ b/public/chord-wheel/main.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 五度圏の上で和音構成音を結んで表示する。自動ルート遷移で和音が変化していく。
+const params = {
+  root: 0, // 0-11 (C,G,D,...の五度圏順)
+  chordType: 0, // 0:major 1:minor 2:dim 3:aug 4:sus4 5:maj7 6:7 7:m7
+  autoChange: true,
+  speed: 0.4,
+  radius: 280,
+  hueStart: 0,
+  hueRange: 360,
+  lineAlpha: 0.8,
+  fillAlpha: 0.18,
+  lineWidth: 2.2,
+  trailFade: 0.1,
+  bloom: 0.7,
+};
+const defaults = { ...params };
+
+const circleOfFifths = [
+  'C',
+  'G',
+  'D',
+  'A',
+  'E',
+  'B',
+  'F#',
+  'C#',
+  'G#',
+  'D#',
+  'A#',
+  'F',
+];
+const chordDefs = [
+  { name: 'maj', intervals: [0, 4, 7] },
+  { name: 'min', intervals: [0, 3, 7] },
+  { name: 'dim', intervals: [0, 3, 6] },
+  { name: 'aug', intervals: [0, 4, 8] },
+  { name: 'sus4', intervals: [0, 5, 7] },
+  { name: 'maj7', intervals: [0, 4, 7, 11] },
+  { name: '7', intervals: [0, 4, 7, 10] },
+  { name: 'm7', intervals: [0, 3, 7, 10] },
+];
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function chromaticToFifthIndex(chromatic) {
+  // 半音番号 0..11 を五度圏位置に変換
+  return (chromatic * 7) % 12;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  if (params.autoChange) {
+    const beat = Math.floor(time * params.speed);
+    params.root = beat % 12;
+    if (beat % 4 === 0)
+      params.chordType = Math.floor(beat / 4) % chordDefs.length;
+  }
+
+  const root = Math.round(params.root);
+  const cType = Math.round(params.chordType) % chordDefs.length;
+  const chord = chordDefs[cType];
+
+  // 五度圏 12 点
+  for (let i = 0; i < 12; i++) {
+    const a = -Math.PI / 2 + (i / 12) * Math.PI * 2;
+    const x = cx + Math.cos(a) * params.radius;
+    const y = cy + Math.sin(a) * params.radius;
+    const hue = params.hueStart + (i / 12) * params.hueRange;
+    ctx.fillStyle = `hsla(${hue}, 70%, 55%, 0.6)`;
+    ctx.beginPath();
+    ctx.arc(x, y, 8, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = 'rgba(230,230,230,0.9)';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(circleOfFifths[i], x, y - 22);
+  }
+
+  // 和音構成音を結ぶ
+  const notes = chord.intervals.map((iv) => (root + iv) % 12);
+  const positions = notes.map((n) => {
+    const fIdx = chromaticToFifthIndex(n);
+    const a = -Math.PI / 2 + (fIdx / 12) * Math.PI * 2;
+    return {
+      x: cx + Math.cos(a) * params.radius,
+      y: cy + Math.sin(a) * params.radius,
+    };
+  });
+
+  // 塗り
+  const rootHue =
+    params.hueStart + (chromaticToFifthIndex(root) / 12) * params.hueRange;
+  ctx.fillStyle = `hsla(${rootHue}, 80%, 55%, ${params.fillAlpha})`;
+  ctx.beginPath();
+  ctx.moveTo(positions[0].x, positions[0].y);
+  for (let i = 1; i < positions.length; i++)
+    ctx.lineTo(positions[i].x, positions[i].y);
+  ctx.closePath();
+  ctx.fill();
+
+  // 線
+  ctx.strokeStyle = `hsla(${rootHue}, 90%, 70%, ${params.lineAlpha})`;
+  ctx.lineWidth = params.lineWidth;
+  ctx.stroke();
+
+  // 構成音マーク
+  for (const p of positions) {
+    ctx.fillStyle = `hsla(${rootHue}, 100%, 80%, ${params.bloom})`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 12, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = `hsla(${rootHue}, 100%, 90%, 1)`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // ラベル
+  ctx.fillStyle = 'rgba(230,230,230,0.9)';
+  ctx.font = '24px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const rootName = circleOfFifths[chromaticToFifthIndex(root)];
+  ctx.fillText(`${rootName}${chord.name}`, cx, cy);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Chord Wheel',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'root', 0, 11, 1);
+gui.add(params, 'chordType', 0, 7, 1);
+gui.add(params, 'autoChange');
+gui.add(params, 'speed', 0.1, 2, 0.01);
+gui.add(params, 'radius', 150, 400, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'lineAlpha', 0.1, 1, 0.01);
+gui.add(params, 'fillAlpha', 0, 0.5, 0.01);
+gui.add(params, 'lineWidth', 0.5, 5, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'bloom', 0, 1, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.speed = rand(0.2, 1.2, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(120, 360, 1);
+  params.autoChange = true;
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/chord-wheel/style.css
+++ b/public/chord-wheel/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/chromatic-aberration/index.html
+++ b/public/chromatic-aberration/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Chromatic Aberration | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/chromatic-aberration/main.js
+++ b/public/chromatic-aberration/main.js
@@ -1,0 +1,148 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 色収差エフェクト。複数の図形の R/G/B チャンネルを左右にずらして描画することで色が分離。
+const params = {
+  aberration: 14,
+  shapeCount: 5,
+  shapeSize: 180,
+  rotationSpeed: 0.2,
+  waveSpeed: 1.1,
+  blurLayers: 3,
+  redShiftX: -1,
+  redShiftY: 0.2,
+  greenShiftX: 0,
+  greenShiftY: -0.2,
+  blueShiftX: 1,
+  blueShiftY: 0.2,
+  trailFade: 0.12,
+  lineWidth: 2.5,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function drawShape(cx, cy, r, angle, layer, channel) {
+  ctx.globalCompositeOperation = 'screen';
+  ctx.strokeStyle = channel;
+  ctx.lineWidth = params.lineWidth + layer * 0.3;
+  ctx.beginPath();
+  const segs = 6 + layer;
+  for (let i = 0; i <= segs; i++) {
+    const a = angle + (i / segs) * Math.PI * 2;
+    const rr = r * (1 + Math.sin(a * 3 + time * params.waveSpeed) * 0.1);
+    const x = cx + Math.cos(a) * rr;
+    const y = cy + Math.sin(a) * rr;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.stroke();
+  ctx.globalCompositeOperation = 'source-over';
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const n = Math.round(params.shapeCount);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  for (let i = 0; i < n; i++) {
+    const orbit = (i * Math.PI * 2) / n;
+    const ox = cx + Math.cos(orbit + time * params.rotationSpeed) * 150;
+    const oy = cy + Math.sin(orbit + time * params.rotationSpeed) * 150;
+    const baseAngle = time * (0.3 + i * 0.07);
+    for (let layer = 0; layer < params.blurLayers; layer++) {
+      const spread = (params.aberration * (layer + 1)) / params.blurLayers;
+      drawShape(
+        ox + params.redShiftX * spread,
+        oy + params.redShiftY * spread,
+        params.shapeSize * (0.7 + Math.sin(time + i) * 0.2),
+        baseAngle,
+        layer,
+        'rgba(255, 40, 80, 0.6)',
+      );
+      drawShape(
+        ox + params.greenShiftX * spread,
+        oy + params.greenShiftY * spread,
+        params.shapeSize * (0.7 + Math.sin(time + i) * 0.2),
+        baseAngle,
+        layer,
+        'rgba(40, 255, 120, 0.6)',
+      );
+      drawShape(
+        ox + params.blueShiftX * spread,
+        oy + params.blueShiftY * spread,
+        params.shapeSize * (0.7 + Math.sin(time + i) * 0.2),
+        baseAngle,
+        layer,
+        'rgba(80, 120, 255, 0.6)',
+      );
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Chromatic Aberration',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'aberration', 0, 60, 0.5);
+gui.add(params, 'shapeCount', 1, 12, 1);
+gui.add(params, 'shapeSize', 40, 400, 1);
+gui.add(params, 'rotationSpeed', -1, 1, 0.01);
+gui.add(params, 'waveSpeed', 0, 3, 0.01);
+gui.add(params, 'blurLayers', 1, 6, 1);
+gui.add(params, 'redShiftX', -2, 2, 0.05);
+gui.add(params, 'redShiftY', -2, 2, 0.05);
+gui.add(params, 'greenShiftX', -2, 2, 0.05);
+gui.add(params, 'greenShiftY', -2, 2, 0.05);
+gui.add(params, 'blueShiftX', -2, 2, 0.05);
+gui.add(params, 'blueShiftY', -2, 2, 0.05);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'lineWidth', 0.5, 6, 0.1);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.aberration = rand(5, 30, 0.5);
+  params.shapeCount = rand(3, 8, 1);
+  params.shapeSize = rand(80, 250, 1);
+  params.redShiftX = rand(-1.5, 1.5, 0.05);
+  params.redShiftY = rand(-1, 1, 0.05);
+  params.greenShiftX = rand(-1, 1, 0.05);
+  params.blueShiftX = rand(-1.5, 1.5, 0.05);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/chromatic-aberration/style.css
+++ b/public/chromatic-aberration/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/circular-sequencer/index.html
+++ b/public/circular-sequencer/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Circular Sequencer | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/circular-sequencer/main.js
+++ b/public/circular-sequencer/main.js
@@ -1,0 +1,180 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  steps: 16,
+  rings: 5,
+  bpm: 120,
+  radius: 280,
+  ringGap: 34,
+  density: 0.35, // 各リングで発音するステップの密度
+  hueStart: 30,
+  hueRange: 240,
+  pulseSize: 1.6,
+  trailFade: 0.2,
+  glow: 0.7,
+  reshuffle: 0,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {boolean[][]} */
+let grid = [];
+
+function rebuild() {
+  const s = Math.round(params.steps);
+  const r = Math.round(params.rings);
+  grid = [];
+  for (let i = 0; i < r; i++) {
+    const row = new Array(s);
+    for (let j = 0; j < s; j++) {
+      row[j] = Math.random() < params.density;
+    }
+    grid.push(row);
+  }
+}
+rebuild();
+
+let time = 0;
+let lastStep = -1;
+/** @type {{ring:number, step:number, t:number}[]} */
+let pulses = [];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const s = Math.round(params.steps);
+  const r = Math.round(params.rings);
+  const stepTime = 60 / params.bpm / 4; // 16分音符
+  const current = Math.floor(time / stepTime) % s;
+  if (current !== lastStep) {
+    lastStep = current;
+    for (let ri = 0; ri < r; ri++) {
+      if (grid[ri]?.[current]) {
+        pulses.push({ ring: ri, step: current, t: 0 });
+      }
+    }
+  }
+
+  // 背景リング
+  for (let ri = 0; ri < r; ri++) {
+    const rad = params.radius - ri * params.ringGap;
+    if (rad <= 4) continue;
+    ctx.strokeStyle = 'rgba(200,200,200,0.12)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+    ctx.stroke();
+    // 各ステップのドット
+    for (let si = 0; si < s; si++) {
+      const a = -Math.PI / 2 + (si / s) * Math.PI * 2;
+      const x = cx + Math.cos(a) * rad;
+      const y = cy + Math.sin(a) * rad;
+      const hue = params.hueStart + (ri / r) * params.hueRange;
+      const active = grid[ri]?.[si];
+      ctx.fillStyle = active
+        ? `hsla(${hue}, 80%, 65%, 0.85)`
+        : 'rgba(200,200,200,0.18)';
+      ctx.beginPath();
+      ctx.arc(x, y, active ? 4 : 1.8, 0, Math.PI * 2);
+      ctx.fill();
+      // 現在ステップ強調
+      if (si === current) {
+        ctx.strokeStyle = `hsla(${hue}, 90%, 75%, 0.9)`;
+        ctx.lineWidth = 1.2;
+        ctx.beginPath();
+        ctx.arc(x, y, 9, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
+  }
+
+  // パルス表示
+  pulses = pulses.filter((p) => p.t < 1);
+  for (const p of pulses) {
+    p.t += 0.04;
+    const rad = params.radius - p.ring * params.ringGap;
+    const a = -Math.PI / 2 + (p.step / s) * Math.PI * 2;
+    const x = cx + Math.cos(a) * rad;
+    const y = cy + Math.sin(a) * rad;
+    const hue = params.hueStart + (p.ring / r) * params.hueRange;
+    const sz = 6 + p.t * 60 * params.pulseSize;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 70%, ${(1 - p.t) * params.glow})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(x, y, sz, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.fillStyle = `hsla(${hue}, 90%, 75%, ${(1 - p.t) * params.glow})`;
+    ctx.beginPath();
+    ctx.arc(x, y, 5 + p.t * 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Circular Sequencer',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'steps', 8, 32, 1);
+gui.add(params, 'rings', 1, 10, 1);
+gui.add(params, 'bpm', 40, 240, 1);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'ringGap', 12, 60, 1);
+gui.add(params, 'density', 0.05, 0.8, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'pulseSize', 0.3, 3, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.5, 0.01);
+gui.add(params, 'glow', 0, 1, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.steps = rand(8, 24, 1);
+  params.rings = rand(3, 7, 1);
+  params.bpm = rand(80, 160, 1);
+  params.density = rand(0.2, 0.5, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Shuffle', () => {
+  rebuild();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/circular-sequencer/style.css
+++ b/public/circular-sequencer/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/comet-tail/index.html
+++ b/public/comet-tail/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Comet Tail | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/comet-tail/main.js
+++ b/public/comet-tail/main.js
@@ -1,0 +1,201 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 彗星の尾：楕円軌道を描く彗星と太陽風による輝く尾。
+// 太陽に近いほど尾が長く明るくなる物理法則を模倣する。
+
+const params = {
+  orbitA: 0.7, // 楕円長半径（画面幅比）
+  orbitB: 0.4, // 楕円短半径（画面高比）
+  orbitSpeed: 0.004, // 軌道速度
+  tailLength: 120, // 尾の長さ
+  tailWidth: 12, // 尾の幅（最大）
+  cometHue: 200, // 彗星色相（青白）
+  tailHue: 40, // 尾の色相（黄橙）
+  brightness: 75, // 明度
+  trailCount: 500, // 粒子数
+  dustHue: 50, // 塵の色相
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {{x: number, y: number}[]} */
+let trail = [];
+let angle = 0;
+
+/**
+ * 楕円軌道上の位置を計算する（ケプラー運動近似）
+ * @param {number} t 角度パラメータ
+ * @returns {{x: number, y: number, speed: number}}
+ */
+function orbitPosition(t) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const cx = w * 0.5;
+  const cy = h * 0.5;
+  const a = w * params.orbitA * 0.5;
+  const b = h * params.orbitB * 0.5;
+  const x = cx + a * Math.cos(t);
+  const y = cy + b * Math.sin(t);
+  // 速度は近点で速く（ケプラー第二法則近似）
+  const r = Math.hypot(x - cx, y - cy);
+  const maxR = Math.max(a, b);
+  const speed = 0.5 + 1.5 * (1 - r / maxR);
+  return { x, y, speed };
+}
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, life: number, size: number }} TailParticle */
+/** @type {TailParticle[]} */
+let dustParticles = [];
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+  const pos = orbitPosition(angle);
+
+  // 近点に近いほど速く動く
+  angle += params.orbitSpeed * (0.5 + pos.speed);
+
+  ctx.fillStyle = 'rgba(5, 5, 12, 0.2)';
+  ctx.fillRect(0, 0, w, h);
+
+  // 軌跡を更新
+  trail.unshift({ x: pos.x, y: pos.y });
+  if (trail.length > params.tailLength) trail.pop();
+
+  // 尾を描く（グラデーション線）
+  for (let i = 1; i < trail.length; i++) {
+    const t = 1 - i / trail.length;
+    const width = params.tailWidth * t;
+    const alpha = t * 0.8;
+    const hue = params.cometHue + (1 - t) * (params.tailHue - params.cometHue);
+    ctx.strokeStyle = `hsla(${hue}, 90%, ${params.brightness}%, ${alpha})`;
+    ctx.lineWidth = width;
+    ctx.beginPath();
+    ctx.moveTo(trail[i - 1].x, trail[i - 1].y);
+    ctx.lineTo(trail[i].x, trail[i].y);
+    ctx.stroke();
+  }
+
+  // 塵のパーティクルを生成
+  if (dustParticles.length < params.trailCount && trail.length > 1) {
+    const idx = Math.floor(Math.random() * Math.min(20, trail.length - 1));
+    const p = trail[idx];
+    const spread = (20 - idx) * 0.5;
+    dustParticles.push({
+      x: p.x + (Math.random() - 0.5) * spread,
+      y: p.y + (Math.random() - 0.5) * spread,
+      vx: (Math.random() - 0.5) * 1.5,
+      vy: (Math.random() - 0.5) * 1.5 - 0.2,
+      life: 0.8 + Math.random() * 0.2,
+      size: 0.5 + Math.random() * 1.5,
+    });
+  }
+
+  // 塵を更新・描画
+  dustParticles = dustParticles.filter((dp) => {
+    dp.x += dp.vx;
+    dp.y += dp.vy;
+    dp.life -= 0.012;
+    if (dp.life > 0) {
+      ctx.fillStyle = `hsla(${params.dustHue}, 80%, 70%, ${dp.life})`;
+      ctx.beginPath();
+      ctx.arc(dp.x, dp.y, dp.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    return dp.life > 0;
+  });
+
+  // 彗星本体（光る核）
+  const grd = ctx.createRadialGradient(pos.x, pos.y, 0, pos.x, pos.y, 15);
+  grd.addColorStop(0, `hsla(${params.cometHue}, 90%, 98%, 1)`);
+  grd.addColorStop(0.4, `hsla(${params.cometHue}, 80%, 80%, 0.8)`);
+  grd.addColorStop(1, `hsla(${params.cometHue}, 70%, 60%, 0)`);
+  ctx.fillStyle = grd;
+  ctx.beginPath();
+  ctx.arc(pos.x, pos.y, 15, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 太陽
+  ctx.beginPath();
+  ctx.arc(w / 2, h / 2, 20, 0, Math.PI * 2);
+  ctx.fillStyle = 'hsl(50, 100%, 70%)';
+  ctx.fill();
+  ctx.shadowColor = 'hsl(40, 100%, 60%)';
+  ctx.shadowBlur = 30;
+  ctx.fill();
+  ctx.shadowBlur = 0;
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Comet Tail',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'orbitA', 0.2, 0.95, 0.01);
+gui.add(params, 'orbitB', 0.1, 0.9, 0.01);
+gui.add(params, 'orbitSpeed', 0.001, 0.02, 0.0005);
+gui.add(params, 'tailLength', 20, 300, 5);
+gui.add(params, 'tailWidth', 2, 30, 1);
+gui.add(params, 'cometHue', 0, 360, 1);
+gui.add(params, 'tailHue', 0, 360, 1);
+gui.add(params, 'brightness', 40, 100, 1);
+gui.add(params, 'dustHue', 0, 360, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.orbitA = rand(0.3, 0.9, 0.01);
+  params.orbitB = rand(0.2, 0.8, 0.01);
+  params.tailLength = rand(40, 200, 5);
+  params.tailWidth = rand(4, 20, 1);
+  params.cometHue = rand(0, 360, 1);
+  params.tailHue = rand(0, 360, 1);
+  trail = [];
+  dustParticles = [];
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  trail = [];
+  dustParticles = [];
+  gui.updateDisplay();
+});

--- a/public/comet-tail/style.css
+++ b/public/comet-tail/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/coral-growth/index.html
+++ b/public/coral-growth/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Coral Growth | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/coral-growth/main.js
+++ b/public/coral-growth/main.js
@@ -1,0 +1,192 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// サンゴが上へ成長する DLA 風ジェネレーティブ。粒子が下から漂い、最上の枝に付着して固まっていく。
+const params = {
+  particlesPerFrame: 15,
+  particleSpeed: 1.4,
+  attachRadius: 7,
+  branchWidth: 5,
+  hueStart: 330,
+  hueEnd: 20,
+  darkFloor: 40, // 海底の色
+  drift: 0.5,
+  backgroundFade: 0.04,
+  maxNodes: 1500,
+  autoRegrow: true,
+  regrowInterval: 12,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {{x:number,y:number,depth:number}[]} */
+let nodes = [];
+/** @type {{x:number,y:number,vx:number,vy:number}[]} */
+let particles = [];
+let time = 0;
+let lastRegrow = 0;
+
+function reset() {
+  nodes = [];
+  particles = [];
+  ctx.fillStyle = '#04070d';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // 海底
+  const grad = ctx.createLinearGradient(
+    0,
+    canvas.height,
+    0,
+    canvas.height - 80,
+  );
+  grad.addColorStop(0, 'rgba(30, 40, 55, 0.9)');
+  grad.addColorStop(1, 'rgba(4, 7, 13, 0)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, canvas.height - 80, canvas.width, 80);
+  // シード
+  const seeds = 5;
+  for (let i = 0; i < seeds; i++) {
+    nodes.push({
+      x: canvas.width * ((i + 1) / (seeds + 1)),
+      y: canvas.height - 20,
+      depth: 0,
+    });
+  }
+  for (const s of nodes) {
+    ctx.fillStyle = `hsla(${params.hueStart}, 80%, 60%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, params.branchWidth, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+reset();
+
+function spawnParticle() {
+  particles.push({
+    x: Math.random() * canvas.width,
+    y: -10,
+    vx: (Math.random() - 0.5) * params.drift,
+    vy: params.particleSpeed,
+  });
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(4, 7, 13, ${params.backgroundFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (
+    params.autoRegrow &&
+    time - lastRegrow > params.regrowInterval &&
+    nodes.length > params.maxNodes
+  ) {
+    lastRegrow = time;
+    reset();
+  }
+
+  for (let i = 0; i < params.particlesPerFrame; i++) spawnParticle();
+
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.vx += (Math.random() - 0.5) * 0.3;
+    p.x += p.vx;
+    p.y += p.vy;
+    if (p.y > canvas.height || p.x < 0 || p.x > canvas.width) {
+      particles.splice(i, 1);
+      continue;
+    }
+    // ヒット判定（近傍ノードを検索：単純 O(N)）
+    if (nodes.length > params.maxNodes) {
+      particles.splice(i, 1);
+      continue;
+    }
+    let attached = false;
+    for (let j = nodes.length - 1; j >= Math.max(0, nodes.length - 80); j--) {
+      const n = nodes[j];
+      if (Math.hypot(p.x - n.x, p.y - n.y) < params.attachRadius) {
+        nodes.push({ x: p.x, y: p.y, depth: n.depth + 1 });
+        const k = Math.min(1, n.depth / 150);
+        const hue = params.hueStart + (params.hueEnd - params.hueStart) * k;
+        const sat = 80 - k * 20;
+        const light = 60 - k * 20;
+        ctx.fillStyle = `hsla(${hue}, ${sat}%, ${light}%, 0.9)`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, params.branchWidth, 0, Math.PI * 2);
+        ctx.fill();
+        // 結線
+        ctx.strokeStyle = `hsla(${hue}, 70%, 50%, 0.6)`;
+        ctx.lineWidth = params.branchWidth * 0.6;
+        ctx.beginPath();
+        ctx.moveTo(n.x, n.y);
+        ctx.lineTo(p.x, p.y);
+        ctx.stroke();
+        attached = true;
+        break;
+      }
+    }
+    if (attached) {
+      particles.splice(i, 1);
+    } else {
+      ctx.fillStyle = 'rgba(180, 220, 230, 0.3)';
+      ctx.fillRect(p.x, p.y, 1, 1);
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Coral Growth',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'particlesPerFrame', 2, 40, 1);
+gui.add(params, 'particleSpeed', 0.3, 4, 0.1);
+gui.add(params, 'attachRadius', 3, 15, 0.5);
+gui.add(params, 'branchWidth', 2, 12, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'drift', 0, 3, 0.05);
+gui.add(params, 'backgroundFade', 0, 0.2, 0.005);
+gui.add(params, 'maxNodes', 300, 3000, 50);
+gui.add(params, 'autoRegrow');
+gui.add(params, 'regrowInterval', 5, 40, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.particlesPerFrame = rand(8, 25, 1);
+  params.drift = rand(0.1, 1.2, 0.05);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/coral-growth/style.css
+++ b/public/coral-growth/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/diffraction-grating/index.html
+++ b/public/diffraction-grating/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Diffraction Grating | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/diffraction-grating/main.js
+++ b/public/diffraction-grating/main.js
@@ -1,0 +1,171 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 回折格子: 格子間隔 d に対する角度 sin(θ) = m λ / d で次数 m の回折スペクトルを描く。
+const params = {
+  gratingLines: 40,
+  d: 16, // 格子間隔（ピクセル）
+  maxOrder: 3,
+  wavelengths: 7, // 可視光の分割数
+  spread: 420, // 画面上の広がり
+  sourceBrightness: 1.4,
+  lineAlpha: 0.6,
+  beamAngle: 0.05,
+  orderGap: 110,
+  trailFade: 0.15,
+  showGrating: true,
+  animate: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+// 波長 (nm) → HSL 色
+function wavelengthHue(wnm) {
+  // 380..780 nm → 280..0 hue (紫→赤)
+  const t = (wnm - 380) / (780 - 380);
+  return 280 - t * 280;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const gy = canvas.height * 0.5;
+  const beamY0 = gy - 250;
+
+  // 入射光源
+  const beamAngle = params.animate
+    ? params.beamAngle + Math.sin(time * 0.5) * 0.08
+    : params.beamAngle;
+  const sx = cx - Math.sin(beamAngle) * 250;
+  const sy = beamY0;
+  // 入射線
+  ctx.strokeStyle = `rgba(255, 255, 255, ${0.4 * params.sourceBrightness})`;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(sx, sy);
+  ctx.lineTo(cx, gy);
+  ctx.stroke();
+
+  // 格子の線
+  if (params.showGrating) {
+    const n = Math.round(params.gratingLines);
+    const halfW = (n * params.d) / 2;
+    ctx.strokeStyle = 'rgba(200, 220, 255, 0.6)';
+    ctx.lineWidth = 1;
+    for (let i = 0; i < n; i++) {
+      const x = cx - halfW + i * params.d;
+      ctx.beginPath();
+      ctx.moveTo(x, gy - 10);
+      ctx.lineTo(x, gy + 10);
+      ctx.stroke();
+    }
+    ctx.strokeStyle = 'rgba(180, 200, 230, 0.8)';
+    ctx.beginPath();
+    ctx.moveTo(cx - halfW - 10, gy);
+    ctx.lineTo(cx + halfW + 10, gy);
+    ctx.stroke();
+  }
+
+  // 回折次数ごとにスペクトル
+  const W = Math.round(params.wavelengths);
+  for (let m = -params.maxOrder; m <= params.maxOrder; m++) {
+    if (m === 0) continue;
+    for (let wi = 0; wi < W; wi++) {
+      const wnm = 380 + (wi + 0.5) * (400 / W); // 380..780 nm
+      // sin(θ) = m * λ / d  (ピクセル単位に換算するため λ ~= wnm/30 とする)
+      const lambda = wnm / 30;
+      const sinT = (m * lambda) / params.d;
+      if (Math.abs(sinT) > 1) continue;
+      const theta = Math.asin(sinT) + beamAngle;
+      const tx = cx + Math.sin(theta) * params.spread;
+      const ty = gy + Math.cos(theta) * params.spread;
+      const hue = wavelengthHue(wnm);
+      ctx.strokeStyle = `hsla(${hue}, 90%, 65%, ${params.lineAlpha})`;
+      ctx.lineWidth = 1.8;
+      ctx.beginPath();
+      ctx.moveTo(cx, gy);
+      ctx.lineTo(tx, ty);
+      ctx.stroke();
+      ctx.fillStyle = `hsla(${hue}, 100%, 75%, 0.8)`;
+      ctx.beginPath();
+      ctx.arc(tx, ty, 4, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // 次数ラベルのスペース
+  }
+
+  // 0 次光（中心の白）
+  ctx.strokeStyle = `rgba(255, 255, 255, ${0.7 * params.sourceBrightness})`;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(cx, gy);
+  ctx.lineTo(
+    cx + Math.sin(beamAngle) * params.spread,
+    gy + Math.cos(beamAngle) * params.spread,
+  );
+  ctx.stroke();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Diffraction Grating',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'gratingLines', 5, 120, 1);
+gui.add(params, 'd', 4, 40, 0.5);
+gui.add(params, 'maxOrder', 1, 6, 1);
+gui.add(params, 'wavelengths', 3, 20, 1);
+gui.add(params, 'spread', 100, 800, 1);
+gui.add(params, 'sourceBrightness', 0.3, 2, 0.05);
+gui.add(params, 'lineAlpha', 0.1, 1, 0.01);
+gui.add(params, 'beamAngle', -0.5, 0.5, 0.01);
+gui.add(params, 'orderGap', 40, 200, 1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'showGrating');
+gui.add(params, 'animate');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.d = rand(6, 28, 0.5);
+  params.maxOrder = rand(2, 5, 1);
+  params.wavelengths = rand(5, 14, 1);
+  params.spread = rand(260, 600, 1);
+  params.beamAngle = rand(-0.3, 0.3, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/diffraction-grating/style.css
+++ b/public/diffraction-grating/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/dna-helix/index.html
+++ b/public/dna-helix/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>DNA Helix | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/dna-helix/main.js
+++ b/public/dna-helix/main.js
@@ -1,0 +1,162 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 二重螺旋 DNA。4 色の塩基対（A/T/G/C）が階段状に連結される。
+const params = {
+  rungs: 40, // 塩基対の数
+  amplitude: 120,
+  spacing: 18,
+  twistSpeed: 0.4,
+  twistFreq: 0.08, // y 方向の角速度
+  hueA: 0,
+  hueT: 60,
+  hueG: 200,
+  hueC: 140,
+  strandWidth: 4,
+  rungWidth: 3,
+  trailFade: 0.12,
+  rotation: 0,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/** 塩基の乱数列（再生成抑制） */
+let bases = /** @type {number[]} */ ([]);
+function rebuildBases() {
+  bases = [];
+  for (let i = 0; i < 300; i++) bases.push(Math.floor(Math.random() * 4));
+}
+rebuildBases();
+
+const baseHues = () => [params.hueA, params.hueT, params.hueG, params.hueC];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const topY = 40;
+  const n = Math.round(params.rungs);
+  const totalH = n * params.spacing;
+  const startY = Math.max(topY, canvas.height / 2 - totalH / 2);
+  ctx.save();
+  ctx.translate(cx, canvas.height / 2);
+  ctx.rotate(params.rotation);
+  ctx.translate(-cx, -canvas.height / 2);
+
+  /** @type {{x:number,y:number,x2:number,y2:number,base:number}[]} */
+  const rungPoints = [];
+
+  for (let i = 0; i < n; i++) {
+    const y = startY + i * params.spacing;
+    const phase = y * params.twistFreq + time * params.twistSpeed * Math.PI * 2;
+    const x1 = cx + Math.cos(phase) * params.amplitude;
+    const x2 = cx + Math.cos(phase + Math.PI) * params.amplitude;
+    // 深度（後ろの線は暗く）
+    const depth1 = (Math.cos(phase) + 1) * 0.5;
+    const depth2 = (Math.cos(phase + Math.PI) + 1) * 0.5;
+    rungPoints.push({ x: x1, y, x2, y2: y, base: bases[i % bases.length] });
+    // ストランドの点
+    const hues = baseHues();
+    const h = hues[bases[i % bases.length]];
+    // 塩基対接続
+    ctx.strokeStyle = `hsla(${h}, 80%, ${45 + Math.min(depth1, depth2) * 40}%, 0.9)`;
+    ctx.lineWidth = params.rungWidth;
+    ctx.beginPath();
+    ctx.moveTo(x1, y);
+    ctx.lineTo(x2, y);
+    ctx.stroke();
+    // ストランドの球
+    ctx.fillStyle = `hsla(${h}, 90%, ${40 + depth1 * 50}%, 0.95)`;
+    ctx.beginPath();
+    ctx.arc(x1, y, 5 + depth1 * 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = `hsla(${(h + 180) % 360}, 90%, ${40 + depth2 * 50}%, 0.95)`;
+    ctx.beginPath();
+    ctx.arc(x2, y, 5 + depth2 * 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // 2 本の糖リン酸バックボーンを線でつなぐ
+  for (let side = 0; side < 2; side++) {
+    ctx.strokeStyle = `hsla(${side === 0 ? 200 : 20}, 60%, 70%, 0.5)`;
+    ctx.lineWidth = params.strandWidth;
+    ctx.beginPath();
+    for (let i = 0; i < rungPoints.length; i++) {
+      const p = rungPoints[i];
+      const x = side === 0 ? p.x : p.x2;
+      if (i === 0) ctx.moveTo(x, p.y);
+      else ctx.lineTo(x, p.y);
+    }
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'DNA Helix',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'rungs', 10, 100, 1);
+gui.add(params, 'amplitude', 30, 250, 1);
+gui.add(params, 'spacing', 6, 40, 0.5);
+gui.add(params, 'twistSpeed', -2, 2, 0.01);
+gui.add(params, 'twistFreq', 0.01, 0.3, 0.005);
+gui.add(params, 'hueA', 0, 360, 1);
+gui.add(params, 'hueT', 0, 360, 1);
+gui.add(params, 'hueG', 0, 360, 1);
+gui.add(params, 'hueC', 0, 360, 1);
+gui.add(params, 'strandWidth', 1, 8, 0.1);
+gui.add(params, 'rungWidth', 1, 8, 0.1);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.rungs = rand(25, 60, 1);
+  params.amplitude = rand(80, 200, 1);
+  params.spacing = rand(10, 25, 0.5);
+  params.twistSpeed = rand(-0.8, 0.8, 0.01);
+  params.hueA = rand(0, 360, 1);
+  params.hueT = rand(0, 360, 1);
+  params.hueG = rand(0, 360, 1);
+  params.hueC = rand(0, 360, 1);
+  rebuildBases();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuildBases();
+  gui.updateDisplay();
+});

--- a/public/dna-helix/style.css
+++ b/public/dna-helix/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/dust-storm/index.html
+++ b/public/dust-storm/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Dust Storm | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/dust-storm/main.js
+++ b/public/dust-storm/main.js
@@ -1,0 +1,175 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 砂嵐：激しい風に舞う砂塵のビジュアル。
+// 複数の風の層が砂粒を異なる速度で運ぶ様子を表現する。
+
+const params = {
+  particleCount: 3000, // 砂粒の数
+  windSpeed: 5.0, // 基本風速
+  windAngle: 15, // 風の角度（度）
+  turbulence: 1.5, // 乱流強度
+  gustFreq: 0.8, // 突風の周期
+  gustStrength: 3.0, // 突風の強さ
+  hueBase: 35, // 基本色相（砂色）
+  hueRange: 25, // 色相レンジ
+  brightness: 55, // 明度
+  fadeAlpha: 0.25, // フェード強度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  initParticles();
+}
+window.addEventListener('resize', resize);
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, size: number, hue: number, layer: number }} DustParticle */
+/** @type {DustParticle[]} */
+let particles = [];
+
+/**
+ * 砂粒を初期化する
+ */
+function initParticles() {
+  particles = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.particleCount; i++) {
+    const layer = Math.floor(Math.random() * 3); // 0=近景 1=中景 2=遠景
+    particles.push({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      vx: 0,
+      vy: 0,
+      size: (3 - layer) * (0.5 + Math.random()),
+      hue: params.hueBase + (Math.random() - 0.5) * params.hueRange,
+      layer,
+    });
+  }
+}
+
+resize();
+
+let time = 0;
+
+/**
+ * 砂粒を1ステップ更新する
+ * @param {DustParticle} p
+ */
+function updateParticle(p) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const angle = (params.windAngle * Math.PI) / 180;
+  const windScale = 1 - p.layer * 0.3; // 遠景は遅い
+  const gust =
+    Math.sin(time * params.gustFreq + p.x * 0.01) * params.gustStrength;
+  const wx = Math.cos(angle) * (params.windSpeed + gust) * windScale;
+  const wy = Math.sin(angle) * (params.windSpeed + gust) * windScale * 0.3;
+
+  p.vx = wx + (Math.random() - 0.5) * params.turbulence;
+  p.vy = wy + (Math.random() - 0.5) * params.turbulence * 0.5;
+
+  p.x += p.vx;
+  p.y += p.vy;
+
+  // 画面外から再出現
+  if (p.x > w + 20) p.x = -20;
+  if (p.x < -20) p.x = w + 20;
+  if (p.y > h + 20) p.y = -20;
+  if (p.y < -20) p.y = h + 20;
+}
+
+function draw() {
+  time += 0.016;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(15, 12, 8, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  for (const p of particles) {
+    updateParticle(p);
+    const speed = Math.hypot(p.vx, p.vy);
+    const alpha = 0.3 + (speed / 10) * 0.5;
+    const lig = params.brightness - p.layer * 10;
+    ctx.fillStyle = `hsla(${p.hue}, 55%, ${lig}%, ${alpha})`;
+    ctx.beginPath();
+    // 速度に応じて引き伸ばす
+    ctx.ellipse(
+      p.x,
+      p.y,
+      p.size * (1 + speed * 0.1),
+      p.size * 0.4,
+      Math.atan2(p.vy, p.vx),
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Dust Storm',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'particleCount', 500, 8000, 250).onChange(initParticles);
+gui.add(params, 'windSpeed', 0, 15, 0.5);
+gui.add(params, 'windAngle', -45, 45, 1);
+gui.add(params, 'turbulence', 0, 5, 0.1);
+gui.add(params, 'gustFreq', 0, 3, 0.05);
+gui.add(params, 'gustStrength', 0, 10, 0.1);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 90, 1);
+gui.add(params, 'brightness', 20, 80, 1);
+gui.add(params, 'fadeAlpha', 0.05, 0.8, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.windSpeed = rand(1, 12, 0.5);
+  params.windAngle = rand(-30, 30, 1);
+  params.turbulence = rand(0.2, 4, 0.1);
+  params.gustStrength = rand(0.5, 8, 0.1);
+  params.hueBase = rand(20, 60, 1);
+  params.brightness = rand(30, 70, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/dust-storm/style.css
+++ b/public/dust-storm/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/electron-cloud/index.html
+++ b/public/electron-cloud/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Electron Cloud | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/electron-cloud/main.js
+++ b/public/electron-cloud/main.js
@@ -1,0 +1,222 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 電子雲：水素原子の電子軌道（s, p, d 殻）の確率密度を
+// パーティクルで可視化する量子力学的ビジュアル。
+
+const params = {
+  particleCount: 3000, // パーティクル数
+  orbital: 0, // 軌道タイプ（0=1s, 1=2p, 2=3d）
+  energy: 1.0, // エネルギー（軌道サイズ）
+  rotSpeedX: 0.3, // X軸回転速度
+  rotSpeedY: 0.5, // Y軸回転速度
+  hueBase: 200, // 基本色相
+  hueRange: 80, // 色相レンジ
+  brightness: 70, // 明度
+  fadeAlpha: 0.06, // フェード強度
+  pointSize: 1.5, // 点のサイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ r: number, theta: number, phi: number, prob: number }} ElectronPoint */
+/** @type {ElectronPoint[]} */
+let points = [];
+
+let rotX = 0;
+let rotY = 0;
+
+/**
+ * 1s軌道の確率密度（水素様）
+ * @param {number} r 半径
+ * @returns {number}
+ */
+function psi1s(r) {
+  const a = 1;
+  const rho = (2 * r) / a;
+  return rho * rho * Math.exp(-rho);
+}
+
+/**
+ * 2p軌道の確率密度
+ * @param {number} r
+ * @param {number} theta
+ * @returns {number}
+ */
+function psi2p(r, theta) {
+  const a = 1;
+  const rho = r / a;
+  const angular = Math.cos(theta) ** 2;
+  return rho * rho * rho * rho * Math.exp(-rho) * angular;
+}
+
+/**
+ * 3d軌道の確率密度
+ * @param {number} r
+ * @param {number} theta
+ * @returns {number}
+ */
+function psi3d(r, theta) {
+  const a = 1;
+  const rho = (2 * r) / (3 * a);
+  const angular = (3 * Math.cos(theta) ** 2 - 1) ** 2;
+  return rho ** 4 * Math.exp(-rho) * angular;
+}
+
+/**
+ * パーティクルをモンテカルロ法でサンプリングする
+ */
+function initParticles() {
+  points = [];
+  const n = params.particleCount;
+  const scale = Math.min(canvas.width, canvas.height) * 0.35 * params.energy;
+  let maxProb = 0;
+
+  for (let i = 0; i < n * 3; i++) {
+    const r = Math.random() * scale;
+    const theta = Math.acos(1 - 2 * Math.random());
+    const phi = Math.random() * Math.PI * 2;
+    const rn = (r / scale) * 10;
+
+    let prob = 0;
+    if (params.orbital === 0) prob = psi1s(rn);
+    else if (params.orbital === 1) prob = psi2p(rn, theta);
+    else prob = psi3d(rn, theta);
+
+    maxProb = Math.max(maxProb, prob);
+    points.push({ r, theta, phi, prob });
+  }
+
+  // 棄却サンプリング
+  points = points
+    .filter((p) => Math.random() < p.prob / (maxProb + 1e-10))
+    .slice(0, n);
+}
+
+initParticles();
+
+/**
+ * 3D球面座標を直交座標に変換してから投影する
+ * @param {number} r
+ * @param {number} theta
+ * @param {number} phi
+ * @returns {{sx: number, sy: number}}
+ */
+function project(r, theta, phi) {
+  const x = r * Math.sin(theta) * Math.cos(phi);
+  const y = r * Math.cos(theta);
+  const z = r * Math.sin(theta) * Math.sin(phi);
+
+  // 回転
+  const y1 = y * Math.cos(rotX) - z * Math.sin(rotX);
+  const z1 = y * Math.sin(rotX) + z * Math.cos(rotX);
+  const x2 = x * Math.cos(rotY) + z1 * Math.sin(rotY);
+  const z2 = -x * Math.sin(rotY) + z1 * Math.cos(rotY);
+
+  const fov = 500;
+  const depth = z2 + 600;
+  const scale2 = fov / depth;
+  return {
+    sx: canvas.width / 2 + x2 * scale2,
+    sy: canvas.height / 2 + y1 * scale2,
+  };
+}
+
+function draw() {
+  rotX += params.rotSpeedX * 0.003;
+  rotY += params.rotSpeedY * 0.005;
+
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(5, 8, 15, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 中心（核）
+  ctx.beginPath();
+  ctx.arc(w / 2, h / 2, 4, 0, Math.PI * 2);
+  ctx.fillStyle = 'hsl(60, 90%, 80%)';
+  ctx.fill();
+
+  // パーティクル
+  for (const p of points) {
+    const { sx, sy } = project(p.r, p.theta, p.phi);
+    const hue = params.hueBase + (p.prob / 0.05) * params.hueRange;
+    const alpha = Math.min(0.9, p.prob * 30 + 0.1);
+    ctx.fillStyle = `hsla(${hue}, 80%, ${params.brightness}%, ${alpha})`;
+    ctx.beginPath();
+    ctx.arc(sx, sy, params.pointSize, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Electron Cloud',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'particleCount', 500, 8000, 250).onChange(initParticles);
+gui.add(params, 'orbital', 0, 2, 1).onChange(initParticles);
+gui.add(params, 'energy', 0.3, 3, 0.05).onChange(initParticles);
+gui.add(params, 'rotSpeedX', 0, 2, 0.05);
+gui.add(params, 'rotSpeedY', 0, 2, 0.05);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 180, 1);
+gui.add(params, 'brightness', 20, 100, 1);
+gui.add(params, 'fadeAlpha', 0.01, 0.3, 0.005);
+gui.add(params, 'pointSize', 0.5, 5, 0.1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.orbital = rand(0, 2, 1);
+  params.energy = rand(0.5, 2.5, 0.05);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(30, 150, 1);
+  params.brightness = rand(40, 85, 1);
+  initParticles();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initParticles();
+  gui.updateDisplay();
+});

--- a/public/electron-cloud/style.css
+++ b/public/electron-cloud/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/escher-tessellation/index.html
+++ b/public/escher-tessellation/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Escher Tessellation | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/escher-tessellation/main.js
+++ b/public/escher-tessellation/main.js
@@ -1,0 +1,180 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// エッシャー風テセレーション：対称変換（回転・反転・並進）で
+// 鳥や魚の形に変形したタイルが隙間なく敷き詰まるパターン。
+
+const params = {
+  tileSize: 80, // タイルの基本サイズ
+  warpAmount: 0.35, // タイル辺の変形量
+  hue1: 30, // タイルA色相
+  hue2: 200, // タイルB色相
+  saturation: 60, // 彩度
+  lightness: 50, // 明度
+  strokeColor: 10, // 枠線の明度
+  strokeWidth: 1.0, // 枠線幅
+  animSpeed: 0.2, // アニメーション速度
+  morphPhase: 0, // 変形位相
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * エッシャー風変形タイルを描く（正方形を波型に変形）
+ * @param {number} cx タイル中心X
+ * @param {number} cy タイル中心Y
+ * @param {number} s タイルサイズ
+ * @param {boolean} flip 反転フラグ（タイルAかBか）
+ * @param {number} phase 変形位相
+ */
+function drawEscherTile(cx, cy, s, flip, phase) {
+  const w = params.warpAmount * s;
+  const h2 = s / 2;
+  const sign = flip ? -1 : 1;
+
+  // 4辺をそれぞれ波状に変形した多角形を定義
+  const pts = /** @type {[number,number][]} */ ([]);
+  const steps = 8;
+
+  // 上辺（左→右）
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps;
+    const x = cx - h2 + s * t;
+    const y = cy - h2 + Math.sin(t * Math.PI * 2 + phase) * w * sign;
+    pts.push([x, y]);
+  }
+  // 右辺（上→下）
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const x = cx + h2 + Math.sin(t * Math.PI * 2 + phase + Math.PI) * w * sign;
+    const y = cy - h2 + s * t;
+    pts.push([x, y]);
+  }
+  // 下辺（右→左）
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const x = cx + h2 - s * t;
+    const y = cy + h2 - Math.sin(t * Math.PI * 2 + phase) * w * sign;
+    pts.push([x, y]);
+  }
+  // 左辺（下→上）
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const x = cx - h2 - Math.sin(t * Math.PI * 2 + phase + Math.PI) * w * sign;
+    const y = cy + h2 - s * t;
+    pts.push([x, y]);
+  }
+
+  ctx.beginPath();
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) {
+    ctx.lineTo(pts[i][0], pts[i][1]);
+  }
+  ctx.closePath();
+}
+
+function draw() {
+  time += params.animSpeed * 0.01;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, w, h);
+
+  const s = params.tileSize;
+  const phase = params.morphPhase + time;
+  const cols = Math.ceil(w / s) + 3;
+  const rows = Math.ceil(h / s) + 3;
+  const sat = params.saturation;
+  const lig = params.lightness;
+
+  for (let row = -1; row < rows; row++) {
+    for (let col = -1; col < cols; col++) {
+      const cx = col * s + s / 2;
+      const cy = row * s + s / 2;
+      const isFlip = (row + col) % 2 === 0;
+      const hue = isFlip ? params.hue1 : params.hue2;
+
+      drawEscherTile(cx, cy, s, isFlip, phase);
+      ctx.fillStyle = `hsl(${hue}, ${sat}%, ${lig}%)`;
+      ctx.fill();
+      if (params.strokeWidth > 0) {
+        ctx.strokeStyle = `hsl(0, 0%, ${params.strokeColor}%)`;
+        ctx.lineWidth = params.strokeWidth;
+        ctx.stroke();
+      }
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Escher Tessellation',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'tileSize', 20, 200, 4);
+gui.add(params, 'warpAmount', 0, 0.8, 0.01);
+gui.add(params, 'hue1', 0, 360, 1);
+gui.add(params, 'hue2', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 10, 90, 1);
+gui.add(params, 'strokeWidth', 0, 5, 0.1);
+gui.add(params, 'animSpeed', 0, 2, 0.05);
+gui.add(params, 'morphPhase', 0, Math.PI * 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.tileSize = rand(40, 140, 4);
+  params.warpAmount = rand(0.1, 0.6, 0.01);
+  params.hue1 = rand(0, 360, 1);
+  params.hue2 = rand(0, 360, 1);
+  params.saturation = rand(30, 85, 1);
+  params.lightness = rand(25, 70, 1);
+  params.animSpeed = rand(0.05, 1.5, 0.05);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/escher-tessellation/style.css
+++ b/public/escher-tessellation/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/euclidean-rhythm/index.html
+++ b/public/euclidean-rhythm/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Euclidean Rhythm | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/euclidean-rhythm/main.js
+++ b/public/euclidean-rhythm/main.js
@@ -1,0 +1,191 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  steps: 16, // ステップ数
+  pulses: 5, // パルス数
+  rotate: 0, // 回転
+  layers: 3, // レイヤー数
+  bpm: 120,
+  radius: 260,
+  ringGap: 36,
+  hueStart: 160,
+  hueRange: 180,
+  pulseGlow: 0.8,
+  trailFade: 0.18,
+  dotSize: 8,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * Bjorklund のユークリッドリズム
+ * @param {number} steps
+ * @param {number} pulses
+ * @returns {boolean[]}
+ */
+function euclid(steps, pulses) {
+  pulses = Math.min(steps, Math.max(0, pulses));
+  /** @type {string[]} */
+  let groups = [];
+  for (let i = 0; i < pulses; i++) groups.push('1');
+  for (let i = 0; i < steps - pulses; i++) groups.push('0');
+  while (true) {
+    const ones = groups.filter((g) => g.startsWith('1'));
+    const zeros = groups.filter((g) => g.startsWith('0'));
+    if (zeros.length <= 1) break;
+    const merge = Math.min(ones.length, zeros.length);
+    /** @type {string[]} */
+    const next = [];
+    for (let i = 0; i < merge; i++) next.push(ones[i] + zeros[i]);
+    for (let i = merge; i < ones.length; i++) next.push(ones[i]);
+    for (let i = merge; i < zeros.length; i++) next.push(zeros[i]);
+    groups = next;
+    if (ones.length === 0 || zeros.length === 0) break;
+  }
+  const s = groups.join('');
+  const out = [];
+  for (const ch of s) out.push(ch === '1');
+  return out;
+}
+
+let time = 0;
+let lastStep = -1;
+/** @type {{layer:number, step:number, t:number}[]} */
+let pulseAnim = [];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const s = Math.round(params.steps);
+  const L = Math.round(params.layers);
+  const stepTime = 60 / params.bpm / 4;
+  const current = Math.floor(time / stepTime) % s;
+
+  const patterns = [];
+  for (let li = 0; li < L; li++) {
+    const p = Math.max(1, Math.round(params.pulses) - li);
+    const pat = euclid(s, p);
+    const rot = Math.round(params.rotate) + li;
+    // rotate
+    const rotated = pat.slice(-rot % s).concat(pat.slice(0, -rot % s || 0));
+    patterns.push(rotated);
+  }
+
+  if (current !== lastStep) {
+    lastStep = current;
+    for (let li = 0; li < L; li++) {
+      if (patterns[li][current])
+        pulseAnim.push({ layer: li, step: current, t: 0 });
+    }
+  }
+
+  for (let li = 0; li < L; li++) {
+    const rad = params.radius - li * params.ringGap;
+    if (rad <= 4) continue;
+    const hue = params.hueStart + (li / L) * params.hueRange;
+    ctx.strokeStyle = `hsla(${hue}, 60%, 50%, 0.2)`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+    ctx.stroke();
+    for (let si = 0; si < s; si++) {
+      const a = -Math.PI / 2 + (si / s) * Math.PI * 2;
+      const x = cx + Math.cos(a) * rad;
+      const y = cy + Math.sin(a) * rad;
+      const on = patterns[li][si];
+      ctx.fillStyle = on
+        ? `hsla(${hue}, 85%, 65%, 0.9)`
+        : 'rgba(180,180,180,0.2)';
+      ctx.beginPath();
+      ctx.arc(x, y, on ? params.dotSize * 0.5 : 2, 0, Math.PI * 2);
+      ctx.fill();
+      if (si === current) {
+        ctx.strokeStyle = `hsla(${hue}, 100%, 80%, 0.9)`;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(x, y, params.dotSize + 2, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
+  }
+
+  pulseAnim = pulseAnim.filter((p) => p.t < 1);
+  for (const p of pulseAnim) {
+    p.t += 0.05;
+    const rad = params.radius - p.layer * params.ringGap;
+    const a = -Math.PI / 2 + (p.step / s) * Math.PI * 2;
+    const x = cx + Math.cos(a) * rad;
+    const y = cy + Math.sin(a) * rad;
+    const hue = params.hueStart + (p.layer / L) * params.hueRange;
+    ctx.strokeStyle = `hsla(${hue}, 100%, 70%, ${(1 - p.t) * params.pulseGlow})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(x, y, 4 + p.t * 30, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Euclidean Rhythm',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'steps', 4, 32, 1);
+gui.add(params, 'pulses', 1, 24, 1);
+gui.add(params, 'rotate', 0, 31, 1);
+gui.add(params, 'layers', 1, 6, 1);
+gui.add(params, 'bpm', 40, 240, 1);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'ringGap', 14, 60, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'pulseGlow', 0, 1, 0.01);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'dotSize', 4, 20, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.steps = rand(8, 24, 1);
+  params.pulses = rand(3, Math.min(12, params.steps - 1), 1);
+  params.rotate = rand(0, params.steps - 1, 1);
+  params.layers = rand(2, 5, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.bpm = rand(80, 160, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/euclidean-rhythm/style.css
+++ b/public/euclidean-rhythm/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/fireflies-trail/index.html
+++ b/public/fireflies-trail/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Fireflies Trail | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/fireflies-trail/main.js
+++ b/public/fireflies-trail/main.js
@@ -1,0 +1,210 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 蛍の光跡：夏の夜に光跡を描きながら舞う蛍のビジュアル。
+// 明滅パターンと光跡の軌跡で幻想的な情景を生成する。
+
+const params = {
+  count: 60, // 蛍の数
+  flashRate: 0.008, // 点滅周期
+  flashDuration: 40, // 点灯フレーム数
+  moveSpeed: 1.2, // 移動速度
+  trailLength: 80, // 光跡の長さ
+  hueBase: 75, // 蛍の色相（黄緑）
+  hueVar: 40, // 色相ばらつき
+  trailFade: 0.1, // フェード強度
+  glowSize: 8, // 発光サイズ
+  windX: 0.3, // 風（X）
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, hue: number, lit: number, phase: number, trail: {x:number,y:number}[] }} Firefly */
+
+/** @type {Firefly[]} */
+let flies = [];
+
+/**
+ * 蛍を初期化する
+ */
+function initFlies() {
+  flies = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.count; i++) {
+    flies.push({
+      x: Math.random() * w,
+      y: h * 0.3 + Math.random() * h * 0.5,
+      vx: (Math.random() - 0.5) * params.moveSpeed,
+      vy: (Math.random() - 0.5) * params.moveSpeed,
+      hue: params.hueBase + (Math.random() - 0.5) * params.hueVar,
+      lit: 0,
+      phase: Math.random() * 1000,
+      trail: [],
+    });
+  }
+}
+initFlies();
+
+/**
+ * 蛍を1ステップ更新する
+ * @param {Firefly} fly
+ */
+function updateFly(fly) {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  // 点滅制御
+  fly.phase += params.flashRate;
+  if (Math.random() < params.flashRate) {
+    fly.lit = params.flashDuration;
+  }
+  if (fly.lit > 0) fly.lit--;
+
+  // 動き（ゆらゆら）
+  fly.vx += (Math.random() - 0.5) * 0.2 + params.windX * 0.02;
+  fly.vy += (Math.random() - 0.5) * 0.2 + Math.sin(fly.phase * 2) * 0.05;
+
+  // 速度制限
+  const speed = Math.hypot(fly.vx, fly.vy);
+  if (speed > params.moveSpeed) {
+    fly.vx = (fly.vx / speed) * params.moveSpeed;
+    fly.vy = (fly.vy / speed) * params.moveSpeed;
+  }
+
+  fly.x += fly.vx;
+  fly.y += fly.vy;
+
+  // 光跡を記録（点灯中のみ）
+  if (fly.lit > 0) {
+    fly.trail.push({ x: fly.x, y: fly.y });
+    if (fly.trail.length > params.trailLength) fly.trail.shift();
+  } else {
+    // 消えたら徐々に軌跡を消す
+    if (fly.trail.length > 0 && Math.random() < 0.1) fly.trail.shift();
+  }
+
+  // 画面折り返し
+  if (fly.x < -50) fly.x += w + 100;
+  if (fly.x > w + 50) fly.x -= w + 100;
+  if (fly.y < h * 0.1) fly.y = h * 0.1;
+  if (fly.y > h * 0.95) fly.y = h * 0.95;
+  fly.vy += (h * 0.6 - fly.y) * 0.0002;
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(3, 6, 10, ${params.trailFade})`;
+  ctx.fillRect(0, 0, w, h);
+
+  for (const fly of flies) {
+    updateFly(fly);
+
+    // 光跡を描く
+    for (let i = 1; i < fly.trail.length; i++) {
+      const t = i / fly.trail.length;
+      ctx.strokeStyle = `hsla(${fly.hue}, 90%, 70%, ${t * 0.6})`;
+      ctx.lineWidth = t * 1.5;
+      ctx.beginPath();
+      ctx.moveTo(fly.trail[i - 1].x, fly.trail[i - 1].y);
+      ctx.lineTo(fly.trail[i].x, fly.trail[i].y);
+      ctx.stroke();
+    }
+
+    // 本体（点灯中）
+    if (fly.lit > 0) {
+      const litFrac = fly.lit / params.flashDuration;
+      const glow = params.glowSize * litFrac;
+      const grd = ctx.createRadialGradient(
+        fly.x,
+        fly.y,
+        0,
+        fly.x,
+        fly.y,
+        glow * 2,
+      );
+      grd.addColorStop(0, `hsla(${fly.hue}, 100%, 95%, ${litFrac})`);
+      grd.addColorStop(0.4, `hsla(${fly.hue}, 90%, 75%, ${litFrac * 0.7})`);
+      grd.addColorStop(1, `hsla(${fly.hue}, 80%, 60%, 0)`);
+      ctx.fillStyle = grd;
+      ctx.beginPath();
+      ctx.arc(fly.x, fly.y, glow * 2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Fireflies Trail',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 10, 200, 5).onChange(initFlies);
+gui.add(params, 'flashRate', 0.001, 0.05, 0.001);
+gui.add(params, 'flashDuration', 10, 100, 1);
+gui.add(params, 'moveSpeed', 0.2, 4, 0.1);
+gui.add(params, 'trailLength', 10, 200, 5);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueVar', 0, 180, 1);
+gui.add(params, 'trailFade', 0.02, 0.5, 0.01);
+gui.add(params, 'glowSize', 2, 25, 0.5);
+gui.add(params, 'windX', -2, 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.count = rand(20, 120, 5);
+  params.flashRate = rand(0.002, 0.03, 0.001);
+  params.flashDuration = rand(15, 80, 1);
+  params.moveSpeed = rand(0.3, 3, 0.1);
+  params.hueBase = rand(0, 360, 1);
+  params.hueVar = rand(10, 120, 1);
+  params.glowSize = rand(4, 20, 0.5);
+  initFlies();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initFlies();
+  gui.updateDisplay();
+});

--- a/public/fireflies-trail/style.css
+++ b/public/fireflies-trail/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/fm-synthesis-visualizer/index.html
+++ b/public/fm-synthesis-visualizer/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>FM Synthesis Visualizer | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/fm-synthesis-visualizer/main.js
+++ b/public/fm-synthesis-visualizer/main.js
@@ -1,0 +1,142 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// y(t) = sin( carrier*t + I * sin( modulator*t ) ) をリサージュ風に 2D プロット
+const params = {
+  carrier: 3,
+  modulator: 2,
+  index: 3.2,
+  ratioY: 2,
+  modulatorY: 5,
+  indexY: 2.4,
+  samples: 2000,
+  scale: 320,
+  hueStart: 200,
+  hueRange: 160,
+  strokeAlpha: 0.45,
+  lineWidth: 1.2,
+  autoMorph: true,
+  morphSpeed: 0.2,
+  trailFade: 0.08,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  const idx = params.autoMorph
+    ? params.index + Math.sin(time * params.morphSpeed) * 1.5
+    : params.index;
+  const idy = params.autoMorph
+    ? params.indexY + Math.cos(time * params.morphSpeed * 0.8) * 1.5
+    : params.indexY;
+
+  ctx.beginPath();
+  const n = Math.round(params.samples);
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2;
+    const x = Math.sin(
+      params.carrier * t + idx * Math.sin(params.modulator * t),
+    );
+    const y = Math.sin(
+      params.ratioY * t + idy * Math.sin(params.modulatorY * t + time * 0.5),
+    );
+    const sx = cx + x * params.scale;
+    const sy = cy + y * params.scale;
+    if (i === 0) ctx.moveTo(sx, sy);
+    else ctx.lineTo(sx, sy);
+  }
+  const hue = params.hueStart + Math.sin(time * 0.3) * params.hueRange * 0.5;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 70%, ${params.strokeAlpha})`;
+  ctx.lineWidth = params.lineWidth;
+  ctx.stroke();
+
+  // 色違いでもう一重
+  ctx.beginPath();
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2 + time * 0.1;
+    const x = Math.sin(
+      params.carrier * t + idx * Math.sin(params.modulator * t),
+    );
+    const y = Math.sin(
+      params.ratioY * t + idy * Math.sin(params.modulatorY * t),
+    );
+    const sx = cx + x * params.scale;
+    const sy = cy + y * params.scale;
+    if (i === 0) ctx.moveTo(sx, sy);
+    else ctx.lineTo(sx, sy);
+  }
+  ctx.strokeStyle = `hsla(${(hue + params.hueRange * 0.5) % 360}, 90%, 65%, ${params.strokeAlpha * 0.6})`;
+  ctx.stroke();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'FM Synthesis Visualizer',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'carrier', 1, 10, 1);
+gui.add(params, 'modulator', 1, 10, 1);
+gui.add(params, 'index', 0, 8, 0.05);
+gui.add(params, 'ratioY', 1, 10, 1);
+gui.add(params, 'modulatorY', 1, 10, 1);
+gui.add(params, 'indexY', 0, 8, 0.05);
+gui.add(params, 'samples', 300, 4000, 50);
+gui.add(params, 'scale', 80, 500, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'lineWidth', 0.3, 3, 0.1);
+gui.add(params, 'autoMorph');
+gui.add(params, 'morphSpeed', 0, 1, 0.01);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.carrier = rand(1, 7, 1);
+  params.modulator = rand(1, 7, 1);
+  params.ratioY = rand(1, 7, 1);
+  params.modulatorY = rand(1, 7, 1);
+  params.index = rand(0.5, 5, 0.05);
+  params.indexY = rand(0.5, 5, 0.05);
+  params.hueStart = rand(0, 360, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/fm-synthesis-visualizer/style.css
+++ b/public/fm-synthesis-visualizer/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/genetic-creatures/index.html
+++ b/public/genetic-creatures/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Genetic Creatures | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/genetic-creatures/main.js
+++ b/public/genetic-creatures/main.js
@@ -1,0 +1,262 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 遺伝的アルゴリズムで育つ生き物の群れ。遺伝子は形状（サイズ・色相・曲率）、速さ、振動数。
+const params = {
+  population: 40,
+  mutationRate: 0.08,
+  selectionPressure: 0.5,
+  foodRate: 2.0,
+  wiggleAmp: 1.2,
+  generationSeconds: 6,
+  hueStart: 120,
+  hueRange: 200,
+  trailFade: 0.1,
+  bodyAlpha: 0.9,
+  tailLength: 18,
+  showFood: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Gene
+ * @property {number} size
+ * @property {number} hue
+ * @property {number} speed
+ * @property {number} wiggle
+ * @property {number} curvature
+ */
+/**
+ * @typedef {object} Creature
+ * @property {number} x
+ * @property {number} y
+ * @property {number} vx
+ * @property {number} vy
+ * @property {number} age
+ * @property {number} fitness
+ * @property {Gene} gene
+ * @property {number[]} tail
+ */
+
+function randGene() {
+  return {
+    size: 4 + Math.random() * 14,
+    hue: params.hueStart + Math.random() * params.hueRange,
+    speed: 30 + Math.random() * 100,
+    wiggle: 0.5 + Math.random() * 3,
+    curvature: Math.random() * 2 - 1,
+  };
+}
+
+/** @param {Gene} g */
+function makeCreature(g) {
+  return {
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+    vx: (Math.random() - 0.5) * g.speed,
+    vy: (Math.random() - 0.5) * g.speed,
+    age: 0,
+    fitness: 0,
+    gene: g,
+    tail: [],
+  };
+}
+
+/** @type {Creature[]} */
+let creatures = [];
+/** @type {{x:number,y:number}[]} */
+let foods = [];
+let time = 0;
+let genTimer = 0;
+
+function reset() {
+  creatures = [];
+  for (let i = 0; i < Math.round(params.population); i++) {
+    creatures.push(makeCreature(randGene()));
+  }
+  foods = [];
+}
+reset();
+
+function spawnFood() {
+  foods.push({
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+  });
+  if (foods.length > 200) foods.shift();
+}
+
+function evolve() {
+  creatures.sort((a, b) => b.fitness - a.fitness);
+  const keep = Math.max(
+    2,
+    Math.round(creatures.length * (1 - params.selectionPressure)),
+  );
+  const elites = creatures.slice(0, keep);
+  const next = [];
+  while (next.length < creatures.length) {
+    const p1 = elites[Math.floor(Math.random() * elites.length)];
+    const p2 = elites[Math.floor(Math.random() * elites.length)];
+    /** @type {Gene} */
+    const child = {
+      size: (p1.gene.size + p2.gene.size) / 2,
+      hue: (p1.gene.hue + p2.gene.hue) / 2,
+      speed: (p1.gene.speed + p2.gene.speed) / 2,
+      wiggle: (p1.gene.wiggle + p2.gene.wiggle) / 2,
+      curvature: (p1.gene.curvature + p2.gene.curvature) / 2,
+    };
+    if (Math.random() < params.mutationRate)
+      child.size += (Math.random() - 0.5) * 4;
+    if (Math.random() < params.mutationRate)
+      child.hue += (Math.random() - 0.5) * 40;
+    if (Math.random() < params.mutationRate)
+      child.speed += (Math.random() - 0.5) * 30;
+    if (Math.random() < params.mutationRate)
+      child.wiggle += (Math.random() - 0.5) * 1;
+    if (Math.random() < params.mutationRate)
+      child.curvature += (Math.random() - 0.5) * 0.5;
+    child.size = Math.max(3, Math.min(20, child.size));
+    child.speed = Math.max(10, Math.min(180, child.speed));
+    next.push(makeCreature(child));
+  }
+  creatures = next;
+}
+
+function draw() {
+  const dt = 1 / 60;
+  time += dt;
+  genTimer += dt;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (Math.random() < params.foodRate * dt) spawnFood();
+  if (genTimer > params.generationSeconds) {
+    genTimer = 0;
+    evolve();
+  }
+
+  if (params.showFood) {
+    for (const f of foods) {
+      ctx.fillStyle = 'rgba(250, 230, 120, 0.7)';
+      ctx.beginPath();
+      ctx.arc(f.x, f.y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  for (const c of creatures) {
+    c.age += dt;
+    // wiggle 付き移動
+    const wig = Math.sin(time * c.gene.wiggle * 3 + c.age) * params.wiggleAmp;
+    c.vx += (Math.cos(c.age * c.gene.curvature) * 10 + wig * 10) * dt;
+    c.vy += (Math.sin(c.age * c.gene.curvature) * 10 + wig * 10) * dt;
+    const sp = Math.hypot(c.vx, c.vy) || 1;
+    c.vx = (c.vx / sp) * c.gene.speed;
+    c.vy = (c.vy / sp) * c.gene.speed;
+    c.x += c.vx * dt;
+    c.y += c.vy * dt;
+    if (c.x < 0) c.x += canvas.width;
+    if (c.x > canvas.width) c.x -= canvas.width;
+    if (c.y < 0) c.y += canvas.height;
+    if (c.y > canvas.height) c.y -= canvas.height;
+    c.tail.push(c.x, c.y);
+    const maxPairs = params.tailLength * 2;
+    while (c.tail.length > maxPairs) c.tail.shift();
+    // 食べる
+    for (let i = foods.length - 1; i >= 0; i--) {
+      const f = foods[i];
+      if (Math.hypot(f.x - c.x, f.y - c.y) < c.gene.size + 4) {
+        foods.splice(i, 1);
+        c.fitness += 1;
+      }
+    }
+    // 描画: 尾
+    ctx.strokeStyle = `hsla(${c.gene.hue}, 80%, 60%, 0.4)`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let i = 0; i < c.tail.length; i += 2) {
+      const tx = c.tail[i];
+      const ty = c.tail[i + 1];
+      if (i === 0) ctx.moveTo(tx, ty);
+      else ctx.lineTo(tx, ty);
+    }
+    ctx.stroke();
+    // 本体
+    ctx.fillStyle = `hsla(${c.gene.hue}, 85%, 65%, ${params.bodyAlpha})`;
+    ctx.beginPath();
+    ctx.arc(c.x, c.y, c.gene.size, 0, Math.PI * 2);
+    ctx.fill();
+    // 目
+    ctx.fillStyle = '#fff';
+    ctx.beginPath();
+    ctx.arc(
+      c.x + Math.cos(Math.atan2(c.vy, c.vx)) * c.gene.size * 0.4,
+      c.y + Math.sin(Math.atan2(c.vy, c.vx)) * c.gene.size * 0.4,
+      c.gene.size * 0.18,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Genetic Creatures',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'population', 10, 100, 1);
+gui.add(params, 'mutationRate', 0, 0.3, 0.01);
+gui.add(params, 'selectionPressure', 0.1, 0.9, 0.05);
+gui.add(params, 'foodRate', 0.2, 8, 0.1);
+gui.add(params, 'wiggleAmp', 0, 3, 0.05);
+gui.add(params, 'generationSeconds', 2, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'bodyAlpha', 0.3, 1, 0.01);
+gui.add(params, 'tailLength', 4, 40, 1);
+gui.add(params, 'showFood');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.population = rand(20, 80, 1);
+  params.mutationRate = rand(0.03, 0.2, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/genetic-creatures/style.css
+++ b/public/genetic-creatures/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/girih-pattern/index.html
+++ b/public/girih-pattern/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Girih Pattern | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/girih-pattern/main.js
+++ b/public/girih-pattern/main.js
@@ -1,0 +1,204 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// ギリパターン：イスラム建築の5種タイル（正十角形・星・蝶・菱形・三角）を
+// 10回対称で敷き詰める幾何学模様。
+
+const params = {
+  tileSize: 60, // タイルの基本サイズ
+  hueBase: 200, // 基本色相
+  hueStar: 40, // 星形の色相
+  hueBody: 260, // 本体の色相
+  saturation: 65, // 彩度
+  strokeWidth: 1.2, // 枠線幅
+  strokeBright: 15, // 枠線明度
+  animSpeed: 0.15, // アニメーション速度
+  colorCycle: 0, // 色相サイクル
+  brightness: 50, // 明度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 正多角形のパスを描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} r 外接円半径
+ * @param {number} n 頂点数
+ * @param {number} rotAngle 回転角（rad）
+ */
+function regularPolygon(cx, cy, r, n, rotAngle) {
+  ctx.beginPath();
+  for (let i = 0; i < n; i++) {
+    const a = rotAngle + (i * Math.PI * 2) / n;
+    const x = cx + r * Math.cos(a);
+    const y = cy + r * Math.sin(a);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+}
+
+/**
+ * 星形多角形のパスを描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} ro 外接円半径
+ * @param {number} ri 内接円半径
+ * @param {number} n 頂点数
+ * @param {number} rotAngle 回転角
+ */
+function starPolygon(cx, cy, ro, ri, n, rotAngle) {
+  ctx.beginPath();
+  for (let i = 0; i < n * 2; i++) {
+    const r = i % 2 === 0 ? ro : ri;
+    const a = rotAngle + (i * Math.PI) / n;
+    const x = cx + r * Math.cos(a);
+    const y = cy + r * Math.sin(a);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+}
+
+/**
+ * ギリタイルを1セル描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} s サイズ
+ * @param {number} phase 位相
+ */
+function drawGirihCell(cx, cy, s, phase) {
+  const hBase = (params.hueBase + phase + time * 20) % 360;
+  const hStar = (params.hueStar + phase + time * 20) % 360;
+  const sat = params.saturation;
+  const lig = params.brightness;
+
+  // 外側の十角形
+  regularPolygon(cx, cy, s * 0.92, 10, -Math.PI / 2);
+  ctx.fillStyle = `hsl(${(hBase + params.hueBody) % 360}, ${sat}%, ${lig}%)`;
+  ctx.fill();
+  if (params.strokeWidth > 0) {
+    ctx.strokeStyle = `hsl(0, 0%, ${params.strokeBright}%)`;
+    ctx.lineWidth = params.strokeWidth;
+    ctx.stroke();
+  }
+
+  // 内側の星形（10角星）
+  starPolygon(cx, cy, s * 0.65, s * 0.28, 10, -Math.PI / 2);
+  ctx.fillStyle = `hsl(${hStar}, ${sat + 10}%, ${lig + 15}%)`;
+  ctx.fill();
+  if (params.strokeWidth > 0) {
+    ctx.strokeStyle = `hsl(0, 0%, ${params.strokeBright}%)`;
+    ctx.lineWidth = params.strokeWidth;
+    ctx.stroke();
+  }
+
+  // 中心の五角形
+  regularPolygon(cx, cy, s * 0.18, 5, -Math.PI / 2);
+  ctx.fillStyle = `hsl(${hBase}, ${sat}%, ${lig + 20}%)`;
+  ctx.fill();
+  if (params.strokeWidth > 0) {
+    ctx.strokeStyle = `hsl(0, 0%, ${params.strokeBright}%)`;
+    ctx.lineWidth = params.strokeWidth;
+    ctx.stroke();
+  }
+}
+
+function draw() {
+  time += params.animSpeed * 0.01;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, w, h);
+
+  const s = params.tileSize;
+  // 六方格子でタイルを配置
+  const dx = s * 2;
+  const dy = s * Math.sqrt(3);
+  const cols = Math.ceil(w / dx) + 3;
+  const rows = Math.ceil(h / dy) + 3;
+
+  for (let row = -1; row < rows; row++) {
+    for (let col = -1; col < cols; col++) {
+      const cx = col * dx + (row % 2) * s;
+      const cy = row * dy;
+      const phase = params.colorCycle + (row + col) * 15;
+      drawGirihCell(cx, cy, s, phase);
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Girih Pattern',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'tileSize', 20, 150, 2);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueStar', 0, 360, 1);
+gui.add(params, 'hueBody', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'brightness', 10, 90, 1);
+gui.add(params, 'strokeWidth', 0, 5, 0.1);
+gui.add(params, 'animSpeed', 0, 3, 0.05);
+gui.add(params, 'colorCycle', 0, 360, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.tileSize = rand(30, 120, 2);
+  params.hueBase = rand(0, 360, 1);
+  params.hueStar = rand(0, 360, 1);
+  params.hueBody = rand(0, 360, 1);
+  params.saturation = rand(40, 85, 1);
+  params.brightness = rand(25, 70, 1);
+  params.animSpeed = rand(0, 2, 0.05);
+  params.colorCycle = rand(0, 360, 1);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/girih-pattern/style.css
+++ b/public/girih-pattern/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/gosper-island/index.html
+++ b/public/gosper-island/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Gosper Island | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/gosper-island/main.js
+++ b/public/gosper-island/main.js
@@ -1,0 +1,179 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  iterations: 3,
+  initialSize: 300,
+  ratio: 1 / Math.sqrt(7), // Gosper の縮小比
+  hueStart: 180,
+  hueEnd: 80,
+  strokeAlpha: 0.9,
+  fillAlpha: 0.15,
+  thickness: 1.4,
+  rotation: 0,
+  rotSpeed: 0.05,
+  bloom: 0.3,
+  showOutline: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+// Gosper 曲線 (flowsnake) を L-System 的に生成
+// Rules: A -> A-B--B+A++AA+B-  /  B -> +A-BB--B-A++A+B
+// 基本 angle = 60 度
+function generateGosper(depth) {
+  let s = 'A';
+  for (let i = 0; i < depth; i++) {
+    let next = '';
+    for (const c of s) {
+      if (c === 'A') next += 'A-B--B+A++AA+B-';
+      else if (c === 'B') next += '+A-BB--B-A++A+B';
+      else next += c;
+    }
+    s = next;
+  }
+  return s;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.2)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const ang = params.rotation + time * params.rotSpeed;
+
+  const depth = Math.round(params.iterations);
+  const s = generateGosper(depth);
+  const step = params.initialSize * params.ratio ** depth;
+  const turn = (60 * Math.PI) / 180;
+
+  // 先に構築（中心合わせのため）
+  /** @type {{x:number,y:number}[]} */
+  const pts = [];
+  let x = 0;
+  let y = 0;
+  let a = 0;
+  pts.push({ x, y });
+  for (const c of s) {
+    if (c === 'A' || c === 'B') {
+      x += Math.cos(a) * step;
+      y += Math.sin(a) * step;
+      pts.push({ x, y });
+    } else if (c === '+') a += turn;
+    else if (c === '-') a -= turn;
+  }
+  // bbox 中心
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  const ox = (minX + maxX) / 2;
+  const oy = (minY + maxY) / 2;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(ang);
+  ctx.beginPath();
+  const p0 = pts[0];
+  ctx.moveTo(p0.x - ox, p0.y - oy);
+  for (let i = 1; i < pts.length; i++) {
+    const t = i / pts.length;
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+    ctx.strokeStyle = `hsla(${hue}, 80%, 60%, ${params.strokeAlpha})`;
+    ctx.lineWidth = params.thickness;
+    ctx.beginPath();
+    ctx.moveTo(pts[i - 1].x - ox, pts[i - 1].y - oy);
+    ctx.lineTo(pts[i].x - ox, pts[i].y - oy);
+    ctx.stroke();
+  }
+
+  if (params.showOutline) {
+    // 全体を閉じて塗り
+    ctx.fillStyle = `hsla(${params.hueStart}, 80%, 50%, ${params.fillAlpha})`;
+    ctx.beginPath();
+    ctx.moveTo(pts[0].x - ox, pts[0].y - oy);
+    for (let i = 1; i < pts.length; i++) {
+      ctx.lineTo(pts[i].x - ox, pts[i].y - oy);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  if (params.bloom > 0) {
+    ctx.fillStyle = `hsla(${params.hueEnd}, 90%, 70%, ${params.bloom})`;
+    ctx.beginPath();
+    ctx.arc(p0.x - ox, p0.y - oy, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Gosper Island',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'iterations', 0, 4, 1);
+gui.add(params, 'initialSize', 120, 500, 1);
+gui.add(params, 'ratio', 0.2, 0.6, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'fillAlpha', 0, 0.6, 0.01);
+gui.add(params, 'thickness', 0.3, 4, 0.1);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+gui.add(params, 'bloom', 0, 1, 0.01);
+gui.add(params, 'showOutline');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.iterations = rand(2, 4, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  params.fillAlpha = rand(0.05, 0.35, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/gosper-island/style.css
+++ b/public/gosper-island/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/granular-cloud/index.html
+++ b/public/granular-cloud/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Granular Cloud | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/granular-cloud/main.js
+++ b/public/granular-cloud/main.js
@@ -1,0 +1,152 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// グラニュラーシンセの粒を視覚化。ソース波形からランダムに小さい粒をサンプリングして空間にばらまく。
+const params = {
+  grainRate: 60, // 1 秒あたりのグレイン生成数
+  grainLifetime: 1.8,
+  grainSize: 4,
+  sourceFreq: 0.5,
+  scatterX: 400,
+  scatterY: 280,
+  driftY: 20,
+  hueStart: 30,
+  hueRange: 300,
+  alpha: 0.8,
+  trailFade: 0.08,
+  pitchJitter: 0.6,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {{x:number,y:number,vx:number,vy:number,t:number,life:number,hue:number,size:number}[]} */
+let grains = [];
+let time = 0;
+let spawnBudget = 0;
+
+function spawn() {
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const dx = (Math.random() - 0.5) * params.scatterX;
+  const dy = (Math.random() - 0.5) * params.scatterY;
+  const pitch = 1 + (Math.random() - 0.5) * params.pitchJitter;
+  const hue =
+    params.hueStart +
+    (Math.sin(time * params.sourceFreq) + 1) * 0.5 * params.hueRange +
+    pitch * 20;
+  grains.push({
+    x: cx + dx,
+    y: cy + dy,
+    vx: (Math.random() - 0.5) * 20,
+    vy: -Math.random() * params.driftY,
+    t: 0,
+    life: params.grainLifetime * (0.7 + Math.random() * 0.6),
+    hue,
+    size: params.grainSize * (0.6 + Math.random() * 0.8) * pitch,
+  });
+}
+
+function draw() {
+  const dt = 1 / 60;
+  time += dt;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  spawnBudget += params.grainRate * dt;
+  while (spawnBudget >= 1) {
+    spawn();
+    spawnBudget--;
+  }
+
+  grains = grains.filter((g) => g.t < g.life);
+  for (const g of grains) {
+    g.t += dt;
+    g.x += g.vx * dt;
+    g.y += g.vy * dt;
+    g.vy -= 5 * dt; // ふわっと上昇
+    const k = g.t / g.life;
+    const a = params.alpha * Math.sin(k * Math.PI); // 包絡
+    ctx.fillStyle = `hsla(${g.hue}, 90%, 70%, ${a})`;
+    ctx.beginPath();
+    ctx.arc(g.x, g.y, g.size * (1 - k * 0.3), 0, Math.PI * 2);
+    ctx.fill();
+    // グロー
+    ctx.fillStyle = `hsla(${g.hue}, 100%, 80%, ${a * 0.4})`;
+    ctx.beginPath();
+    ctx.arc(g.x, g.y, g.size * 2.2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // ソース波形の線（装飾）
+  ctx.strokeStyle = `hsla(${params.hueStart + 180}, 60%, 60%, 0.3)`;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  const mid = canvas.height / 2;
+  const amp = 60;
+  for (let x = 0; x < canvas.width; x += 3) {
+    const y = mid + Math.sin(x * 0.02 + time * params.sourceFreq * 3) * amp;
+    if (x === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Granular Cloud',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'grainRate', 10, 300, 1);
+gui.add(params, 'grainLifetime', 0.3, 5, 0.05);
+gui.add(params, 'grainSize', 1, 15, 0.1);
+gui.add(params, 'sourceFreq', 0.05, 2, 0.01);
+gui.add(params, 'scatterX', 50, 800, 1);
+gui.add(params, 'scatterY', 30, 500, 1);
+gui.add(params, 'driftY', 0, 80, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'pitchJitter', 0, 2, 0.05);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.grainRate = rand(30, 150, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.sourceFreq = rand(0.2, 1.2, 0.01);
+  params.driftY = rand(5, 60, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  grains = [];
+  gui.updateDisplay();
+});

--- a/public/granular-cloud/style.css
+++ b/public/granular-cloud/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/gray-scott-model/index.html
+++ b/public/gray-scott-model/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Gray-Scott Model | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/gray-scott-model/main.js
+++ b/public/gray-scott-model/main.js
@@ -1,0 +1,239 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Gray-Scott モデルのプリセット探索版。パラメータ一覧でパターン分類を切り替え。
+const params = {
+  presetIdx: 0, // 0:spots 1:stripes 2:mitosis 3:bubbles 4:worms 5:chaos
+  feed: 0.036,
+  kill: 0.06,
+  dA: 1,
+  dB: 0.5,
+  gridScale: 5,
+  iterPerFrame: 8,
+  hueA: 40,
+  hueB: 220,
+  brightness: 1.5,
+  seedRadius: 14,
+  multiSeed: 5,
+  flowBias: 0,
+};
+const defaults = { ...params };
+
+const presets = [
+  { name: 'Spots', feed: 0.036, kill: 0.06 },
+  { name: 'Stripes', feed: 0.042, kill: 0.063 },
+  { name: 'Mitosis', feed: 0.0367, kill: 0.0649 },
+  { name: 'Bubbles', feed: 0.098, kill: 0.057 },
+  { name: 'Worms', feed: 0.058, kill: 0.065 },
+  { name: 'Chaos', feed: 0.026, kill: 0.051 },
+];
+
+function applyPreset(i) {
+  const p = presets[i % presets.length];
+  params.feed = p.feed;
+  params.kill = p.kill;
+}
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** @type {Float32Array} */
+let A;
+/** @type {Float32Array} */
+let B;
+/** @type {Float32Array} */
+let A2;
+/** @type {Float32Array} */
+let B2;
+let gw = 0;
+let gh = 0;
+
+function rebuild() {
+  gw = Math.max(40, Math.floor(canvas.width / params.gridScale));
+  gh = Math.max(40, Math.floor(canvas.height / params.gridScale));
+  A = new Float32Array(gw * gh);
+  B = new Float32Array(gw * gh);
+  A2 = new Float32Array(gw * gh);
+  B2 = new Float32Array(gw * gh);
+  for (let i = 0; i < A.length; i++) A[i] = 1;
+  const m = Math.max(1, Math.round(params.multiSeed));
+  for (let i = 0; i < m; i++) {
+    seed(Math.random() * gw, Math.random() * gh);
+  }
+}
+
+function seed(cx, cy) {
+  const r = Math.round(params.seedRadius);
+  for (let y = -r; y <= r; y++) {
+    for (let x = -r; x <= r; x++) {
+      const px = Math.floor(cx + x);
+      const py = Math.floor(cy + y);
+      if (px < 0 || py < 0 || px >= gw || py >= gh) continue;
+      if (x * x + y * y <= r * r) B[py * gw + px] = 1;
+    }
+  }
+}
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  rebuild();
+}
+window.addEventListener('resize', resize);
+resize();
+
+function laplacian(buf, x, y) {
+  const idx = y * gw + x;
+  const xm = (x - 1 + gw) % gw;
+  const xp = (x + 1) % gw;
+  const ym = (y - 1 + gh) % gh;
+  const yp = (y + 1) % gh;
+  return (
+    buf[ym * gw + xm] * 0.05 +
+    buf[ym * gw + x] * 0.2 +
+    buf[ym * gw + xp] * 0.05 +
+    buf[y * gw + xm] * 0.2 +
+    buf[idx] * -1 +
+    buf[y * gw + xp] * 0.2 +
+    buf[yp * gw + xm] * 0.05 +
+    buf[yp * gw + x] * 0.2 +
+    buf[yp * gw + xp] * 0.05
+  );
+}
+
+function iterate() {
+  const F = params.feed;
+  const K = params.kill;
+  const bias = params.flowBias;
+  for (let y = 0; y < gh; y++) {
+    for (let x = 0; x < gw; x++) {
+      const idx = y * gw + x;
+      const av = A[idx];
+      const bv = B[idx];
+      const abb = av * bv * bv;
+      A2[idx] = av + (params.dA * laplacian(A, x, y) - abb + F * (1 - av));
+      B2[idx] =
+        bv +
+        (params.dB * laplacian(B, x, y) + abb - (K + F) * bv) +
+        bias * 0.001 * (x / gw - 0.5);
+      if (A2[idx] < 0) A2[idx] = 0;
+      if (A2[idx] > 1) A2[idx] = 1;
+      if (B2[idx] < 0) B2[idx] = 0;
+      if (B2[idx] > 1) B2[idx] = 1;
+    }
+  }
+  [A, A2] = [A2, A];
+  [B, B2] = [B2, B];
+}
+
+let lastPreset = -1;
+
+function draw() {
+  if (Math.round(params.presetIdx) !== lastPreset) {
+    lastPreset = Math.round(params.presetIdx);
+    applyPreset(lastPreset);
+  }
+  const iters = Math.round(params.iterPerFrame);
+  for (let i = 0; i < iters; i++) iterate();
+
+  const img = ctx.createImageData(canvas.width, canvas.height);
+  const data = img.data;
+  const sx = canvas.width / gw;
+  const sy = canvas.height / gh;
+  for (let py = 0; py < canvas.height; py++) {
+    const gy = Math.min(gh - 1, Math.floor(py / sy));
+    for (let px = 0; px < canvas.width; px++) {
+      const gx = Math.min(gw - 1, Math.floor(px / sx));
+      const i = gy * gw + gx;
+      const av = A[i];
+      const bv = B[i] * params.brightness;
+      const t = Math.min(1, bv);
+      const hue = params.hueA * (1 - t) + params.hueB * t;
+      const h = (hue % 360) / 60;
+      const c = t;
+      const x = c * (1 - Math.abs((h % 2) - 1));
+      let r = 0;
+      let g = 0;
+      let bb = 0;
+      if (h < 1) {
+        r = c;
+        g = x;
+      } else if (h < 2) {
+        r = x;
+        g = c;
+      } else if (h < 3) {
+        g = c;
+        bb = x;
+      } else if (h < 4) {
+        g = x;
+        bb = c;
+      } else if (h < 5) {
+        r = x;
+        bb = c;
+      } else {
+        r = c;
+        bb = x;
+      }
+      const m = av * 0.2;
+      const off = (py * canvas.width + px) * 4;
+      data[off] = Math.floor((r + m) * 255);
+      data[off + 1] = Math.floor((g + m) * 255);
+      data[off + 2] = Math.floor((bb + m) * 255);
+      data[off + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Gray-Scott Model',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'presetIdx', 0, presets.length - 1, 1);
+gui.add(params, 'feed', 0.02, 0.1, 0.001);
+gui.add(params, 'kill', 0.04, 0.075, 0.001);
+gui.add(params, 'dA', 0.5, 1.5, 0.01);
+gui.add(params, 'dB', 0.2, 1, 0.01);
+gui.add(params, 'gridScale', 3, 10, 1);
+gui.add(params, 'iterPerFrame', 2, 20, 1);
+gui.add(params, 'hueA', 0, 360, 1);
+gui.add(params, 'hueB', 0, 360, 1);
+gui.add(params, 'brightness', 0.5, 3, 0.05);
+gui.add(params, 'seedRadius', 3, 40, 1);
+gui.add(params, 'multiSeed', 1, 15, 1);
+gui.add(params, 'flowBias', -5, 5, 0.1);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.presetIdx = rand(0, presets.length - 1, 1);
+  params.hueA = rand(0, 360, 1);
+  params.hueB = rand(0, 360, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reseed', () => rebuild());
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/gray-scott-model/style.css
+++ b/public/gray-scott-model/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/h-tree/index.html
+++ b/public/h-tree/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>H Tree | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/h-tree/main.js
+++ b/public/h-tree/main.js
@@ -1,0 +1,196 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 9,
+  initialLength: 260,
+  ratio: Math.SQRT1_2,
+  thickness: 3,
+  thickDecay: 0.72,
+  hueStart: 200,
+  hueEnd: 320,
+  alpha: 0.9,
+  rotation: 0,
+  rotSpeed: 0.08,
+  fade: 0.18,
+  bloom: 0.7,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 水平もしくは垂直の「H」形を再帰描画
+ * @param {number} x
+ * @param {number} y
+ * @param {number} length
+ * @param {boolean} horizontal
+ * @param {number} depth
+ * @param {number} thickness
+ */
+function hTree(x, y, length, horizontal, depth, thickness) {
+  if (depth <= 0 || length < 1) return;
+  const t = 1 - depth / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.alpha})`;
+  ctx.lineWidth = Math.max(0.1, thickness);
+
+  const half = length / 2;
+  let x1;
+  let y1;
+  let x2;
+  let y2;
+  let x3;
+  let y3;
+  let x4;
+  let y4;
+  if (horizontal) {
+    // 水平棒
+    x1 = x - half;
+    y1 = y;
+    x2 = x + half;
+    y2 = y;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+    // 左右の垂直棒
+    x3 = x1;
+    y3 = y - half;
+    x4 = x1;
+    y4 = y + half;
+    ctx.beginPath();
+    ctx.moveTo(x3, y3);
+    ctx.lineTo(x4, y4);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x2, y - half);
+    ctx.lineTo(x2, y + half);
+    ctx.stroke();
+    const nl = length * params.ratio;
+    const nt = thickness * params.thickDecay;
+    hTree(x1, y - half, nl, !horizontal, depth - 1, nt);
+    hTree(x1, y + half, nl, !horizontal, depth - 1, nt);
+    hTree(x2, y - half, nl, !horizontal, depth - 1, nt);
+    hTree(x2, y + half, nl, !horizontal, depth - 1, nt);
+  } else {
+    x1 = x;
+    y1 = y - half;
+    x2 = x;
+    y2 = y + half;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x - half, y1);
+    ctx.lineTo(x + half, y1);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x - half, y2);
+    ctx.lineTo(x + half, y2);
+    ctx.stroke();
+    const nl = length * params.ratio;
+    const nt = thickness * params.thickDecay;
+    hTree(x - half, y1, nl, !horizontal, depth - 1, nt);
+    hTree(x + half, y1, nl, !horizontal, depth - 1, nt);
+    hTree(x - half, y2, nl, !horizontal, depth - 1, nt);
+    hTree(x + half, y2, nl, !horizontal, depth - 1, nt);
+  }
+
+  if (depth === 1 && params.bloom > 0) {
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, ${params.bloom})`;
+    ctx.beginPath();
+    ctx.arc(x, y, thickness + 1, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const ang = params.rotation + time * params.rotSpeed;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(ang);
+  ctx.lineCap = 'round';
+  hTree(
+    0,
+    0,
+    params.initialLength,
+    true,
+    Math.round(params.depth),
+    params.thickness,
+  );
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'H Tree',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 2, 12, 1);
+gui.add(params, 'initialLength', 80, 400, 1);
+gui.add(params, 'ratio', 0.4, 0.8, 0.01);
+gui.add(params, 'thickness', 0.5, 8, 0.1);
+gui.add(params, 'thickDecay', 0.5, 0.95, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'alpha', 0.1, 1, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+gui.add(params, 'fade', 0, 0.5, 0.01);
+gui.add(params, 'bloom', 0, 1, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(6, 10, 1);
+  params.initialLength = rand(160, 320, 1);
+  params.ratio = rand(0.55, 0.75, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  params.bloom = rand(0.3, 0.9, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/h-tree/style.css
+++ b/public/h-tree/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/hilbert-curve/index.html
+++ b/public/hilbert-curve/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Hilbert Curve | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/hilbert-curve/main.js
+++ b/public/hilbert-curve/main.js
@@ -1,0 +1,197 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// ヒルベルト曲線：空間充填曲線。
+// 再帰的に四角形を細分化し、一筆書きで全点を通る曲線を描く。
+
+const params = {
+  order: 6, // 再帰次数（1〜8）
+  hueStart: 240, // 開始色相
+  hueEnd: 360, // 終了色相
+  lineWidth: 1.5, // 線幅
+  drawSpeed: 8, // 描画速度（点/フレーム）
+  padding: 0.05, // 余白率
+  glow: 0.4, // 発光強度
+  bgAlpha: 0.03, // 背景フェード
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  buildCurve();
+}
+window.addEventListener('resize', resize);
+
+/** @type {{x: number, y: number}[]} */
+let points = [];
+let drawIdx = 0;
+
+/**
+ * (d, n) からヒルベルト曲線の (x, y) 座標を求める
+ * @param {number} n グリッドサイズ
+ * @param {number} d 距離
+ * @returns {{x: number, y: number}}
+ */
+function d2xy(n, d) {
+  let rx = 0;
+  let ry = 0;
+  let x = 0;
+  let y = 0;
+  let s = 1;
+  let t = d;
+  while (s < n) {
+    rx = 1 & (t / 2);
+    ry = 1 & (t ^ rx);
+    // rot
+    if (ry === 0) {
+      if (rx === 1) {
+        x = s - 1 - x;
+        y = s - 1 - y;
+      }
+      const tmp = x;
+      x = y;
+      y = tmp;
+    }
+    x += s * rx;
+    y += s * ry;
+    t = Math.floor(t / 4);
+    s *= 2;
+  }
+  return { x, y };
+}
+
+/**
+ * ヒルベルト曲線の点列を生成する
+ */
+function buildCurve() {
+  const order = Math.max(1, Math.min(8, Math.round(params.order)));
+  const n = 1 << order; // 2^order
+  const total = n * n;
+  const w = canvas.width;
+  const h = canvas.height;
+  const size = Math.min(w, h) * (1 - params.padding * 2);
+  const ox = (w - size) / 2;
+  const oy = (h - size) / 2;
+  const step = size / (n - 1);
+
+  points = [];
+  for (let d = 0; d < total; d++) {
+    const { x, y } = d2xy(n, d);
+    points.push({
+      x: ox + x * step,
+      y: oy + y * step,
+    });
+  }
+  drawIdx = 0;
+  ctx.clearRect(0, 0, w, h);
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, w, h);
+}
+
+buildCurve();
+
+/**
+ * 描画進捗に応じた色相を返す
+ * @param {number} t 0〜1
+ * @returns {string}
+ */
+function colorAt(t) {
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  return `hsl(${hue}, 80%, 60%)`;
+}
+
+function draw() {
+  const total = points.length;
+  if (drawIdx >= total - 1) {
+    // アニメーション完了後はリセット
+    drawIdx = 0;
+    ctx.fillStyle = '#0b0a07';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return;
+  }
+
+  const speed = Math.max(1, Math.round(params.drawSpeed));
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+
+  for (let i = 0; i < speed && drawIdx < total - 1; i++) {
+    const t = drawIdx / (total - 1);
+    ctx.strokeStyle = colorAt(t);
+
+    if (params.glow > 0) {
+      ctx.shadowColor = colorAt(t);
+      ctx.shadowBlur = params.glow * 10;
+    } else {
+      ctx.shadowBlur = 0;
+    }
+
+    ctx.beginPath();
+    ctx.moveTo(points[drawIdx].x, points[drawIdx].y);
+    ctx.lineTo(points[drawIdx + 1].x, points[drawIdx + 1].y);
+    ctx.stroke();
+    drawIdx++;
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Hilbert Curve',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'order', 1, 8, 1).onChange(buildCurve);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'lineWidth', 0.5, 5, 0.1);
+gui.add(params, 'drawSpeed', 1, 200, 1);
+gui.add(params, 'glow', 0, 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.order = rand(3, 7, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.lineWidth = rand(0.5, 3, 0.1);
+  params.drawSpeed = rand(4, 80, 1);
+  params.glow = rand(0, 1.5, 0.05);
+  buildCurve();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  buildCurve();
+  gui.updateDisplay();
+});

--- a/public/hilbert-curve/style.css
+++ b/public/hilbert-curve/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -823,6 +823,12 @@
               <span class="nav-description">メンガースポンジ断面</span>
             </a>
           </li>
+          <li>
+            <a href="/spectrogram-painter/">
+              Spectrogram Painter
+              <span class="nav-description">スペクトログラム描画</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -907,6 +907,12 @@
               <span class="nav-description">遺伝的生物</span>
             </a>
           </li>
+          <li>
+            <a href="/neural-network-viz/">
+              Neural Network Viz
+              <span class="nav-description">ニューラルネット可視化</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -877,6 +877,12 @@
               <span class="nav-description">グラニュラークラウド</span>
             </a>
           </li>
+          <li>
+            <a href="/beat-interference/">
+              Beat Interference
+              <span class="nav-description">ビート干渉</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -661,6 +661,12 @@
               <span class="nav-description">ギリパターン</span>
             </a>
           </li>
+          <li>
+            <a href="/aztec-geometry/">
+              Aztec Geometry
+              <span class="nav-description">アステカ幾何模様</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -895,6 +895,12 @@
               <span class="nav-description">反応拡散系</span>
             </a>
           </li>
+          <li>
+            <a href="/gray-scott-model/">
+              Gray-Scott Model
+              <span class="nav-description">Gray-Scott モデル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -841,6 +841,12 @@
               <span class="nav-description">位相シフトメトロノーム</span>
             </a>
           </li>
+          <li>
+            <a href="/euclidean-rhythm/">
+              Euclidean Rhythm
+              <span class="nav-description">ユークリッドリズム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -625,6 +625,12 @@
               <span class="nav-description">ヒルベルト曲線</span>
             </a>
           </li>
+          <li>
+            <a href="/peano-curve/">
+              Peano Curve
+              <span class="nav-description">ペアノ曲線</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -937,6 +937,12 @@
               <span class="nav-description">DNAヘリックス</span>
             </a>
           </li>
+          <li>
+            <a href="/cell-division/">
+              Cell Division
+              <span class="nav-description">細胞分裂</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -919,6 +919,12 @@
               <span class="nav-description">葉脈形成</span>
             </a>
           </li>
+          <li>
+            <a href="/coral-growth/">
+              Coral Growth
+              <span class="nav-description">サンゴの成長</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -757,6 +757,12 @@
               <span class="nav-description">蛾と炎</span>
             </a>
           </li>
+          <li>
+            <a href="/pollen-drift/">
+              Pollen Drift
+              <span class="nav-description">花粉の漂い</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -931,6 +931,12 @@
               <span class="nav-description">菌糸ネットワーク</span>
             </a>
           </li>
+          <li>
+            <a href="/dna-helix/">
+              DNA Helix
+              <span class="nav-description">DNAヘリックス</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -691,6 +691,12 @@
               <span class="nav-description">アリの橋</span>
             </a>
           </li>
+          <li>
+            <a href="/bee-swarm/">
+              Bee Swarm
+              <span class="nav-description">ミツバチの群れ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -619,6 +619,12 @@
               <span class="nav-description">雪崩のカスケード</span>
             </a>
           </li>
+          <li>
+            <a href="/hilbert-curve/">
+              Hilbert Curve
+              <span class="nav-description">ヒルベルト曲線</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -901,6 +901,12 @@
               <span class="nav-description">Gray-Scott モデル</span>
             </a>
           </li>
+          <li>
+            <a href="/genetic-creatures/">
+              Genetic Creatures
+              <span class="nav-description">遺伝的生物</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -613,6 +613,12 @@
               <span class="nav-description">渦巻く竜巻のパーティクル</span>
             </a>
           </li>
+          <li>
+            <a href="/avalanche-cascade/">
+              Avalanche Cascade
+              <span class="nav-description">雪崩のカスケード</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -889,6 +889,12 @@
               <span class="nav-description">リセのリズム</span>
             </a>
           </li>
+          <li>
+            <a href="/reaction-diffusion/">
+              Reaction Diffusion
+              <span class="nav-description">反応拡散系</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -649,6 +649,12 @@
               <span class="nav-description">エッシャー風テセレーション</span>
             </a>
           </li>
+          <li>
+            <a href="/quasicrystal/">
+              Quasicrystal
+              <span class="nav-description">準結晶パターン</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -637,6 +637,12 @@
               <span class="nav-description">菱形タイリング</span>
             </a>
           </li>
+          <li>
+            <a href="/celtic-knot/">
+              Celtic Knot
+              <span class="nav-description">ケルト結び目模様</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -829,6 +829,12 @@
               <span class="nav-description">スペクトログラム描画</span>
             </a>
           </li>
+          <li>
+            <a href="/circular-sequencer/">
+              Circular Sequencer
+              <span class="nav-description">円形シーケンサー</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -703,6 +703,12 @@
               <span class="nav-description">バクテリアコロニー</span>
             </a>
           </li>
+          <li>
+            <a href="/plankton-bloom/">
+              Plankton Bloom
+              <span class="nav-description">プランクトンブルーム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -697,6 +697,12 @@
               <span class="nav-description">ミツバチの群れ</span>
             </a>
           </li>
+          <li>
+            <a href="/bacterial-colony/">
+              Bacterial Colony
+              <span class="nav-description">バクテリアコロニー</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -853,6 +853,12 @@
               <span class="nav-description">ポリリズム円盤</span>
             </a>
           </li>
+          <li>
+            <a href="/chord-wheel/">
+              Chord Wheel
+              <span class="nav-description">コードホイール</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -751,6 +751,12 @@
               <span class="nav-description">蛍の光跡</span>
             </a>
           </li>
+          <li>
+            <a href="/moth-to-flame/">
+              Moth to Flame
+              <span class="nav-description">蛾と炎</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -643,6 +643,12 @@
               <span class="nav-description">ケルト結び目模様</span>
             </a>
           </li>
+          <li>
+            <a href="/escher-tessellation/">
+              Escher Tessellation
+              <span class="nav-description">エッシャー風テセレーション</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -727,6 +727,12 @@
               <span class="nav-description">電子雲</span>
             </a>
           </li>
+          <li>
+            <a href="/magnetic-dust/">
+              Magnetic Dust
+              <span class="nav-description">磁性粉のパターン</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -631,6 +631,12 @@
               <span class="nav-description">ペアノ曲線</span>
             </a>
           </li>
+          <li>
+            <a href="/rhombille-tiling/">
+              Rhombille Tiling
+              <span class="nav-description">菱形タイリング</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -655,6 +655,12 @@
               <span class="nav-description">準結晶パターン</span>
             </a>
           </li>
+          <li>
+            <a href="/girih-pattern/">
+              Girih Pattern
+              <span class="nav-description">ギリパターン</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -817,6 +817,12 @@
               <span class="nav-description">ゴスパー島</span>
             </a>
           </li>
+          <li>
+            <a href="/menger-slice/">
+              Menger Slice
+              <span class="nav-description">メンガースポンジ断面</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -925,6 +925,12 @@
               <span class="nav-description">サンゴの成長</span>
             </a>
           </li>
+          <li>
+            <a href="/mycelium-network/">
+              Mycelium Network
+              <span class="nav-description">菌糸ネットワーク</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -883,6 +883,12 @@
               <span class="nav-description">ビート干渉</span>
             </a>
           </li>
+          <li>
+            <a href="/risset-rhythm/">
+              Risset Rhythm
+              <span class="nav-description">リセのリズム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -835,6 +835,12 @@
               <span class="nav-description">円形シーケンサー</span>
             </a>
           </li>
+          <li>
+            <a href="/phase-shift-metronome/">
+              Phase Shift Metronome
+              <span class="nav-description">位相シフトメトロノーム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -775,6 +775,12 @@
               <span class="nav-description">燃える船フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/newton-fractal/">
+              Newton Fractal
+              <span class="nav-description">ニュートン法フラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -769,6 +769,12 @@
               <span class="nav-description">マンデルブロ集合ズーム</span>
             </a>
           </li>
+          <li>
+            <a href="/burning-ship/">
+              Burning Ship
+              <span class="nav-description">燃える船フラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -781,6 +781,12 @@
               <span class="nav-description">ニュートン法フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/barnsley-fern/">
+              Barnsley Fern
+              <span class="nav-description">バーンズリーのシダ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -763,6 +763,12 @@
               <span class="nav-description">花粉の漂い</span>
             </a>
           </li>
+          <li>
+            <a href="/mandelbrot-zoom/">
+              Mandelbrot Zoom
+              <span class="nav-description">マンデルブロ集合ズーム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -787,6 +787,12 @@
               <span class="nav-description">バーンズリーのシダ</span>
             </a>
           </li>
+          <li>
+            <a href="/apollonian-gasket/">
+              Apollonian Gasket
+              <span class="nav-description">アポロニウスのガスケット</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -739,6 +739,12 @@
               <span class="nav-description">砂嵐</span>
             </a>
           </li>
+          <li>
+            <a href="/comet-tail/">
+              Comet Tail
+              <span class="nav-description">彗星の尾</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -943,6 +943,12 @@
               <span class="nav-description">細胞分裂</span>
             </a>
           </li>
+          <li>
+            <a href="/virus-capsid/">
+              Virus Capsid
+              <span class="nav-description">ウイルスカプシド</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -721,6 +721,12 @@
               <span class="nav-description">鳥の群れの旋回</span>
             </a>
           </li>
+          <li>
+            <a href="/electron-cloud/">
+              Electron Cloud
+              <span class="nav-description">電子雲</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -859,6 +859,12 @@
               <span class="nav-description">コードホイール</span>
             </a>
           </li>
+          <li>
+            <a href="/fm-synthesis-visualizer/">
+              FM Synthesis Visualizer
+              <span class="nav-description">FM 合成ビジュアライザ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -607,6 +607,12 @@
               <span class="nav-description">熱気で地平線が揺らぐ蜃気楼のビジュアル</span>
             </a>
           </li>
+          <li>
+            <a href="/tornado-vortex/">
+              Tornado Vortex
+              <span class="nav-description">渦巻く竜巻のパーティクル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -913,6 +913,12 @@
               <span class="nav-description">ニューラルネット可視化</span>
             </a>
           </li>
+          <li>
+            <a href="/leaf-venation/">
+              Leaf Venation
+              <span class="nav-description">葉脈形成</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -793,6 +793,12 @@
               <span class="nav-description">アポロニウスのガスケット</span>
             </a>
           </li>
+          <li>
+            <a href="/h-tree/">
+              H Tree
+              <span class="nav-description">H木フラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -733,6 +733,12 @@
               <span class="nav-description">磁性粉のパターン</span>
             </a>
           </li>
+          <li>
+            <a href="/dust-storm/">
+              Dust Storm
+              <span class="nav-description">砂嵐</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -949,6 +949,12 @@
               <span class="nav-description">ウイルスカプシド</span>
             </a>
           </li>
+          <li>
+            <a href="/chromatic-aberration/">
+              Chromatic Aberration
+              <span class="nav-description">色収差</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -667,6 +667,12 @@
               <span class="nav-description">アステカ幾何模様</span>
             </a>
           </li>
+          <li>
+            <a href="/mandala-generator/">
+              Mandala Generator
+              <span class="nav-description">マンダラ生成器</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -715,6 +715,12 @@
               <span class="nav-description">粘菌ネットワーク</span>
             </a>
           </li>
+          <li>
+            <a href="/bird-murmuration/">
+              Bird Murmuration
+              <span class="nav-description">鳥の群れの旋回</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -745,6 +745,12 @@
               <span class="nav-description">彗星の尾</span>
             </a>
           </li>
+          <li>
+            <a href="/fireflies-trail/">
+              Fireflies Trail
+              <span class="nav-description">蛍の光跡</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -865,6 +865,12 @@
               <span class="nav-description">FM 合成ビジュアライザ</span>
             </a>
           </li>
+          <li>
+            <a href="/karplus-strong-strings/">
+              Karplus-Strong Strings
+              <span class="nav-description">カープラス・ストロング弦</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -685,6 +685,12 @@
               <span class="nav-description">群泳する魚</span>
             </a>
           </li>
+          <li>
+            <a href="/ant-bridge/">
+              Ant Bridge
+              <span class="nav-description">アリの橋</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -679,6 +679,12 @@
               <span class="nav-description">3D リサジュー曲線</span>
             </a>
           </li>
+          <li>
+            <a href="/schooling-fish/">
+              Schooling Fish
+              <span class="nav-description">群泳する魚</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -811,6 +811,12 @@
               <span class="nav-description">T-スクエアフラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/gosper-island/">
+              Gosper Island
+              <span class="nav-description">ゴスパー島</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -709,6 +709,12 @@
               <span class="nav-description">プランクトンブルーム</span>
             </a>
           </li>
+          <li>
+            <a href="/slime-mold/">
+              Slime Mold
+              <span class="nav-description">粘菌ネットワーク</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -799,6 +799,12 @@
               <span class="nav-description">H木フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/pythagoras-tree/">
+              Pythagoras Tree
+              <span class="nav-description">ピタゴラスの木</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -847,6 +847,12 @@
               <span class="nav-description">ユークリッドリズム</span>
             </a>
           </li>
+          <li>
+            <a href="/polyrhythm-wheel/">
+              Polyrhythm Wheel
+              <span class="nav-description">ポリリズム円盤</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -805,6 +805,12 @@
               <span class="nav-description">ピタゴラスの木</span>
             </a>
           </li>
+          <li>
+            <a href="/t-square-fractal/">
+              T-Square Fractal
+              <span class="nav-description">T-スクエアフラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -955,6 +955,12 @@
               <span class="nav-description">色収差</span>
             </a>
           </li>
+          <li>
+            <a href="/diffraction-grating/">
+              Diffraction Grating
+              <span class="nav-description">回折格子</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -673,6 +673,12 @@
               <span class="nav-description">マンダラ生成器</span>
             </a>
           </li>
+          <li>
+            <a href="/lissajous-3d/">
+              Lissajous 3D
+              <span class="nav-description">3D リサジュー曲線</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -871,6 +871,12 @@
               <span class="nav-description">カープラス・ストロング弦</span>
             </a>
           </li>
+          <li>
+            <a href="/granular-cloud/">
+              Granular Cloud
+              <span class="nav-description">グラニュラークラウド</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/karplus-strong-strings/index.html
+++ b/public/karplus-strong-strings/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Karplus-Strong Strings | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/karplus-strong-strings/main.js
+++ b/public/karplus-strong-strings/main.js
@@ -1,0 +1,171 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 物理モデル合成の Karplus-Strong を可視化（音は出さず、弦の波形アニメーション）
+const params = {
+  strings: 6, // 弦の本数
+  length: 600, // 弦の長さ（ドット数）
+  damping: 0.993, // 減衰
+  pluckInterval: 0.7,
+  pluckStrength: 0.9,
+  stringGap: 60,
+  hueStart: 20,
+  hueRange: 300,
+  amplitude: 35,
+  strokeAlpha: 0.9,
+  lineWidth: 1.6,
+  trailFade: 0.08,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Float32Array[]} */
+let strings = [];
+
+function rebuild() {
+  const n = Math.round(params.strings);
+  const L = Math.round(params.length);
+  strings = [];
+  for (let i = 0; i < n; i++) {
+    strings.push(new Float32Array(L));
+  }
+}
+rebuild();
+
+/**
+ * 弦を撥弦（ランダム振動で初期化）
+ * @param {number} i
+ */
+function pluck(i) {
+  const buf = strings[i];
+  if (!buf) return;
+  for (let k = 0; k < buf.length; k++) {
+    buf[k] = (Math.random() * 2 - 1) * params.pluckStrength;
+  }
+}
+
+let time = 0;
+let lastPluck = 0;
+
+function step() {
+  // Karplus-Strong: buf[k] = damping * (buf[k] + buf[k-1]) / 2
+  for (const buf of strings) {
+    const L = buf.length;
+    let prev = buf[L - 1];
+    for (let k = 0; k < L; k++) {
+      const cur = buf[k];
+      buf[k] = params.damping * ((cur + prev) / 2);
+      prev = cur;
+    }
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (time - lastPluck > params.pluckInterval) {
+    lastPluck = time;
+    const i = Math.floor(Math.random() * strings.length);
+    pluck(i);
+  }
+
+  for (let iter = 0; iter < 4; iter++) step();
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const n = strings.length;
+  const totalH = (n - 1) * params.stringGap;
+  const startY = cy - totalH / 2;
+  for (let i = 0; i < n; i++) {
+    const y0 = startY + i * params.stringGap;
+    const hue = params.hueStart + (i / Math.max(1, n - 1)) * params.hueRange;
+    const buf = strings[i];
+    const L = buf.length;
+    const w = Math.min(canvas.width - 80, L);
+    const x0 = cx - w / 2;
+    ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.strokeAlpha})`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    for (let k = 0; k < L; k += 2) {
+      const sx = x0 + (k / L) * w;
+      const sy = y0 + buf[k] * params.amplitude;
+      if (k === 0) ctx.moveTo(sx, sy);
+      else ctx.lineTo(sx, sy);
+    }
+    ctx.stroke();
+    // 両端のピン
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(x0, y0, 4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(x0 + w, y0, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Karplus-Strong Strings',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'strings', 1, 10, 1);
+gui.add(params, 'length', 100, 1000, 10);
+gui.add(params, 'damping', 0.9, 0.999, 0.001);
+gui.add(params, 'pluckInterval', 0.1, 3, 0.05);
+gui.add(params, 'pluckStrength', 0.2, 1.5, 0.05);
+gui.add(params, 'stringGap', 20, 120, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'amplitude', 5, 80, 1);
+gui.add(params, 'strokeAlpha', 0.2, 1, 0.01);
+gui.add(params, 'lineWidth', 0.5, 4, 0.1);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Pluck', () => {
+  for (let i = 0; i < strings.length; i++) pluck(i);
+});
+gui.addButton('Random', () => {
+  params.strings = rand(3, 8, 1);
+  params.damping = rand(0.985, 0.998, 0.001);
+  params.pluckInterval = rand(0.3, 1.2, 0.05);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/karplus-strong-strings/style.css
+++ b/public/karplus-strong-strings/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/leaf-venation/index.html
+++ b/public/leaf-venation/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Leaf Venation | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/leaf-venation/main.js
+++ b/public/leaf-venation/main.js
@@ -1,0 +1,221 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Space Colonization 法で葉脈を成長させる。葉の輪郭内に魅力点を散布し、枝が最近傍で伸びる。
+const params = {
+  attractors: 600,
+  killDistance: 8,
+  influenceRadius: 60,
+  stepLength: 4,
+  maxSteps: 1500,
+  leafWidth: 480,
+  leafHeight: 700,
+  hueStart: 90,
+  hueEnd: 40,
+  fadeAlpha: 0,
+  lineWidth: 1.2,
+  autoRegrow: true,
+  regrowInterval: 8,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Node
+ * @property {number} x
+ * @property {number} y
+ * @property {Node|null} parent
+ * @property {number} depth
+ */
+
+/** @type {{x:number,y:number}[]} */
+let attractors = [];
+/** @type {Node[]} */
+let nodes = [];
+let stepCount = 0;
+let time = 0;
+let lastRegrow = 0;
+
+function isInLeaf(x, y, cx, cy) {
+  // 葉の形: 両端がすぼむ楕円 (0.5 * (1 - cos(t)) で y 方向の幅を変える)
+  const u = (y - (cy - params.leafHeight / 2)) / params.leafHeight; // 0..1
+  if (u < 0 || u > 1) return false;
+  const w = Math.sin(u * Math.PI) * params.leafWidth * 0.5;
+  const dx = x - cx;
+  return Math.abs(dx) <= w;
+}
+
+function reset() {
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  attractors = [];
+  for (let i = 0; i < params.attractors; i++) {
+    let x;
+    let y;
+    let tries = 0;
+    do {
+      x = cx + (Math.random() - 0.5) * params.leafWidth;
+      y = cy + (Math.random() - 0.5) * params.leafHeight;
+      tries++;
+    } while (!isInLeaf(x, y, cx, cy) && tries < 20);
+    attractors.push({ x, y });
+  }
+  nodes = [{ x: cx, y: cy + params.leafHeight / 2, parent: null, depth: 0 }];
+  stepCount = 0;
+  // 背景クリア
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // 葉の輪郭
+  const seg = 80;
+  ctx.strokeStyle = 'rgba(140, 180, 100, 0.18)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 0; i <= seg; i++) {
+    const u = i / seg;
+    const w = Math.sin(u * Math.PI) * params.leafWidth * 0.5;
+    const y = cy - params.leafHeight / 2 + u * params.leafHeight;
+    if (i === 0) ctx.moveTo(cx + w, y);
+    else ctx.lineTo(cx + w, y);
+  }
+  for (let i = seg; i >= 0; i--) {
+    const u = i / seg;
+    const w = Math.sin(u * Math.PI) * params.leafWidth * 0.5;
+    const y = cy - params.leafHeight / 2 + u * params.leafHeight;
+    ctx.lineTo(cx - w, y);
+  }
+  ctx.closePath();
+  ctx.stroke();
+}
+reset();
+
+function step() {
+  if (stepCount > params.maxSteps || attractors.length === 0) return;
+  /** @type {Map<number, {dx:number, dy:number, count:number}>} */
+  const influences = new Map();
+  for (const a of attractors) {
+    let nearest = -1;
+    let minD = Infinity;
+    for (let i = 0; i < nodes.length; i++) {
+      const d = Math.hypot(a.x - nodes[i].x, a.y - nodes[i].y);
+      if (d < params.influenceRadius && d < minD) {
+        minD = d;
+        nearest = i;
+      }
+    }
+    if (nearest >= 0) {
+      const inf = influences.get(nearest) ?? { dx: 0, dy: 0, count: 0 };
+      const dx = a.x - nodes[nearest].x;
+      const dy = a.y - nodes[nearest].y;
+      const len = Math.hypot(dx, dy) || 1;
+      inf.dx += dx / len;
+      inf.dy += dy / len;
+      inf.count++;
+      influences.set(nearest, inf);
+    }
+  }
+  /** @type {Node[]} */
+  const newNodes = [];
+  for (const [idx, inf] of influences) {
+    const base = nodes[idx];
+    const len = Math.hypot(inf.dx, inf.dy) || 1;
+    const nx = base.x + (inf.dx / len) * params.stepLength;
+    const ny = base.y + (inf.dy / len) * params.stepLength;
+    /** @type {Node} */
+    const nn = { x: nx, y: ny, parent: base, depth: base.depth + 1 };
+    newNodes.push(nn);
+    // 描画（新しい枝）
+    const k = Math.min(1, nn.depth / 80);
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * k;
+    ctx.strokeStyle = `hsla(${hue}, 70%, 55%, 0.85)`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(base.x, base.y);
+    ctx.lineTo(nx, ny);
+    ctx.stroke();
+  }
+  nodes.push(...newNodes);
+  // 到達済みアトラクタを削除
+  attractors = attractors.filter((a) => {
+    for (const n of nodes) {
+      if (Math.hypot(a.x - n.x, a.y - n.y) < params.killDistance) return false;
+    }
+    return true;
+  });
+  stepCount++;
+}
+
+function draw() {
+  time += 1 / 60;
+  for (let i = 0; i < 2; i++) step();
+
+  if (params.autoRegrow && time - lastRegrow > params.regrowInterval) {
+    lastRegrow = time;
+    reset();
+  }
+
+  // 枝先の光
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  if (params.fadeAlpha > 0) ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Leaf Venation',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'attractors', 100, 1500, 10);
+gui.add(params, 'killDistance', 3, 20, 0.5);
+gui.add(params, 'influenceRadius', 20, 150, 1);
+gui.add(params, 'stepLength', 1, 10, 0.5);
+gui.add(params, 'maxSteps', 100, 3000, 50);
+gui.add(params, 'leafWidth', 200, 800, 5);
+gui.add(params, 'leafHeight', 300, 900, 5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'lineWidth', 0.5, 3, 0.1);
+gui.add(params, 'fadeAlpha', 0, 0.1, 0.005);
+gui.add(params, 'autoRegrow');
+gui.add(params, 'regrowInterval', 3, 30, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.attractors = rand(300, 1000, 10);
+  params.hueStart = rand(60, 160, 1);
+  params.hueEnd = rand(20, 80, 1);
+  params.leafWidth = rand(300, 600, 5);
+  params.leafHeight = rand(500, 800, 5);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/leaf-venation/style.css
+++ b/public/leaf-venation/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/lissajous-3d/index.html
+++ b/public/lissajous-3d/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Lissajous 3D | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/lissajous-3d/main.js
+++ b/public/lissajous-3d/main.js
@@ -1,0 +1,168 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 3D リサジュー曲線：3軸の正弦波を組み合わせた空間曲線。
+// 透視投影で3D回転させながら軌跡を残す。
+
+const params = {
+  freqX: 3, // X軸周波数
+  freqY: 4, // Y軸周波数
+  freqZ: 5, // Z軸周波数
+  phaseX: 0, // X位相
+  phaseY: 0.5, // Y位相
+  phaseZ: 1.0, // Z位相
+  rotSpeedX: 0.3, // X軸回転速度
+  rotSpeedY: 0.5, // Y軸回転速度
+  trailLength: 800, // 軌跡の長さ
+  hueStart: 180, // 軌跡の開始色相
+  hueEnd: 300, // 軌跡の終了色相
+  lineWidth: 1.5, // 線幅
+  fadeAlpha: 0.04, // フェード強度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+let rotX = 0;
+let rotY = 0;
+
+/** @type {{x: number, y: number, z: number}[]} */
+let trail = [];
+
+/**
+ * 3D点を2D投影する（透視投影）
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @returns {{sx: number, sy: number}}
+ */
+function project(x, y, z) {
+  // X軸回転
+  const y1 = y * Math.cos(rotX) - z * Math.sin(rotX);
+  const z1 = y * Math.sin(rotX) + z * Math.cos(rotX);
+  // Y軸回転
+  const x2 = x * Math.cos(rotY) + z1 * Math.sin(rotY);
+  const z2 = -x * Math.sin(rotY) + z1 * Math.cos(rotY);
+
+  const fov = 400;
+  const depth = z2 + 500;
+  const scale = fov / depth;
+  const sx = canvas.width / 2 + x2 * scale;
+  const sy = canvas.height / 2 + y1 * scale;
+  return { sx, sy };
+}
+
+function draw() {
+  time += 0.016;
+  rotX += params.rotSpeedX * 0.005;
+  rotY += params.rotSpeedY * 0.007;
+
+  const w = canvas.width;
+  const h = canvas.height;
+  const scale = Math.min(w, h) * 0.35;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 現在の3D点を計算
+  const x = Math.sin(params.freqX * time + params.phaseX) * scale;
+  const y = Math.sin(params.freqY * time + params.phaseY) * scale;
+  const z = Math.sin(params.freqZ * time + params.phaseZ) * scale;
+
+  trail.push({ x, y, z });
+  if (trail.length > params.trailLength) {
+    trail.splice(0, trail.length - params.trailLength);
+  }
+
+  // 軌跡を描画
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+  for (let i = 1; i < trail.length; i++) {
+    const t = i / trail.length;
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+    ctx.strokeStyle = `hsla(${hue}, 85%, 65%, ${t * 0.9})`;
+
+    const p1 = project(trail[i - 1].x, trail[i - 1].y, trail[i - 1].z);
+    const p2 = project(trail[i].x, trail[i].y, trail[i].z);
+    ctx.beginPath();
+    ctx.moveTo(p1.sx, p1.sy);
+    ctx.lineTo(p2.sx, p2.sy);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Lissajous 3D',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'freqX', 1, 10, 1);
+gui.add(params, 'freqY', 1, 10, 1);
+gui.add(params, 'freqZ', 1, 10, 1);
+gui.add(params, 'phaseX', 0, Math.PI * 2, 0.05);
+gui.add(params, 'phaseY', 0, Math.PI * 2, 0.05);
+gui.add(params, 'phaseZ', 0, Math.PI * 2, 0.05);
+gui.add(params, 'rotSpeedX', 0, 2, 0.05);
+gui.add(params, 'rotSpeedY', 0, 2, 0.05);
+gui.add(params, 'trailLength', 100, 2000, 50);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'fadeAlpha', 0.01, 0.3, 0.005);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.freqX = rand(1, 8, 1);
+  params.freqY = rand(1, 8, 1);
+  params.freqZ = rand(1, 8, 1);
+  params.phaseX = rand(0, Math.PI * 2, 0.05);
+  params.phaseY = rand(0, Math.PI * 2, 0.05);
+  params.phaseZ = rand(0, Math.PI * 2, 0.05);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  trail = [];
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  trail = [];
+  gui.updateDisplay();
+});

--- a/public/lissajous-3d/style.css
+++ b/public/lissajous-3d/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/magnetic-dust/index.html
+++ b/public/magnetic-dust/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Magnetic Dust | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/magnetic-dust/main.js
+++ b/public/magnetic-dust/main.js
@@ -1,0 +1,214 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 磁性粉のパターン：磁石の周りに鉄粉が磁力線に沿って集まるパターン。
+// 磁場の磁力線に沿って動くパーティクルで表現する。
+
+const params = {
+  particleCount: 2000, // 鉄粉の数
+  magnetCount: 3, // 磁石の数
+  fieldStrength: 1.5, // 磁場の強さ
+  damping: 0.92, // 速度減衰
+  maxSpeed: 3.0, // 最高速度
+  hueBase: 30, // 基本色相（茶・金属色）
+  hueRange: 60, // 色相レンジ
+  brightness: 55, // 明度
+  fadeAlpha: 0.15, // フェード強度
+  dustSize: 2.0, // 鉄粉サイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  initMagnets();
+  initDust();
+}
+window.addEventListener('resize', resize);
+
+/** @typedef {{ x: number, y: number, polarity: number }} Magnet */
+/** @typedef {{ x: number, y: number, vx: number, vy: number }} Dust */
+
+/** @type {Magnet[]} */
+let magnets = [];
+/** @type {Dust[]} */
+let dust = [];
+
+/**
+ * 磁石を初期化する
+ */
+function initMagnets() {
+  magnets = [];
+  const n = Math.max(1, Math.round(params.magnetCount));
+  for (let i = 0; i < n; i++) {
+    magnets.push({
+      x: canvas.width * 0.15 + (canvas.width * 0.7 * i) / (n - 1 || 1),
+      y: canvas.height / 2,
+      polarity: i % 2 === 0 ? 1 : -1,
+    });
+  }
+}
+
+/**
+ * 鉄粉を初期化する
+ */
+function initDust() {
+  dust = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.particleCount; i++) {
+    dust.push({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      vx: 0,
+      vy: 0,
+    });
+  }
+}
+
+resize();
+
+/**
+ * 鉄粉を1ステップ更新する
+ * @param {Dust} p
+ */
+function updateDust(p) {
+  const w = canvas.width;
+  const h = canvas.height;
+  let fx = 0;
+  let fy = 0;
+
+  for (const mag of magnets) {
+    const dx = p.x - mag.x;
+    const dy = p.y - mag.y;
+    const dist = Math.max(5, Math.hypot(dx, dy));
+    const force = (params.fieldStrength * mag.polarity) / (dist * dist * 0.01);
+
+    // 磁力線に沿う方向（接線方向）
+    const angle = Math.atan2(dy, dx);
+    const tangentX = -Math.sin(angle) * mag.polarity;
+    const tangentY = Math.cos(angle) * mag.polarity;
+
+    fx += tangentX * force * 0.5 + (dx / dist) * force * 0.1;
+    fy += tangentY * force * 0.5 + (dy / dist) * force * 0.1;
+  }
+
+  p.vx = (p.vx + fx * 0.01) * params.damping;
+  p.vy = (p.vy + fy * 0.01) * params.damping;
+
+  const speed = Math.hypot(p.vx, p.vy);
+  if (speed > params.maxSpeed) {
+    p.vx = (p.vx / speed) * params.maxSpeed;
+    p.vy = (p.vy / speed) * params.maxSpeed;
+  }
+
+  p.x += p.vx;
+  p.y += p.vy;
+
+  // 画面折り返し
+  if (p.x < 0) p.x += w;
+  if (p.x > w) p.x -= w;
+  if (p.y < 0) p.y += h;
+  if (p.y > h) p.y -= h;
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  for (const p of dust) {
+    updateDust(p);
+    const speed = Math.hypot(p.vx, p.vy) / params.maxSpeed;
+    const hue = params.hueBase + speed * params.hueRange;
+    const lig = params.brightness + speed * 20;
+    ctx.fillStyle = `hsl(${hue}, 60%, ${lig}%)`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, params.dustSize * (0.5 + speed * 0.5), 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // 磁石を描画
+  for (const mag of magnets) {
+    ctx.beginPath();
+    ctx.arc(mag.x, mag.y, 12, 0, Math.PI * 2);
+    ctx.fillStyle =
+      mag.polarity > 0 ? 'hsl(0, 80%, 55%)' : 'hsl(220, 80%, 55%)';
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Magnetic Dust',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'particleCount', 200, 5000, 200).onChange(initDust);
+gui.add(params, 'magnetCount', 1, 8, 1).onChange(() => {
+  initMagnets();
+  initDust();
+});
+gui.add(params, 'fieldStrength', 0.1, 5, 0.1);
+gui.add(params, 'damping', 0.8, 0.99, 0.01);
+gui.add(params, 'maxSpeed', 0.5, 8, 0.1);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 180, 1);
+gui.add(params, 'brightness', 10, 90, 1);
+gui.add(params, 'dustSize', 0.5, 6, 0.1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.magnetCount = rand(1, 6, 1);
+  params.fieldStrength = rand(0.3, 4, 0.1);
+  params.damping = rand(0.85, 0.98, 0.01);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(20, 150, 1);
+  params.brightness = rand(25, 75, 1);
+  initMagnets();
+  initDust();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initMagnets();
+  initDust();
+  gui.updateDisplay();
+});

--- a/public/magnetic-dust/style.css
+++ b/public/magnetic-dust/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/mandala-generator/index.html
+++ b/public/mandala-generator/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Mandala Generator | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/mandala-generator/main.js
+++ b/public/mandala-generator/main.js
@@ -1,0 +1,187 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// マンダラ生成器：回転対称要素を同心円状に配置し、
+// 瞑想的なマンダラパターンをリアルタイム生成する。
+
+const params = {
+  symmetry: 8, // 回転対称次数
+  rings: 5, // リング数
+  petalCount: 6, // 花弁数/リング
+  hueStart: 280, // 内側色相（紫）
+  hueEnd: 60, // 外側色相（黄）
+  saturation: 70, // 彩度
+  brightness: 55, // 明度
+  animSpeed: 0.3, // アニメーション速度
+  ringSpacing: 0.85, // リング間隔比率
+  petalSize: 0.12, // 花弁サイズ比率
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 花弁形（楕円を回転）を描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} rx 横半径
+ * @param {number} ry 縦半径
+ * @param {number} angle 回転角
+ * @param {string} color 色
+ */
+function drawPetal(cx, cy, rx, ry, angle, color) {
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(angle);
+  ctx.beginPath();
+  ctx.ellipse(0, 0, rx, ry, 0, 0, Math.PI * 2);
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.restore();
+}
+
+/**
+ * マンダラの1リングを描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} radius リング半径
+ * @param {number} ringIdx リングインデックス
+ * @param {number} totalRings 全リング数
+ */
+function drawRing(cx, cy, radius, ringIdx, totalRings) {
+  const t = ringIdx / Math.max(1, totalRings - 1);
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  const sat = params.saturation;
+  const lig = params.brightness;
+  const sym = Math.max(3, Math.round(params.symmetry));
+  const pc = Math.max(1, Math.round(params.petalCount));
+  const ps = params.petalSize;
+  const rotPhase = time * (ringIdx % 2 === 0 ? 1 : -1) * 0.5;
+
+  for (let k = 0; k < sym; k++) {
+    const baseAngle = (k * Math.PI * 2) / sym + rotPhase;
+    for (let p = 0; p < pc; p++) {
+      const petalAngle = baseAngle + (p * Math.PI * 2) / (sym * pc);
+      const px = cx + Math.cos(petalAngle) * radius;
+      const py = cy + Math.sin(petalAngle) * radius;
+      const rx = radius * ps;
+      const ry = radius * ps * 0.45;
+      const alpha = 0.6 + 0.4 * (1 - t);
+      drawPetal(
+        px,
+        py,
+        rx,
+        ry,
+        petalAngle,
+        `hsla(${hue}, ${sat}%, ${lig}%, ${alpha})`,
+      );
+    }
+  }
+
+  // リングの輪郭円
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.strokeStyle = `hsla(${hue}, ${sat}%, ${lig + 15}%, 0.25)`;
+  ctx.lineWidth = 0.5;
+  ctx.stroke();
+}
+
+function draw() {
+  time += params.animSpeed * 0.01;
+  const w = canvas.width;
+  const h = canvas.height;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.18)';
+  ctx.fillRect(0, 0, w, h);
+
+  const maxR = Math.min(w, h) * 0.46;
+  const n = Math.max(1, Math.round(params.rings));
+
+  for (let i = n; i >= 1; i--) {
+    const r = maxR * params.ringSpacing ** (n - i);
+    drawRing(cx, cy, r, i - 1, n);
+  }
+
+  // 中心点
+  ctx.beginPath();
+  ctx.arc(cx, cy, maxR * 0.04, 0, Math.PI * 2);
+  ctx.fillStyle = `hsl(${params.hueStart}, ${params.saturation}%, ${params.brightness + 20}%)`;
+  ctx.fill();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Mandala Generator',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'symmetry', 3, 16, 1);
+gui.add(params, 'rings', 1, 10, 1);
+gui.add(params, 'petalCount', 1, 8, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'brightness', 10, 90, 1);
+gui.add(params, 'animSpeed', 0, 3, 0.05);
+gui.add(params, 'ringSpacing', 0.5, 0.99, 0.01);
+gui.add(params, 'petalSize', 0.04, 0.3, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.symmetry = rand(4, 14, 1);
+  params.rings = rand(3, 8, 1);
+  params.petalCount = rand(2, 6, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.saturation = rand(50, 90, 1);
+  params.brightness = rand(35, 70, 1);
+  params.animSpeed = rand(0.1, 2, 0.05);
+  params.ringSpacing = rand(0.7, 0.96, 0.01);
+  params.petalSize = rand(0.06, 0.22, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/mandala-generator/style.css
+++ b/public/mandala-generator/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/mandelbrot-zoom/index.html
+++ b/public/mandelbrot-zoom/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Mandelbrot Zoom | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/mandelbrot-zoom/main.js
+++ b/public/mandelbrot-zoom/main.js
@@ -1,0 +1,210 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// マンデルブロ集合ズーム：自動的に深い場所にズームインしていく。
+// カラーマッピングと反復回数で美しいフラクタルを描画する。
+
+const params = {
+  centerX: -0.7435669, // ズーム中心X
+  centerY: 0.1314023, // ズーム中心Y
+  maxIter: 200, // 最大反復回数
+  zoomSpeed: 0.005, // ズーム速度
+  hueOffset: 240, // 色相オフセット
+  hueScale: 3.0, // 色相スケール
+  brightness: 60, // 明度
+  saturation: 80, // 彩度
+  smoothColor: 1, // スムーズカラー（0/1）
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+const SCALE = 0.35; // 描画解像度
+const offscreen = document.createElement('canvas');
+const offCtx = /** @type {CanvasRenderingContext2D} */ (
+  offscreen.getContext('2d')
+);
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  offscreen.width = Math.round(canvas.width * SCALE);
+  offscreen.height = Math.round(canvas.height * SCALE);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let zoom = 1;
+const animating = true;
+
+/**
+ * マンデルブロ集合の反復回数を計算する
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} maxIter
+ * @returns {number}
+ */
+function mandelbrot(cx, cy, maxIter) {
+  let zx = 0;
+  let zy = 0;
+  let iter = 0;
+  while (iter < maxIter && zx * zx + zy * zy <= 4) {
+    const tmp = zx * zx - zy * zy + cx;
+    zy = 2 * zx * zy + cy;
+    zx = tmp;
+    iter++;
+  }
+  if (params.smoothColor && iter < maxIter) {
+    const logZn = Math.log(zx * zx + zy * zy) / 2;
+    const nu = Math.log(logZn / Math.log(2)) / Math.log(2);
+    return iter + 1 - nu;
+  }
+  return iter;
+}
+
+/**
+ * 反復回数を色に変換する
+ * @param {number} iter
+ * @param {number} maxIter
+ * @returns {{r: number, g: number, b: number}}
+ */
+function iterToColor(iter, maxIter) {
+  if (iter >= maxIter) return { r: 0, g: 0, b: 0 };
+  const t = iter / maxIter;
+  const hue = (params.hueOffset + t * 360 * params.hueScale) % 360;
+  const sat = params.saturation / 100;
+  const lig = (params.brightness / 100) * t ** 0.3;
+
+  const h0 = hue / 60;
+  const c0 = (1 - Math.abs(2 * lig - 1)) * sat;
+  const x0 = c0 * (1 - Math.abs((h0 % 2) - 1));
+  const m0 = lig - c0 / 2;
+  let r0 = 0,
+    g0 = 0,
+    b0 = 0;
+  if (h0 < 1) {
+    r0 = c0;
+    g0 = x0;
+  } else if (h0 < 2) {
+    r0 = x0;
+    g0 = c0;
+  } else if (h0 < 3) {
+    g0 = c0;
+    b0 = x0;
+  } else if (h0 < 4) {
+    g0 = x0;
+    b0 = c0;
+  } else if (h0 < 5) {
+    r0 = x0;
+    b0 = c0;
+  } else {
+    r0 = c0;
+    b0 = x0;
+  }
+
+  return {
+    r: Math.round((r0 + m0) * 255),
+    g: Math.round((g0 + m0) * 255),
+    b: Math.round((b0 + m0) * 255),
+  };
+}
+
+function draw() {
+  if (animating) zoom *= 1 + params.zoomSpeed;
+
+  const ow = offscreen.width;
+  const oh = offscreen.height;
+  const imgData = offCtx.createImageData(ow, oh);
+  const data = imgData.data;
+
+  const scale = 4 / (ow * zoom);
+  const cx = params.centerX;
+  const cy = params.centerY;
+  const maxIter = Math.round(params.maxIter);
+
+  for (let py = 0; py < oh; py++) {
+    for (let px = 0; px < ow; px++) {
+      const x = (px - ow / 2) * scale + cx;
+      const y = (py - oh / 2) * scale + cy;
+      const iter = mandelbrot(x, y, maxIter);
+      const { r, g, b } = iterToColor(iter, maxIter);
+      const idx = (py * ow + px) * 4;
+      data[idx] = r;
+      data[idx + 1] = g;
+      data[idx + 2] = b;
+      data[idx + 3] = 255;
+    }
+  }
+  offCtx.putImageData(imgData, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(offscreen, 0, 0, canvas.width, canvas.height);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Mandelbrot Zoom',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'centerX', -2, 1, 0.0000001);
+gui.add(params, 'centerY', -1.5, 1.5, 0.0000001);
+gui.add(params, 'maxIter', 50, 1000, 10);
+gui.add(params, 'zoomSpeed', 0, 0.05, 0.001);
+gui.add(params, 'hueOffset', 0, 360, 1);
+gui.add(params, 'hueScale', 0.5, 10, 0.1);
+gui.add(params, 'brightness', 20, 90, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+// 有名な場所のプリセット
+const presets = [
+  { x: -0.7435669, y: 0.1314023 },
+  { x: -0.7453, y: 0.1127 },
+  { x: 0.3602404, y: -0.641313 },
+  { x: -1.0149416, y: 0.3521033 },
+];
+
+gui.addButton('Random', () => {
+  const p = presets[Math.floor(Math.random() * presets.length)];
+  params.centerX = p.x;
+  params.centerY = p.y;
+  params.hueOffset = rand(0, 360, 1);
+  params.hueScale = rand(1, 8, 0.1);
+  zoom = 1;
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  zoom = 1;
+  gui.updateDisplay();
+});

--- a/public/mandelbrot-zoom/style.css
+++ b/public/mandelbrot-zoom/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/menger-slice/index.html
+++ b/public/menger-slice/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Menger Slice | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/menger-slice/main.js
+++ b/public/menger-slice/main.js
@@ -1,0 +1,145 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 4,
+  size: 520,
+  zSlice: 0.5, // 断面の位置（0-1）
+  zAnimate: true,
+  sliceSpeed: 0.08,
+  hueStart: 20,
+  hueEnd: 280,
+  alpha: 0.95,
+  rotation: 0,
+  rotSpeed: 0.04,
+  strokeAlpha: 0.5,
+  showGrid: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 指定位置 (u,v,w) が Menger スポンジ内部かどうか
+ * @param {number} u 0-1
+ * @param {number} v 0-1
+ * @param {number} w 0-1
+ * @param {number} depth
+ */
+function isSolid(u, v, w, depth) {
+  for (let i = 0; i < depth; i++) {
+    const x = Math.floor(u * 3) % 3;
+    const y = Math.floor(v * 3) % 3;
+    const z = Math.floor(w * 3) % 3;
+    // 中央面 2 個以上で 1 になると穴
+    let mids = 0;
+    if (x === 1) mids++;
+    if (y === 1) mids++;
+    if (z === 1) mids++;
+    if (mids >= 2) return false;
+    u = (u * 3) % 1;
+    v = (v * 3) % 1;
+    w = (w * 3) % 1;
+  }
+  return true;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.25)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const depth = Math.round(params.depth);
+  const n = 3 ** depth;
+  const cell = params.size / n;
+  const wSlice = params.zAnimate
+    ? (Math.sin(time * params.sliceSpeed) + 1) * 0.5
+    : params.zSlice;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(params.rotation + time * params.rotSpeed);
+  ctx.translate(-params.size / 2, -params.size / 2);
+
+  for (let iy = 0; iy < n; iy++) {
+    for (let ix = 0; ix < n; ix++) {
+      const u = (ix + 0.5) / n;
+      const v = (iy + 0.5) / n;
+      if (isSolid(u, v, wSlice, depth)) {
+        const dist = Math.hypot(u - 0.5, v - 0.5, wSlice - 0.5);
+        const hue =
+          params.hueStart + (params.hueEnd - params.hueStart) * (1 - dist * 2);
+        ctx.fillStyle = `hsla(${hue}, 75%, 55%, ${params.alpha})`;
+        ctx.fillRect(ix * cell, iy * cell, cell + 0.5, cell + 0.5);
+        if (params.showGrid && cell > 3) {
+          ctx.strokeStyle = `hsla(${hue}, 85%, 75%, ${params.strokeAlpha})`;
+          ctx.lineWidth = 0.5;
+          ctx.strokeRect(ix * cell, iy * cell, cell, cell);
+        }
+      }
+    }
+  }
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Menger Slice',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 1, 5, 1);
+gui.add(params, 'size', 200, 700, 1);
+gui.add(params, 'zSlice', 0, 1, 0.001);
+gui.add(params, 'zAnimate');
+gui.add(params, 'sliceSpeed', 0, 0.5, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+gui.add(params, 'showGrid');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.depth = rand(3, 5, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.sliceSpeed = rand(0.03, 0.2, 0.01);
+  params.rotSpeed = rand(-0.15, 0.15, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/menger-slice/style.css
+++ b/public/menger-slice/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/moth-to-flame/index.html
+++ b/public/moth-to-flame/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Moth to Flame | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/moth-to-flame/main.js
+++ b/public/moth-to-flame/main.js
@@ -1,0 +1,262 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 蛾と炎：炎の光に引き寄せられる蛾と揺らめく炎のビジュアル。
+// 蛾たちが螺旋を描きながら炎に近づく様子を描く。
+
+const params = {
+  mothCount: 40, // 蛾の数
+  attractForce: 0.04, // 炎への引力
+  orbitForce: 0.06, // 旋回力
+  maxSpeed: 2.5, // 最高速度
+  flameHeight: 0.35, // 炎の高さ比率
+  flameWidth: 0.06, // 炎の幅比率
+  mothHue: 40, // 蛾の色相
+  fadeAlpha: 0.15, // フェード強度
+  mothSize: 5, // 蛾のサイズ
+  turbulence: 0.5, // 乱気流
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, angle: number, dist: number }} Moth */
+/** @type {Moth[]} */
+let moths = [];
+
+/**
+ * 蛾を初期化する
+ */
+function initMoths() {
+  moths = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.mothCount; i++) {
+    const a = Math.random() * Math.PI * 2;
+    const r = 100 + Math.random() * Math.min(w, h) * 0.4;
+    moths.push({
+      x: w / 2 + Math.cos(a) * r,
+      y: h * 0.6 + Math.sin(a) * r * 0.5,
+      vx: (Math.random() - 0.5) * 2,
+      vy: (Math.random() - 0.5) * 2,
+      angle: a,
+      dist: r,
+    });
+  }
+}
+initMoths();
+
+let time = 0;
+
+/**
+ * 炎パーティクルを生成・描画する
+ * @param {number} fx 炎の中心X
+ * @param {number} fy 炎の中心Y
+ * @param {number} t 時間
+ */
+function drawFlame(fx, fy, t) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const fh = h * params.flameHeight;
+  const fw = w * params.flameWidth;
+
+  // 炎本体（複数層のグラデーション楕円）
+  const layers = [
+    { r: fw * 0.4, color: 'rgba(255, 255, 200, 0.9)' },
+    { r: fw * 0.7, color: 'rgba(255, 160, 20, 0.7)' },
+    { r: fw * 1.0, color: 'rgba(255, 60, 0, 0.5)' },
+    { r: fw * 1.5, color: 'rgba(200, 20, 0, 0.2)' },
+  ];
+
+  for (const layer of layers) {
+    const flicker = 1 + Math.sin(t * 8 + layer.r) * 0.1;
+    const grd = ctx.createRadialGradient(
+      fx,
+      fy,
+      0,
+      fx,
+      fy - fh * 0.6,
+      fh * flicker,
+    );
+    grd.addColorStop(0, layer.color);
+    grd.addColorStop(1, 'rgba(0,0,0,0)');
+    ctx.fillStyle = grd;
+    ctx.beginPath();
+    ctx.ellipse(fx, fy, layer.r * flicker, fh * flicker, 0, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // 煙
+  for (let i = 0; i < 3; i++) {
+    const sx = fx + (Math.random() - 0.5) * fw * 2;
+    const sy = fy - fh * (0.8 + Math.random() * 0.5);
+    ctx.beginPath();
+    ctx.arc(sx, sy, fw * 0.3 * Math.random(), 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(50, 40, 30, 0.08)';
+    ctx.fill();
+  }
+}
+
+/**
+ * 蛾を1ステップ更新する
+ * @param {Moth} moth
+ */
+function updateMoth(moth) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const fx = w / 2;
+  const fy = h * 0.62;
+
+  const dx = fx - moth.x;
+  const dy = fy - moth.y;
+  const dist = Math.max(10, Math.hypot(dx, dy));
+
+  // 炎への引力
+  moth.vx += (dx / dist) * params.attractForce * (dist / 100);
+  moth.vy += (dy / dist) * params.attractForce * (dist / 100);
+
+  // 旋回力（接線方向）
+  const nx = -dy / dist;
+  const ny = dx / dist;
+  moth.vx += nx * params.orbitForce;
+  moth.vy += ny * params.orbitForce;
+
+  // 乱気流
+  moth.vx += (Math.random() - 0.5) * params.turbulence * 0.1;
+  moth.vy += (Math.random() - 0.5) * params.turbulence * 0.1;
+
+  const speed = Math.hypot(moth.vx, moth.vy);
+  if (speed > params.maxSpeed) {
+    moth.vx = (moth.vx / speed) * params.maxSpeed;
+    moth.vy = (moth.vy / speed) * params.maxSpeed;
+  }
+
+  moth.x += moth.vx;
+  moth.y += moth.vy;
+  moth.angle = Math.atan2(moth.vy, moth.vx);
+  moth.dist = dist;
+
+  // 炎に近すぎたらリセット
+  if (dist < 15) {
+    const a = Math.random() * Math.PI * 2;
+    const r = 150 + Math.random() * Math.min(w, h) * 0.3;
+    moth.x = w / 2 + Math.cos(a) * r;
+    moth.y = h * 0.6 + Math.sin(a) * r * 0.5;
+    moth.vx = 0;
+    moth.vy = 0;
+  }
+
+  if (moth.x < 0 || moth.x > w) moth.vx *= -0.5;
+  if (moth.y < 0 || moth.y > h) moth.vy *= -0.5;
+}
+
+function draw() {
+  time += 0.016;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(8, 5, 3, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 炎を描く
+  drawFlame(w / 2, h * 0.62, time);
+
+  // 蛾を更新・描画
+  for (const moth of moths) {
+    updateMoth(moth);
+    const s = params.mothSize;
+    const proximity = Math.max(0, 1 - moth.dist / 200);
+    const hue = params.mothHue + proximity * 20;
+    const lig = 45 + proximity * 25;
+
+    ctx.save();
+    ctx.translate(moth.x, moth.y);
+    ctx.rotate(moth.angle);
+
+    // 翅
+    ctx.fillStyle = `hsla(${hue}, 50%, ${lig}%, 0.7)`;
+    ctx.beginPath();
+    ctx.ellipse(-s * 0.3, -s * 0.4, s * 1.2, s * 0.5, 0.4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.ellipse(-s * 0.3, s * 0.4, s * 1.2, s * 0.5, -0.4, 0, Math.PI * 2);
+    ctx.fill();
+
+    // 胴体
+    ctx.fillStyle = `hsl(${hue - 10}, 40%, 30%)`;
+    ctx.beginPath();
+    ctx.ellipse(0, 0, s * 0.4, s * 0.2, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Moth to Flame',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'mothCount', 5, 150, 5).onChange(initMoths);
+gui.add(params, 'attractForce', 0.005, 0.2, 0.005);
+gui.add(params, 'orbitForce', 0, 0.3, 0.005);
+gui.add(params, 'maxSpeed', 0.5, 6, 0.1);
+gui.add(params, 'flameHeight', 0.1, 0.6, 0.01);
+gui.add(params, 'flameWidth', 0.02, 0.15, 0.005);
+gui.add(params, 'mothHue', 0, 360, 1);
+gui.add(params, 'mothSize', 2, 15, 0.5);
+gui.add(params, 'turbulence', 0, 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.mothCount = rand(10, 100, 5);
+  params.attractForce = rand(0.01, 0.15, 0.005);
+  params.orbitForce = rand(0.01, 0.2, 0.005);
+  params.maxSpeed = rand(1, 5, 0.1);
+  params.mothHue = rand(0, 360, 1);
+  params.turbulence = rand(0.1, 1.5, 0.05);
+  initMoths();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initMoths();
+  gui.updateDisplay();
+});

--- a/public/moth-to-flame/style.css
+++ b/public/moth-to-flame/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/mycelium-network/index.html
+++ b/public/mycelium-network/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Mycelium Network | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/mycelium-network/main.js
+++ b/public/mycelium-network/main.js
@@ -1,0 +1,207 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 菌糸ネットワーク：先端がランダムに曲がりながら伸び、一定確率で分岐、既存の糸に近づくと結合する。
+const params = {
+  seeds: 6,
+  maxTips: 220,
+  stepLength: 2.4,
+  wanderAmt: 0.18,
+  branchProb: 0.012,
+  terminateProb: 0.002,
+  connectRadius: 8,
+  hueStart: 40,
+  hueEnd: 320,
+  lineWidth: 1.1,
+  fade: 0.015,
+  glowAlpha: 0.35,
+  autoRegrow: true,
+  regrowInterval: 14,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Tip
+ * @property {number} x
+ * @property {number} y
+ * @property {number} angle
+ * @property {number} depth
+ * @property {number} age
+ */
+
+/** @type {Tip[]} */
+let tips = [];
+/** @type {{x:number, y:number}[]} */
+let trace = [];
+let time = 0;
+let lastRegrow = 0;
+
+function reset() {
+  tips = [];
+  trace = [];
+  for (let i = 0; i < Math.round(params.seeds); i++) {
+    tips.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      angle: Math.random() * Math.PI * 2,
+      depth: 0,
+      age: 0,
+    });
+  }
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+reset();
+
+function nearestDistance(x, y, ignoreIdx) {
+  let minD = Infinity;
+  for (let i = 0; i < trace.length; i++) {
+    if (i === ignoreIdx) continue;
+    const p = trace[i];
+    const d = Math.hypot(x - p.x, y - p.y);
+    if (d < minD) minD = d;
+  }
+  return minD;
+}
+
+function step() {
+  /** @type {Tip[]} */
+  const newTips = [];
+  for (const tip of tips) {
+    tip.angle += (Math.random() - 0.5) * params.wanderAmt;
+    const nx = tip.x + Math.cos(tip.angle) * params.stepLength;
+    const ny = tip.y + Math.sin(tip.angle) * params.stepLength;
+    // 画面外なら折り返し
+    if (nx < 0 || nx > canvas.width || ny < 0 || ny > canvas.height) {
+      tip.angle += Math.PI;
+      continue;
+    }
+    const k = Math.min(1, tip.depth / 300);
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * k;
+    ctx.strokeStyle = `hsla(${hue}, 70%, 60%, 0.85)`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(tip.x, tip.y);
+    ctx.lineTo(nx, ny);
+    ctx.stroke();
+    // グロー
+    ctx.fillStyle = `hsla(${hue}, 90%, 80%, ${params.glowAlpha})`;
+    ctx.beginPath();
+    ctx.arc(nx, ny, 2.4, 0, Math.PI * 2);
+    ctx.fill();
+
+    tip.x = nx;
+    tip.y = ny;
+    tip.depth++;
+    tip.age++;
+    trace.push({ x: nx, y: ny });
+    if (trace.length > 3000) trace.shift();
+
+    // 近傍結合（終端）
+    if (tip.depth > 8) {
+      const minD = nearestDistance(nx, ny, trace.length - 1);
+      if (minD < params.connectRadius) {
+        continue; // tip 削除
+      }
+    }
+    // 分岐
+    if (
+      tips.length + newTips.length < params.maxTips &&
+      Math.random() < params.branchProb
+    ) {
+      newTips.push({
+        x: nx,
+        y: ny,
+        angle: tip.angle + (Math.random() - 0.5) * 1.2,
+        depth: tip.depth,
+        age: 0,
+      });
+    }
+    // 終端
+    if (Math.random() < params.terminateProb) continue;
+    newTips.push(tip);
+  }
+  tips = newTips;
+}
+
+function draw() {
+  time += 1 / 60;
+  if (params.fade > 0) {
+    ctx.fillStyle = `rgba(11, 10, 7, ${params.fade})`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  step();
+  if (params.autoRegrow) {
+    if (
+      (tips.length === 0 || time - lastRegrow > params.regrowInterval) &&
+      time > 1
+    ) {
+      lastRegrow = time;
+      reset();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Mycelium Network',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'seeds', 1, 20, 1);
+gui.add(params, 'maxTips', 30, 500, 5);
+gui.add(params, 'stepLength', 0.5, 6, 0.1);
+gui.add(params, 'wanderAmt', 0, 0.6, 0.01);
+gui.add(params, 'branchProb', 0, 0.1, 0.001);
+gui.add(params, 'terminateProb', 0, 0.02, 0.0005);
+gui.add(params, 'connectRadius', 2, 25, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'lineWidth', 0.3, 2.5, 0.1);
+gui.add(params, 'fade', 0, 0.05, 0.001);
+gui.add(params, 'glowAlpha', 0, 1, 0.01);
+gui.add(params, 'autoRegrow');
+gui.add(params, 'regrowInterval', 5, 40, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.seeds = rand(3, 12, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.branchProb = rand(0.005, 0.03, 0.001);
+  params.wanderAmt = rand(0.08, 0.3, 0.01);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/mycelium-network/style.css
+++ b/public/mycelium-network/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/neural-network-viz/index.html
+++ b/public/neural-network-viz/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Neural Network Viz | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/neural-network-viz/main.js
+++ b/public/neural-network-viz/main.js
@@ -1,0 +1,199 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 全結合多層ニューラルネットの活性伝播を可視化する。重みと活性を変化させながら描画。
+const params = {
+  inputs: 5,
+  hidden: 8,
+  hidden2: 6,
+  outputs: 4,
+  waveSpeed: 1.3,
+  weightPulse: 0.6,
+  lineAlpha: 0.5,
+  nodeSize: 14,
+  hueStart: 180,
+  hueRange: 180,
+  pulseSpeed: 2,
+  trailFade: 0.1,
+  thickness: 1.2,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Float32Array[][]} */
+let weights = [];
+/** @type {number[][]} */
+let activations = [];
+
+function rebuild() {
+  const layers = [
+    Math.round(params.inputs),
+    Math.round(params.hidden),
+    Math.round(params.hidden2),
+    Math.round(params.outputs),
+  ];
+  weights = [];
+  activations = layers.map((n) => new Array(n).fill(0));
+  for (let i = 0; i < layers.length - 1; i++) {
+    const w = [];
+    for (let j = 0; j < layers[i]; j++) {
+      const row = new Float32Array(layers[i + 1]);
+      for (let k = 0; k < layers[i + 1]; k++) row[k] = Math.random() * 2 - 1;
+      w.push(row);
+    }
+    weights.push(w);
+  }
+}
+rebuild();
+
+let time = 0;
+
+function sigmoid(x) {
+  return 1 / (1 + Math.exp(-x));
+}
+
+function step() {
+  const inputLen = activations[0].length;
+  for (let i = 0; i < inputLen; i++) {
+    activations[0][i] = (Math.sin(time * params.waveSpeed + i * 1.3) + 1) * 0.5;
+  }
+  for (let l = 1; l < activations.length; l++) {
+    for (let k = 0; k < activations[l].length; k++) {
+      let sum = 0;
+      for (let j = 0; j < activations[l - 1].length; j++) {
+        sum += activations[l - 1][j] * weights[l - 1][j][k];
+      }
+      activations[l][k] = sigmoid(sum);
+    }
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  step();
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const L = activations.length;
+  const margin = 80;
+  const usableW = canvas.width - margin * 2;
+  for (let l = 0; l < L; l++) {
+    const x = margin + (usableW * l) / Math.max(1, L - 1);
+    const n = activations[l].length;
+    const totalH = 500;
+    const startY = canvas.height / 2 - totalH / 2;
+    for (let i = 0; i < n; i++) {
+      const y = startY + (totalH * i) / Math.max(1, n - 1);
+      // 結線
+      if (l < L - 1) {
+        const nNext = activations[l + 1].length;
+        const xNext = margin + (usableW * (l + 1)) / Math.max(1, L - 1);
+        for (let k = 0; k < nNext; k++) {
+          const yNext = startY + (totalH * k) / Math.max(1, nNext - 1);
+          const w = weights[l][i][k];
+          const pulse =
+            0.5 +
+            0.5 *
+              Math.sin(
+                time * params.pulseSpeed * 2 * Math.PI + (l + i + k) * 0.3,
+              );
+          const act = activations[l][i] * Math.abs(w);
+          const alpha =
+            params.lineAlpha *
+            Math.min(1, act + 0.1) *
+            (0.5 + params.weightPulse * pulse);
+          const hue = params.hueStart + (w > 0 ? 40 : 280);
+          ctx.strokeStyle = `hsla(${hue}, 80%, 60%, ${alpha})`;
+          ctx.lineWidth = params.thickness * (0.5 + Math.abs(w));
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(xNext, yNext);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  // ノード（重ねて描画）
+  for (let l = 0; l < L; l++) {
+    const x = margin + (usableW * l) / Math.max(1, L - 1);
+    const n = activations[l].length;
+    const totalH = 500;
+    const startY = canvas.height / 2 - totalH / 2;
+    for (let i = 0; i < n; i++) {
+      const y = startY + (totalH * i) / Math.max(1, n - 1);
+      const a = activations[l][i];
+      const hue = params.hueStart + (l / Math.max(1, L - 1)) * params.hueRange;
+      ctx.fillStyle = `hsla(${hue}, 85%, ${30 + a * 50}%, 0.95)`;
+      ctx.beginPath();
+      ctx.arc(x, y, params.nodeSize, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = `hsla(${hue}, 90%, 80%, 0.9)`;
+      ctx.lineWidth = 1.2;
+      ctx.stroke();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Neural Network Viz',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'inputs', 2, 12, 1);
+gui.add(params, 'hidden', 2, 16, 1);
+gui.add(params, 'hidden2', 2, 16, 1);
+gui.add(params, 'outputs', 2, 10, 1);
+gui.add(params, 'waveSpeed', 0.1, 4, 0.05);
+gui.add(params, 'weightPulse', 0, 1, 0.01);
+gui.add(params, 'lineAlpha', 0.1, 1, 0.01);
+gui.add(params, 'nodeSize', 6, 25, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'pulseSpeed', 0.1, 5, 0.05);
+gui.add(params, 'trailFade', 0.05, 0.3, 0.01);
+gui.add(params, 'thickness', 0.3, 3, 0.1);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.inputs = rand(3, 8, 1);
+  params.hidden = rand(5, 12, 1);
+  params.hidden2 = rand(4, 10, 1);
+  params.outputs = rand(3, 6, 1);
+  params.hueStart = rand(0, 360, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reseed', () => rebuild());
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/neural-network-viz/style.css
+++ b/public/neural-network-viz/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/newton-fractal/index.html
+++ b/public/newton-fractal/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Newton Fractal | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/newton-fractal/main.js
+++ b/public/newton-fractal/main.js
@@ -1,0 +1,237 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// ニュートン法フラクタル：複素平面上での多項式のゼロ点を
+// ニュートン法で反復し、収束先で色分けするフラクタル。
+
+const params = {
+  degree: 3, // 多項式の次数（3: z^3-1, 4: z^4-1 等）
+  centerX: 0, // 中心X
+  centerY: 0, // 中心Y
+  scale: 2.5, // 表示スケール
+  maxIter: 40, // 最大反復回数
+  tolerance: 0.0001, // 収束判定閾値
+  damping: 1.0, // ニュートンの減衰係数
+  brightness: 65, // 明度
+  saturation: 80, // 彩度
+  zoomSpeed: 0.002, // ズーム速度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+const SCALE = 0.35;
+const offscreen = document.createElement('canvas');
+const offCtx = /** @type {CanvasRenderingContext2D} */ (
+  offscreen.getContext('2d')
+);
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  offscreen.width = Math.round(canvas.width * SCALE);
+  offscreen.height = Math.round(canvas.height * SCALE);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let zoom = 1;
+
+/**
+ * 複素数の掛け算
+ * @param {{r: number, i: number}} a
+ * @param {{r: number, i: number}} b
+ * @returns {{r: number, i: number}}
+ */
+function cmul(a, b) {
+  return { r: a.r * b.r - a.i * b.i, i: a.r * b.i + a.i * b.r };
+}
+
+/**
+ * 複素数の割り算
+ * @param {{r: number, i: number}} a
+ * @param {{r: number, i: number}} b
+ * @returns {{r: number, i: number}}
+ */
+function cdiv(a, b) {
+  const d = b.r * b.r + b.i * b.i;
+  return { r: (a.r * b.r + a.i * b.i) / d, i: (a.i * b.r - a.r * b.i) / d };
+}
+
+/**
+ * z^n を計算する（複素数）
+ * @param {{r: number, i: number}} z
+ * @param {number} n
+ * @returns {{r: number, i: number}}
+ */
+function cpow(z, n) {
+  let result = { r: 1, i: 0 };
+  for (let i = 0; i < n; i++) result = cmul(result, z);
+  return result;
+}
+
+/**
+ * ニュートン法で z^n - 1 = 0 の解に収束させる
+ * @param {number} x 実部
+ * @param {number} y 虚部
+ * @param {number} deg 次数
+ * @returns {{root: number, iter: number}}
+ */
+function newton(x, y, deg) {
+  let z = { r: x, i: y };
+  for (let i = 0; i < params.maxIter; i++) {
+    const zn = cpow(z, deg);
+    const fn = { r: zn.r - 1, i: zn.i }; // f(z) = z^n - 1
+    const zn1 = cpow(z, deg - 1);
+    const dfn = { r: deg * zn1.r, i: deg * zn1.i }; // f'(z) = n * z^(n-1)
+    const step = cdiv(fn, dfn);
+    z = { r: z.r - params.damping * step.r, i: z.i - params.damping * step.i };
+
+    const r2 = step.r * step.r + step.i * step.i;
+    if (r2 < params.tolerance * params.tolerance) {
+      // 収束した根のインデックスを特定
+      let minDist = Infinity;
+      let root = 0;
+      for (let k = 0; k < deg; k++) {
+        const angle = (k * Math.PI * 2) / deg;
+        const rx = Math.cos(angle);
+        const ry = Math.sin(angle);
+        const d = (z.r - rx) ** 2 + (z.i - ry) ** 2;
+        if (d < minDist) {
+          minDist = d;
+          root = k;
+        }
+      }
+      return { root, iter: i };
+    }
+  }
+  return { root: -1, iter: params.maxIter };
+}
+
+function draw() {
+  zoom *= 1 + params.zoomSpeed;
+
+  const ow = offscreen.width;
+  const oh = offscreen.height;
+  const imgData = offCtx.createImageData(ow, oh);
+  const data = imgData.data;
+
+  const viewScale = params.scale / (ow * zoom);
+  const deg = Math.max(2, Math.min(8, Math.round(params.degree)));
+
+  for (let py = 0; py < oh; py++) {
+    for (let px = 0; px < ow; px++) {
+      const x = (px - ow / 2) * viewScale + params.centerX;
+      const y = (py - oh / 2) * viewScale + params.centerY;
+      const { root, iter } = newton(x, y, deg);
+      const idx = (py * ow + px) * 4;
+
+      if (root < 0) {
+        data[idx] = 0;
+        data[idx + 1] = 0;
+        data[idx + 2] = 0;
+      } else {
+        const hue = ((root * 360) / deg) % 360;
+        const t = iter / params.maxIter;
+        const sat = params.saturation / 100;
+        const lig = (params.brightness / 100) * (1 - t * 0.5);
+
+        const h0 = hue / 60;
+        const c0 = (1 - Math.abs(2 * lig - 1)) * sat;
+        const x0 = c0 * (1 - Math.abs((h0 % 2) - 1));
+        const m0 = lig - c0 / 2;
+        let r0 = 0,
+          g0 = 0,
+          b0 = 0;
+        if (h0 < 1) {
+          r0 = c0;
+          g0 = x0;
+        } else if (h0 < 2) {
+          r0 = x0;
+          g0 = c0;
+        } else if (h0 < 3) {
+          g0 = c0;
+          b0 = x0;
+        } else if (h0 < 4) {
+          g0 = x0;
+          b0 = c0;
+        } else if (h0 < 5) {
+          r0 = x0;
+          b0 = c0;
+        } else {
+          r0 = c0;
+          b0 = x0;
+        }
+
+        data[idx] = Math.round((r0 + m0) * 255);
+        data[idx + 1] = Math.round((g0 + m0) * 255);
+        data[idx + 2] = Math.round((b0 + m0) * 255);
+      }
+      data[idx + 3] = 255;
+    }
+  }
+  offCtx.putImageData(imgData, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(offscreen, 0, 0, canvas.width, canvas.height);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Newton Fractal',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'degree', 2, 8, 1);
+gui.add(params, 'centerX', -2, 2, 0.001);
+gui.add(params, 'centerY', -2, 2, 0.001);
+gui.add(params, 'scale', 0.5, 8, 0.1);
+gui.add(params, 'maxIter', 10, 200, 5);
+gui.add(params, 'damping', 0.1, 2, 0.01);
+gui.add(params, 'zoomSpeed', 0, 0.02, 0.001);
+gui.add(params, 'brightness', 20, 90, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.degree = rand(2, 7, 1);
+  params.damping = rand(0.5, 1.5, 0.01);
+  params.brightness = rand(40, 80, 1);
+  params.saturation = rand(60, 100, 1);
+  zoom = 1;
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  zoom = 1;
+  gui.updateDisplay();
+});

--- a/public/newton-fractal/style.css
+++ b/public/newton-fractal/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/peano-curve/index.html
+++ b/public/peano-curve/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Peano Curve | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/peano-curve/main.js
+++ b/public/peano-curve/main.js
@@ -1,0 +1,180 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// ペアノ曲線：3分割を再帰的に繰り返す空間充填曲線。
+// 各正方形を9等分し、特定順序で全セルを訪問する。
+
+const params = {
+  order: 4, // 再帰次数（1〜5）
+  hueStart: 120, // 開始色相
+  hueEnd: 280, // 終了色相
+  lineWidth: 1.5, // 線幅
+  drawSpeed: 12, // 描画速度（点/フレーム）
+  glow: 0.5, // 発光強度
+  padding: 0.05, // 余白率
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  buildCurve();
+}
+window.addEventListener('resize', resize);
+
+/** @type {{x: number, y: number}[]} */
+let points = [];
+let drawIdx = 0;
+
+/**
+ * ペアノ曲線の点列を再帰的に生成する（L-System 近似）
+ * @param {number} x 開始X（グリッド座標）
+ * @param {number} y 開始Y（グリッド座標）
+ * @param {number} n グリッドサイズ（3^order）
+ * @param {number} flipX X反転フラグ
+ * @param {number} flipY Y反転フラグ
+ * @param {{x:number,y:number}[]} out 出力配列
+ */
+function peano(x, y, n, flipX, flipY, out) {
+  if (n === 1) {
+    out.push({ x, y });
+    return;
+  }
+  const m = n / 3;
+  // ペアノの9セル訪問順（蛇行パターン）
+  const cols = [0, 1, 2, 2, 1, 0, 0, 1, 2];
+  const rows = [0, 0, 0, 1, 1, 1, 2, 2, 2];
+  for (let i = 0; i < 9; i++) {
+    const cx = flipX ? 2 - cols[i] : cols[i];
+    const cy = flipY ? 2 - rows[i] : rows[i];
+    const nx2 = i % 2 === 0 ? flipX : !flipX;
+    const ny2 = Math.floor(i / 3) % 2 === 0 ? flipY : !flipY;
+    peano(x + cx * m, y + cy * m, m, nx2, ny2, out);
+  }
+}
+
+/**
+ * ペアノ曲線の点列を構築する
+ */
+function buildCurve() {
+  const order = Math.max(1, Math.min(5, Math.round(params.order)));
+  const n = 3 ** order;
+  const w = canvas.width;
+  const h = canvas.height;
+  const size = Math.min(w, h) * (1 - params.padding * 2);
+  const ox = (w - size) / 2;
+  const oy = (h - size) / 2;
+  const gridPoints = /** @type {{x: number, y: number}[]} */ ([]);
+  peano(0, 0, n, false, false, gridPoints);
+
+  const step = size / (n - 1);
+  points = gridPoints.map((p) => ({
+    x: ox + p.x * step,
+    y: oy + p.y * step,
+  }));
+  drawIdx = 0;
+  ctx.clearRect(0, 0, w, h);
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, w, h);
+}
+
+buildCurve();
+
+/**
+ * 描画進捗に応じた色相を返す
+ * @param {number} t 0〜1
+ * @returns {string}
+ */
+function colorAt(t) {
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  return `hsl(${hue}, 80%, 60%)`;
+}
+
+function draw() {
+  const total = points.length;
+  if (drawIdx >= total - 1) {
+    drawIdx = 0;
+    ctx.fillStyle = '#0b0a07';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    return;
+  }
+
+  const speed = Math.max(1, Math.round(params.drawSpeed));
+  ctx.lineWidth = params.lineWidth;
+  ctx.lineCap = 'round';
+
+  for (let i = 0; i < speed && drawIdx < total - 1; i++) {
+    const t = drawIdx / (total - 1);
+    ctx.strokeStyle = colorAt(t);
+    ctx.shadowColor = colorAt(t);
+    ctx.shadowBlur = params.glow * 8;
+
+    ctx.beginPath();
+    ctx.moveTo(points[drawIdx].x, points[drawIdx].y);
+    ctx.lineTo(points[drawIdx + 1].x, points[drawIdx + 1].y);
+    ctx.stroke();
+    drawIdx++;
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Peano Curve',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'order', 1, 5, 1).onChange(buildCurve);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'lineWidth', 0.5, 5, 0.1);
+gui.add(params, 'drawSpeed', 1, 300, 1);
+gui.add(params, 'glow', 0, 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.order = rand(2, 4, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.lineWidth = rand(0.5, 3, 0.1);
+  params.drawSpeed = rand(5, 100, 1);
+  params.glow = rand(0, 1.5, 0.05);
+  buildCurve();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  buildCurve();
+  gui.updateDisplay();
+});

--- a/public/peano-curve/style.css
+++ b/public/peano-curve/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/phase-shift-metronome/index.html
+++ b/public/phase-shift-metronome/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Phase Shift Metronome | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/phase-shift-metronome/main.js
+++ b/public/phase-shift-metronome/main.js
@@ -1,0 +1,128 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Steve Reich の phase music 風。複数のメトロノームが少しずつ位相をずらしながら叩く。
+const params = {
+  count: 8, // メトロノーム数
+  baseBpm: 90,
+  drift: 2.5, // BPM差の最大値
+  lineLength: 520,
+  amplitude: 280, // 振幅
+  hueStart: 30,
+  hueRange: 300,
+  trailFade: 0.08,
+  ballSize: 8,
+  glow: 0.8,
+  showLines: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const n = Math.round(params.count);
+  const rowH = params.lineLength / Math.max(1, n - 1);
+
+  for (let i = 0; i < n; i++) {
+    const t = n === 1 ? 0 : i / (n - 1);
+    const bpm = params.baseBpm + (t - 0.5) * 2 * params.drift;
+    const freq = bpm / 60 / 2; // 半周期 = 1 拍
+    const phase = time * freq * Math.PI;
+    const x = cx + Math.sin(phase) * params.amplitude;
+    const y = cy - params.lineLength / 2 + i * rowH;
+    const hue = params.hueStart + t * params.hueRange;
+
+    if (params.showLines) {
+      ctx.strokeStyle = `hsla(${hue}, 60%, 40%, 0.3)`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx - params.amplitude, y);
+      ctx.lineTo(cx + params.amplitude, y);
+      ctx.stroke();
+    }
+
+    // 振動ボール
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, ${params.glow})`;
+    ctx.beginPath();
+    ctx.arc(x, y, params.ballSize, 0, Math.PI * 2);
+    ctx.fill();
+    // ハイライト
+    ctx.fillStyle = `hsla(${hue}, 100%, 85%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(x - 1.5, y - 1.5, params.ballSize * 0.4, 0, Math.PI * 2);
+    ctx.fill();
+    // 拍を打つ瞬間の強調（端で折り返す時）
+    const edge = Math.abs(Math.sin(phase));
+    if (edge > 0.995) {
+      ctx.strokeStyle = `hsla(${hue}, 100%, 75%, 0.8)`;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(x, y, params.ballSize + 6, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Phase Shift Metronome',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 2, 20, 1);
+gui.add(params, 'baseBpm', 40, 200, 1);
+gui.add(params, 'drift', 0, 10, 0.1);
+gui.add(params, 'lineLength', 100, 800, 1);
+gui.add(params, 'amplitude', 60, 500, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'trailFade', 0, 0.3, 0.01);
+gui.add(params, 'ballSize', 3, 20, 0.5);
+gui.add(params, 'glow', 0.3, 1, 0.01);
+gui.add(params, 'showLines');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.count = rand(5, 14, 1);
+  params.baseBpm = rand(60, 140, 1);
+  params.drift = rand(1, 6, 0.1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/phase-shift-metronome/style.css
+++ b/public/phase-shift-metronome/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/plankton-bloom/index.html
+++ b/public/plankton-bloom/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Plankton Bloom | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/plankton-bloom/main.js
+++ b/public/plankton-bloom/main.js
@@ -1,0 +1,201 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// プランクトンブルーム：海面を覆う植物プランクトンの大増殖を表現。
+// 渦巻きと拡散で海洋ブルームの美しいパターンを生成する。
+
+const params = {
+  count: 2000, // プランクトン数
+  diffusion: 0.8, // 拡散速度
+  vortexStrength: 0.6, // 渦の強さ
+  bloom: 0.008, // 増殖率
+  maxPop: 4000, // 最大個体数
+  hueBase: 160, // 基本色相（海緑）
+  hueVar: 60, // 色相のばらつき
+  saturation: 75, // 彩度
+  brightness: 55, // 明度
+  fadeAlpha: 0.08, // フェード強度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, hue: number, size: number }} Plankton */
+
+/** @type {Plankton[]} */
+let plankton = [];
+
+/**
+ * プランクトンを初期化する
+ */
+function initPlankton() {
+  plankton = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.count; i++) {
+    plankton.push({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      vx: (Math.random() - 0.5) * params.diffusion,
+      vy: (Math.random() - 0.5) * params.diffusion,
+      hue: params.hueBase + (Math.random() - 0.5) * params.hueVar,
+      size: 1 + Math.random() * 2,
+    });
+  }
+}
+
+initPlankton();
+
+let time = 0;
+
+/**
+ * プランクトンを1ステップ更新する
+ * @param {Plankton} p
+ */
+function updatePlankton(p) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  // 複数の渦（カルマン渦列のような渦）
+  const vortices = [
+    { x: cx - w * 0.2, y: cy, strength: params.vortexStrength },
+    { x: cx + w * 0.2, y: cy, strength: -params.vortexStrength * 0.8 },
+    { x: cx, y: cy - h * 0.25, strength: params.vortexStrength * 0.5 },
+  ];
+
+  for (const vortex of vortices) {
+    const dx = p.x - vortex.x;
+    const dy = p.y - vortex.y;
+    const dist = Math.max(10, Math.hypot(dx, dy));
+    const force = vortex.strength / (dist * 0.1);
+    p.vx += -dy * force * 0.001;
+    p.vy += dx * force * 0.001;
+  }
+
+  // 拡散
+  p.vx += (Math.random() - 0.5) * params.diffusion * 0.1;
+  p.vy += (Math.random() - 0.5) * params.diffusion * 0.1;
+
+  // 速度制限
+  const speed = Math.hypot(p.vx, p.vy);
+  const maxSpeed = params.diffusion * 2;
+  if (speed > maxSpeed) {
+    p.vx = (p.vx / speed) * maxSpeed;
+    p.vy = (p.vy / speed) * maxSpeed;
+  }
+
+  p.x += p.vx;
+  p.y += p.vy;
+
+  // 画面折り返し
+  if (p.x < 0) p.x += w;
+  if (p.x > w) p.x -= w;
+  if (p.y < 0) p.y += h;
+  if (p.y > h) p.y -= h;
+}
+
+function draw() {
+  time += 0.016;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(5, 15, 20, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 増殖
+  if (plankton.length < params.maxPop && Math.random() < params.bloom) {
+    const parent = plankton[Math.floor(Math.random() * plankton.length)];
+    if (parent) {
+      plankton.push({
+        x: parent.x + (Math.random() - 0.5) * 10,
+        y: parent.y + (Math.random() - 0.5) * 10,
+        vx: parent.vx + (Math.random() - 0.5) * 0.5,
+        vy: parent.vy + (Math.random() - 0.5) * 0.5,
+        hue: parent.hue + (Math.random() - 0.5) * 20,
+        size: 1 + Math.random() * 2,
+      });
+    }
+  }
+
+  for (const p of plankton) {
+    updatePlankton(p);
+    const alpha = 0.5 + Math.sin(time * 2 + p.x * 0.01) * 0.2;
+    ctx.fillStyle = `hsla(${p.hue}, ${params.saturation}%, ${params.brightness}%, ${alpha})`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Plankton Bloom',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 500, 5000, 100).onChange(initPlankton);
+gui.add(params, 'diffusion', 0.1, 3, 0.05);
+gui.add(params, 'vortexStrength', 0, 2, 0.05);
+gui.add(params, 'bloom', 0, 0.05, 0.001);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueVar', 0, 180, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'brightness', 10, 90, 1);
+gui.add(params, 'fadeAlpha', 0.01, 0.5, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.diffusion = rand(0.2, 2, 0.05);
+  params.vortexStrength = rand(0.1, 1.5, 0.05);
+  params.bloom = rand(0.002, 0.03, 0.001);
+  params.hueBase = rand(0, 360, 1);
+  params.hueVar = rand(20, 120, 1);
+  params.saturation = rand(50, 95, 1);
+  params.brightness = rand(30, 75, 1);
+  initPlankton();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initPlankton();
+  gui.updateDisplay();
+});

--- a/public/plankton-bloom/style.css
+++ b/public/plankton-bloom/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/pollen-drift/index.html
+++ b/public/pollen-drift/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Pollen Drift | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/pollen-drift/main.js
+++ b/public/pollen-drift/main.js
@@ -1,0 +1,221 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 花粉の漂い：風に揺られて空中を漂う花粉粒子のビジュアル。
+// ブラウン運動と微弱な風の効果で自然な浮遊感を表現する。
+
+const params = {
+  count: 400, // 花粉の数
+  brownian: 0.6, // ブラウン運動の強さ
+  windX: 0.3, // 風（X方向）
+  windY: -0.1, // 風（Y方向、上向きが負）
+  gravity: 0.02, // 重力
+  pollenHue: 55, // 花粉の色相（黄）
+  pollenSize: 3, // 花粉サイズ
+  fadeAlpha: 0.05, // フェード強度
+  spawnRate: 2, // 生成レート
+  glowStrength: 0.6, // 発光強度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number, size: number, hue: number, alpha: number, age: number }} Pollen */
+/** @type {Pollen[]} */
+let pollen = [];
+
+/**
+ * 花粉を初期化する
+ */
+function initPollen() {
+  pollen = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.count; i++) {
+    pollen.push({
+      x: Math.random() * w,
+      y: Math.random() * h,
+      vx: (Math.random() - 0.5) * 0.5,
+      vy: (Math.random() - 0.5) * 0.5,
+      size: params.pollenSize * (0.5 + Math.random()),
+      hue: params.pollenHue + (Math.random() - 0.5) * 30,
+      alpha: 0.4 + Math.random() * 0.5,
+      age: Math.random() * 1000,
+    });
+  }
+}
+initPollen();
+
+/**
+ * 花粉を1ステップ更新する
+ * @param {Pollen} p
+ */
+function updatePollen(p) {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  // ブラウン運動
+  p.vx += (Math.random() - 0.5) * params.brownian * 0.1;
+  p.vy += (Math.random() - 0.5) * params.brownian * 0.1;
+
+  // 風
+  p.vx += params.windX * 0.01;
+  p.vy += params.windY * 0.01;
+
+  // 重力
+  p.vy += params.gravity * 0.01;
+
+  // 速度減衰
+  p.vx *= 0.98;
+  p.vy *= 0.98;
+
+  p.x += p.vx;
+  p.y += p.vy;
+  p.age += 1;
+
+  // 画面外から再出現
+  if (p.x < -10) p.x = w + 10;
+  if (p.x > w + 10) p.x = -10;
+  if (p.y < -10) p.y = h + 10;
+  if (p.y > h + 10) p.y = -10;
+
+  // アルファの揺らぎ
+  p.alpha = 0.3 + Math.sin(p.age * 0.03) * 0.2 + 0.2;
+}
+
+/**
+ * 花粉を描く（球形＋発光）
+ * @param {Pollen} p
+ */
+function drawPollen(p) {
+  const s = p.size;
+
+  if (params.glowStrength > 0) {
+    const grd = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, s * 3);
+    grd.addColorStop(
+      0,
+      `hsla(${p.hue}, 90%, 80%, ${p.alpha * params.glowStrength})`,
+    );
+    grd.addColorStop(1, `hsla(${p.hue}, 80%, 60%, 0)`);
+    ctx.fillStyle = grd;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, s * 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.fillStyle = `hsla(${p.hue}, 85%, 70%, ${p.alpha})`;
+  ctx.beginPath();
+  ctx.arc(p.x, p.y, s, 0, Math.PI * 2);
+  ctx.fill();
+
+  // 花粉の表面テクスチャ（小さな突起）
+  ctx.strokeStyle = `hsla(${p.hue + 20}, 70%, 55%, ${p.alpha * 0.5})`;
+  ctx.lineWidth = 0.5;
+  for (let i = 0; i < 6; i++) {
+    const a = (i * Math.PI * 2) / 6;
+    ctx.beginPath();
+    ctx.moveTo(p.x + Math.cos(a) * s * 0.5, p.y + Math.sin(a) * s * 0.5);
+    ctx.lineTo(p.x + Math.cos(a) * s * 1.3, p.y + Math.sin(a) * s * 1.3);
+    ctx.stroke();
+  }
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = `rgba(8, 10, 5, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  // 新規花粉を生成
+  for (let i = 0; i < params.spawnRate; i++) {
+    if (pollen.length < params.count * 2) {
+      pollen.push({
+        x: Math.random() < 0.5 ? -5 : w + 5,
+        y: Math.random() * h,
+        vx: params.windX * (0.5 + Math.random()),
+        vy: (Math.random() - 0.5) * 0.5,
+        size: params.pollenSize * (0.5 + Math.random()),
+        hue: params.pollenHue + (Math.random() - 0.5) * 30,
+        alpha: 0.4 + Math.random() * 0.4,
+        age: 0,
+      });
+    }
+  }
+
+  for (const p of pollen) {
+    updatePollen(p);
+    drawPollen(p);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Pollen Drift',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 50, 1000, 25).onChange(initPollen);
+gui.add(params, 'brownian', 0, 3, 0.05);
+gui.add(params, 'windX', -2, 2, 0.05);
+gui.add(params, 'windY', -1, 1, 0.05);
+gui.add(params, 'gravity', 0, 0.3, 0.005);
+gui.add(params, 'pollenHue', 0, 360, 1);
+gui.add(params, 'pollenSize', 1, 10, 0.5);
+gui.add(params, 'fadeAlpha', 0.01, 0.3, 0.005);
+gui.add(params, 'glowStrength', 0, 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.brownian = rand(0.1, 2.5, 0.05);
+  params.windX = rand(-1.5, 1.5, 0.05);
+  params.windY = rand(-0.8, 0.2, 0.05);
+  params.gravity = rand(0, 0.2, 0.005);
+  params.pollenHue = rand(30, 90, 1);
+  params.pollenSize = rand(1.5, 7, 0.5);
+  params.glowStrength = rand(0, 1.5, 0.05);
+  initPollen();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initPollen();
+  gui.updateDisplay();
+});

--- a/public/pollen-drift/style.css
+++ b/public/pollen-drift/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/polyrhythm-wheel/index.html
+++ b/public/polyrhythm-wheel/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Polyrhythm Wheel | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/polyrhythm-wheel/main.js
+++ b/public/polyrhythm-wheel/main.js
@@ -1,0 +1,161 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  bpm: 90,
+  division1: 3,
+  division2: 4,
+  division3: 5,
+  division4: 7,
+  showWheel4: true,
+  radius: 280,
+  gap: 50,
+  hueStart: 40,
+  hueStep: 80,
+  pulseGlow: 0.9,
+  trailFade: 0.15,
+  ballSize: 8,
+  lineAlpha: 0.4,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+/** @type {{x:number,y:number,t:number,hue:number}[]} */
+let pulses = [];
+
+/** @type {Map<string, number>} */
+const lastBeat = new Map();
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const barSec = 240 / params.bpm; // 1 小節 4 拍で 240/bpm 秒
+  const tBar = (time % barSec) / barSec;
+
+  const divs = [
+    Math.round(params.division1),
+    Math.round(params.division2),
+    Math.round(params.division3),
+  ];
+  if (params.showWheel4) divs.push(Math.round(params.division4));
+
+  for (let i = 0; i < divs.length; i++) {
+    const n = Math.max(1, divs[i]);
+    const rad = params.radius - i * params.gap;
+    if (rad <= 4) continue;
+    const hue = params.hueStart + i * params.hueStep;
+    // 背景円
+    ctx.strokeStyle = `hsla(${hue}, 60%, 45%, ${params.lineAlpha})`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+    ctx.stroke();
+    // 拍点
+    for (let k = 0; k < n; k++) {
+      const a = -Math.PI / 2 + (k / n) * Math.PI * 2;
+      const x = cx + Math.cos(a) * rad;
+      const y = cy + Math.sin(a) * rad;
+      ctx.fillStyle = `hsla(${hue}, 80%, 60%, 0.8)`;
+      ctx.beginPath();
+      ctx.arc(x, y, 4, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // 回転ボール
+    const angle = -Math.PI / 2 + tBar * Math.PI * 2 * n;
+    const bx = cx + Math.cos(angle) * rad;
+    const by = cy + Math.sin(angle) * rad;
+    ctx.fillStyle = `hsla(${hue}, 95%, 75%, 1)`;
+    ctx.beginPath();
+    ctx.arc(bx, by, params.ballSize, 0, Math.PI * 2);
+    ctx.fill();
+    // 拍打ち判定
+    const currentBeat = Math.floor(tBar * n);
+    const key = `${i}`;
+    if (lastBeat.get(key) !== currentBeat) {
+      lastBeat.set(key, currentBeat);
+      const bangAngle = -Math.PI / 2 + (currentBeat / n) * Math.PI * 2;
+      pulses.push({
+        x: cx + Math.cos(bangAngle) * rad,
+        y: cy + Math.sin(bangAngle) * rad,
+        t: 0,
+        hue,
+      });
+    }
+  }
+
+  pulses = pulses.filter((p) => p.t < 1);
+  for (const p of pulses) {
+    p.t += 0.04;
+    ctx.strokeStyle = `hsla(${p.hue}, 100%, 75%, ${(1 - p.t) * params.pulseGlow})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 6 + p.t * 40, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Polyrhythm Wheel',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'bpm', 30, 200, 1);
+gui.add(params, 'division1', 2, 16, 1);
+gui.add(params, 'division2', 2, 16, 1);
+gui.add(params, 'division3', 2, 16, 1);
+gui.add(params, 'division4', 2, 16, 1);
+gui.add(params, 'showWheel4');
+gui.add(params, 'radius', 150, 400, 1);
+gui.add(params, 'gap', 20, 80, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueStep', 20, 180, 1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'ballSize', 4, 16, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  const opts = [3, 4, 5, 6, 7, 8, 9, 11, 13];
+  params.division1 = opts[Math.floor(Math.random() * opts.length)];
+  params.division2 = opts[Math.floor(Math.random() * opts.length)];
+  params.division3 = opts[Math.floor(Math.random() * opts.length)];
+  params.division4 = opts[Math.floor(Math.random() * opts.length)];
+  params.bpm = rand(60, 140, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueStep = rand(40, 150, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/polyrhythm-wheel/style.css
+++ b/public/polyrhythm-wheel/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/pythagoras-tree/index.html
+++ b/public/pythagoras-tree/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Pythagoras Tree | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/pythagoras-tree/main.js
+++ b/public/pythagoras-tree/main.js
@@ -1,0 +1,150 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 10,
+  baseSize: 90,
+  angle: 45, // 分岐角
+  leftRatio: Math.SQRT1_2, // 左子の大きさ比
+  rightRatio: Math.SQRT1_2, // 右子の大きさ比
+  asymmetry: 0,
+  hueStart: 120,
+  hueEnd: 30,
+  alpha: 0.85,
+  fade: 0.12,
+  sway: 0.15,
+  swaySpeed: 0.6,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 正方形を描いて左右に子の正方形を再帰
+ * @param {number} x 底辺左端 x
+ * @param {number} y 底辺左端 y
+ * @param {number} size 一辺
+ * @param {number} rot 回転（ラジアン、底辺の向き）
+ * @param {number} depth
+ */
+function drawSquare(x, y, size, rot, depth) {
+  if (depth <= 0 || size < 1) return;
+  const t = 1 - depth / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.fillStyle = `hsla(${hue}, 70%, 55%, ${params.alpha * 0.3})`;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.alpha})`;
+  ctx.lineWidth = Math.max(0.5, 1.2);
+
+  const cosR = Math.cos(rot);
+  const sinR = Math.sin(rot);
+  // 4 頂点（底辺左から時計回り）
+  const p1 = { x, y };
+  const p2 = { x: x + cosR * size, y: y + sinR * size };
+  const up = { x: -sinR, y: cosR };
+  const p3 = { x: p2.x + up.x * size, y: p2.y + up.y * size };
+  const p4 = { x: p1.x + up.x * size, y: p1.y + up.y * size };
+
+  ctx.beginPath();
+  ctx.moveTo(p1.x, p1.y);
+  ctx.lineTo(p2.x, p2.y);
+  ctx.lineTo(p3.x, p3.y);
+  ctx.lineTo(p4.x, p4.y);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  // 屋根の頂点を角度で決める
+  const sway =
+    Math.sin(time * params.swaySpeed + depth * 0.5) * params.sway * 8;
+  const aL = ((params.angle + params.asymmetry + sway) * Math.PI) / 180;
+  const aR = ((params.angle - params.asymmetry - sway) * Math.PI) / 180;
+  // 左子: 上辺左端 (p4) を底辺左端、長さは size * cos(aL) に比例
+  const lSize = size * Math.cos(aL) * params.leftRatio;
+  const lRot = rot - aL;
+  drawSquare(p4.x, p4.y, lSize, lRot, depth - 1);
+
+  // 右子: 屋根の頂点から p3 まで。
+  const rSize = size * Math.sin(aL) * params.rightRatio;
+  // 屋根頂点 = p4 + (cos(aL), sin(aL)) in 回転座標で size*cos(aL)
+  const apex = {
+    x:
+      p4.x + (cosR * Math.cos(aL) + -sinR * Math.sin(aL)) * size * Math.cos(aL),
+    y: p4.y + (sinR * Math.cos(aL) + cosR * Math.sin(aL)) * size * Math.cos(aL),
+  };
+  const rRot = rot + (Math.PI / 2 - aR);
+  drawSquare(apex.x, apex.y, rSize, rRot, depth - 1);
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const x0 = canvas.width / 2 - params.baseSize / 2;
+  const y0 = canvas.height * 0.92;
+  drawSquare(x0, y0, params.baseSize, 0, Math.round(params.depth));
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Pythagoras Tree',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 3, 13, 1);
+gui.add(params, 'baseSize', 30, 180, 1);
+gui.add(params, 'angle', 10, 80, 1);
+gui.add(params, 'leftRatio', 0.5, 1, 0.01);
+gui.add(params, 'rightRatio', 0.5, 1, 0.01);
+gui.add(params, 'asymmetry', -20, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'fade', 0, 0.4, 0.01);
+gui.add(params, 'sway', 0, 0.6, 0.01);
+gui.add(params, 'swaySpeed', 0, 2, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(7, 11, 1);
+  params.angle = rand(25, 60, 1);
+  params.leftRatio = rand(0.6, 0.85, 0.01);
+  params.rightRatio = rand(0.6, 0.85, 0.01);
+  params.asymmetry = rand(-10, 10, 0.5);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.sway = rand(0.05, 0.3, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/pythagoras-tree/style.css
+++ b/public/pythagoras-tree/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/quasicrystal/index.html
+++ b/public/quasicrystal/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Quasicrystal | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/quasicrystal/main.js
+++ b/public/quasicrystal/main.js
@@ -1,0 +1,176 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 準結晶パターン：N個の平面波の重ね合わせで生成する非周期的干渉縞。
+// 5-foldや7-fold対称のモアレ様パターンが現れる。
+
+const params = {
+  waves: 7, // 波の数（対称性）
+  frequency: 0.018, // 空間周波数
+  animSpeed: 0.3, // アニメーション速度
+  hueBase: 220, // 基本色相
+  hueRange: 120, // 色相の幅
+  contrast: 1.4, // コントラスト
+  saturation: 80, // 彩度
+  brightness: 55, // 明度
+  phaseShift: 0, // 初期位相ずれ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+// 解像度を下げて高速化するためオフスクリーンキャンバスを使う
+const offscreen = document.createElement('canvas');
+const offCtx = /** @type {CanvasRenderingContext2D} */ (
+  offscreen.getContext('2d')
+);
+const SCALE = 0.25; // 1/4解像度で描画
+
+/** @type {ImageData|null} */
+let offImgData = null;
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  offscreen.width = Math.round(canvas.width * SCALE);
+  offscreen.height = Math.round(canvas.height * SCALE);
+  offImgData = offCtx.createImageData(offscreen.width, offscreen.height);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += params.animSpeed * 0.016;
+  const ow = offscreen.width;
+  const oh = offscreen.height;
+  if (!offImgData) return;
+  const data = offImgData.data;
+
+  const n = Math.max(3, Math.round(params.waves));
+  const freq = params.frequency / SCALE;
+  const t = time;
+  const cx = ow / 2;
+  const cy = oh / 2;
+
+  for (let py = 0; py < oh; py++) {
+    for (let px = 0; px < ow; px++) {
+      const x = px - cx;
+      const y = py - cy;
+      let sum = 0;
+      for (let k = 0; k < n; k++) {
+        const angle = (k * Math.PI * 2) / n + params.phaseShift;
+        const kx = Math.cos(angle);
+        const ky = Math.sin(angle);
+        sum += Math.cos((kx * x + ky * y) * freq * 2 * Math.PI + t * k * 0.3);
+      }
+      const v = (sum / n + 1) / 2;
+      const vc = Math.max(0, Math.min(1, v)) ** params.contrast;
+
+      const hue = (params.hueBase + vc * params.hueRange) % 360;
+      const sat = params.saturation / 100;
+      const lig = (params.brightness * (0.3 + vc * 0.7)) / 100;
+
+      const h0 = hue / 60;
+      const c0 = (1 - Math.abs(2 * lig - 1)) * sat;
+      const x0 = c0 * (1 - Math.abs((h0 % 2) - 1));
+      const m0 = lig - c0 / 2;
+      let r0 = 0;
+      let g0 = 0;
+      let b0 = 0;
+      if (h0 < 1) {
+        r0 = c0;
+        g0 = x0;
+      } else if (h0 < 2) {
+        r0 = x0;
+        g0 = c0;
+      } else if (h0 < 3) {
+        g0 = c0;
+        b0 = x0;
+      } else if (h0 < 4) {
+        g0 = x0;
+        b0 = c0;
+      } else if (h0 < 5) {
+        r0 = x0;
+        b0 = c0;
+      } else {
+        r0 = c0;
+        b0 = x0;
+      }
+
+      const idx = (py * ow + px) * 4;
+      data[idx] = Math.round((r0 + m0) * 255);
+      data[idx + 1] = Math.round((g0 + m0) * 255);
+      data[idx + 2] = Math.round((b0 + m0) * 255);
+      data[idx + 3] = 255;
+    }
+  }
+  offCtx.putImageData(offImgData, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  ctx.drawImage(offscreen, 0, 0, canvas.width, canvas.height);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Quasicrystal',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'waves', 3, 12, 1);
+gui.add(params, 'frequency', 0.005, 0.06, 0.001);
+gui.add(params, 'animSpeed', 0, 3, 0.05);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'contrast', 0.2, 4, 0.05);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'brightness', 10, 90, 1);
+gui.add(params, 'phaseShift', 0, Math.PI * 2, 0.05);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.waves = rand(3, 11, 1);
+  params.frequency = rand(0.008, 0.04, 0.001);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.contrast = rand(0.5, 3, 0.05);
+  params.saturation = rand(50, 100, 1);
+  params.brightness = rand(30, 70, 1);
+  params.phaseShift = rand(0, Math.PI * 2, 0.05);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/quasicrystal/style.css
+++ b/public/quasicrystal/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/reaction-diffusion/index.html
+++ b/public/reaction-diffusion/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Reaction Diffusion | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/reaction-diffusion/main.js
+++ b/public/reaction-diffusion/main.js
@@ -1,0 +1,198 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 簡易 Gray-Scott 反応拡散系（格子 160x100 程度でリアルタイム）
+const params = {
+  gridScale: 5, // 画面ピクセルあたりの格子サイズ
+  feed: 0.055,
+  kill: 0.062,
+  dA: 1.0,
+  dB: 0.5,
+  iterPerFrame: 8,
+  hueStart: 180,
+  hueRange: 160,
+  brightness: 1.3,
+  seedSize: 12,
+  seedSpawn: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** @type {Float32Array} */
+let a;
+/** @type {Float32Array} */
+let b;
+let gw = 0;
+let gh = 0;
+
+function rebuild() {
+  gw = Math.max(40, Math.floor(canvas.width / params.gridScale));
+  gh = Math.max(40, Math.floor(canvas.height / params.gridScale));
+  a = new Float32Array(gw * gh);
+  b = new Float32Array(gw * gh);
+  for (let i = 0; i < a.length; i++) a[i] = 1;
+  seed(gw / 2, gh / 2);
+}
+
+function seed(cx, cy) {
+  const r = Math.round(params.seedSize);
+  for (let y = -r; y <= r; y++) {
+    for (let x = -r; x <= r; x++) {
+      const px = Math.floor(cx + x);
+      const py = Math.floor(cy + y);
+      if (px < 0 || py < 0 || px >= gw || py >= gh) continue;
+      if (x * x + y * y <= r * r) b[py * gw + px] = 1;
+    }
+  }
+}
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  rebuild();
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Float32Array} */
+let a2;
+/** @type {Float32Array} */
+let b2;
+
+function laplacian(buf, x, y) {
+  const idx = y * gw + x;
+  const xm = (x - 1 + gw) % gw;
+  const xp = (x + 1) % gw;
+  const ym = (y - 1 + gh) % gh;
+  const yp = (y + 1) % gh;
+  return (
+    buf[ym * gw + xm] * 0.05 +
+    buf[ym * gw + x] * 0.2 +
+    buf[ym * gw + xp] * 0.05 +
+    buf[y * gw + xm] * 0.2 +
+    buf[idx] * -1 +
+    buf[y * gw + xp] * 0.2 +
+    buf[yp * gw + xm] * 0.05 +
+    buf[yp * gw + x] * 0.2 +
+    buf[yp * gw + xp] * 0.05
+  );
+}
+
+function iterate() {
+  if (!a2 || a2.length !== a.length) {
+    a2 = new Float32Array(a.length);
+    b2 = new Float32Array(b.length);
+  }
+  const F = params.feed;
+  const K = params.kill;
+  for (let y = 0; y < gh; y++) {
+    for (let x = 0; x < gw; x++) {
+      const idx = y * gw + x;
+      const av = a[idx];
+      const bv = b[idx];
+      const abb = av * bv * bv;
+      a2[idx] = av + (params.dA * laplacian(a, x, y) - abb + F * (1 - av));
+      b2[idx] = bv + (params.dB * laplacian(b, x, y) + abb - (K + F) * bv);
+      if (a2[idx] < 0) a2[idx] = 0;
+      if (a2[idx] > 1) a2[idx] = 1;
+      if (b2[idx] < 0) b2[idx] = 0;
+      if (b2[idx] > 1) b2[idx] = 1;
+    }
+  }
+  [a, a2] = [a2, a];
+  [b, b2] = [b2, b];
+}
+
+let spawnTimer = 0;
+
+function draw() {
+  if (params.seedSpawn) {
+    spawnTimer++;
+    if (spawnTimer > 240) {
+      spawnTimer = 0;
+      seed(Math.random() * gw, Math.random() * gh);
+    }
+  }
+  const iters = Math.round(params.iterPerFrame);
+  for (let i = 0; i < iters; i++) iterate();
+
+  const img = ctx.createImageData(canvas.width, canvas.height);
+  const data = img.data;
+  const sx = canvas.width / gw;
+  const sy = canvas.height / gh;
+  for (let py = 0; py < canvas.height; py++) {
+    const gy = Math.min(gh - 1, Math.floor(py / sy));
+    for (let px = 0; px < canvas.width; px++) {
+      const gx = Math.min(gw - 1, Math.floor(px / sx));
+      const v = Math.min(1, b[gy * gw + gx] * params.brightness);
+      const hue = params.hueStart + v * params.hueRange;
+      const l = Math.floor(v * 255);
+      const rr = Math.floor(l * 0.8 + 20);
+      const gg = Math.floor(
+        l * (0.5 + Math.sin((hue * Math.PI) / 180) * 0.3) + 10,
+      );
+      const bb = Math.floor(
+        l * (0.3 + Math.cos((hue * Math.PI) / 180) * 0.3) + 10,
+      );
+      const off = (py * canvas.width + px) * 4;
+      data[off] = rr;
+      data[off + 1] = gg;
+      data[off + 2] = bb;
+      data[off + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Reaction Diffusion',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'gridScale', 3, 10, 1);
+gui.add(params, 'feed', 0.02, 0.1, 0.001);
+gui.add(params, 'kill', 0.04, 0.075, 0.001);
+gui.add(params, 'dA', 0.5, 1.5, 0.01);
+gui.add(params, 'dB', 0.2, 1, 0.01);
+gui.add(params, 'iterPerFrame', 2, 20, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'brightness', 0.5, 3, 0.05);
+gui.add(params, 'seedSize', 3, 30, 1);
+gui.add(params, 'seedSpawn');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.feed = rand(0.03, 0.08, 0.001);
+  params.kill = rand(0.05, 0.068, 0.001);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Seed', () => seed(Math.random() * gw, Math.random() * gh));
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/reaction-diffusion/style.css
+++ b/public/reaction-diffusion/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/rhombille-tiling/index.html
+++ b/public/rhombille-tiling/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Rhombille Tiling | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/rhombille-tiling/main.js
+++ b/public/rhombille-tiling/main.js
@@ -1,0 +1,187 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 菱形タイリング：等角三菱形で平面を敷き詰める。
+// 3方向の平行四辺形を使い、3Dキューブの投影に見える模様を生成する。
+
+const params = {
+  tileSize: 40, // タイルサイズ
+  hue1: 220, // 上面の色相
+  hue2: 260, // 左面の色相
+  hue3: 300, // 右面の色相
+  saturation: 55, // 彩度
+  lightTop: 70, // 上面明度
+  lightLeft: 45, // 左面明度
+  lightRight: 30, // 右面明度
+  strokeWidth: 0.5, // 枠線幅
+  animSpeed: 0.4, // アニメーション速度
+  colorShift: 0, // 色相シフト
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 菱形（平行四辺形）を描く
+ * @param {number} cx 中心X
+ * @param {number} cy 中心Y
+ * @param {number} dx1 方向1 X
+ * @param {number} dy1 方向1 Y
+ * @param {number} dx2 方向2 X
+ * @param {number} dy2 方向2 Y
+ * @param {string} color 塗りつぶし色
+ */
+function drawRhombus(cx, cy, dx1, dy1, dx2, dy2, color) {
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.lineTo(cx + dx1, cy + dy1);
+  ctx.lineTo(cx + dx1 + dx2, cy + dy1 + dy2);
+  ctx.lineTo(cx + dx2, cy + dy2);
+  ctx.closePath();
+  ctx.fillStyle = color;
+  ctx.fill();
+  if (params.strokeWidth > 0) {
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.3)';
+    ctx.lineWidth = params.strokeWidth;
+    ctx.stroke();
+  }
+}
+
+function draw() {
+  time += params.animSpeed * 0.005;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, w, h);
+
+  const s = params.tileSize;
+  // 六方格子の基底ベクトル
+  const ax = s;
+  const ay = 0;
+  const bx = s * 0.5;
+  const by = s * Math.sqrt(3) * 0.5;
+
+  const shift = params.colorShift + time * 30;
+  const h1 = (params.hue1 + shift) % 360;
+  const h2 = (params.hue2 + shift) % 360;
+  const h3 = (params.hue3 + shift) % 360;
+  const sat = params.saturation;
+
+  // グリッド描画範囲
+  const cols = Math.ceil(w / s) + 4;
+  const rows = Math.ceil(h / by) + 4;
+
+  for (let row = -2; row < rows; row++) {
+    for (let col = -2; col < cols; col++) {
+      const cx = col * ax + row * bx - w * 0.1;
+      const cy = row * by - h * 0.05;
+
+      // 上面（水平菱形）
+      drawRhombus(
+        cx,
+        cy,
+        ax,
+        ay,
+        bx,
+        by,
+        `hsl(${h1}, ${sat}%, ${params.lightTop}%)`,
+      );
+      // 左面
+      drawRhombus(
+        cx + bx,
+        cy + by,
+        ax,
+        ay,
+        bx,
+        by,
+        `hsl(${h2}, ${sat}%, ${params.lightLeft}%)`,
+      );
+      // 右面
+      drawRhombus(
+        cx + ax,
+        cy,
+        bx,
+        by,
+        bx,
+        by,
+        `hsl(${h3}, ${sat}%, ${params.lightRight}%)`,
+      );
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Rhombille Tiling',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'tileSize', 10, 120, 2);
+gui.add(params, 'hue1', 0, 360, 1);
+gui.add(params, 'hue2', 0, 360, 1);
+gui.add(params, 'hue3', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightTop', 0, 100, 1);
+gui.add(params, 'lightLeft', 0, 100, 1);
+gui.add(params, 'lightRight', 0, 100, 1);
+gui.add(params, 'strokeWidth', 0, 3, 0.1);
+gui.add(params, 'animSpeed', 0, 3, 0.05);
+gui.add(params, 'colorShift', 0, 360, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.tileSize = rand(20, 80, 2);
+  params.hue1 = rand(0, 360, 1);
+  params.hue2 = rand(0, 360, 1);
+  params.hue3 = rand(0, 360, 1);
+  params.saturation = rand(30, 90, 1);
+  params.lightTop = rand(55, 85, 1);
+  params.lightLeft = rand(30, 55, 1);
+  params.lightRight = rand(15, 40, 1);
+  params.animSpeed = rand(0, 2, 0.05);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/rhombille-tiling/style.css
+++ b/public/rhombille-tiling/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/risset-rhythm/index.html
+++ b/public/risset-rhythm/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Risset Rhythm | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/risset-rhythm/main.js
+++ b/public/risset-rhythm/main.js
@@ -1,0 +1,142 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Risset のリズム錯覚: 複数層が加速しつつ音量が徐々にフェードする。見かけ上無限に加速していく。
+const params = {
+  layers: 6,
+  baseBpm: 60,
+  rampSeconds: 10, // 1 オクターブ分加速するのにかかる時間
+  radius: 260,
+  hueStart: 180,
+  hueRange: 200,
+  ballSize: 10,
+  ringWidth: 2,
+  trailFade: 0.15,
+  glow: 0.7,
+  showSpiral: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+/** @type {{x:number,y:number,t:number,hue:number}[]} */
+let pulses = [];
+/** @type {number[]} */
+let lastBeatPerLayer = [];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const n = Math.round(params.layers);
+
+  for (let i = 0; i < n; i++) {
+    // 各レイヤーは位相 (time + i * rampSeconds / n) / rampSeconds で 0→1 のオクターブランプ
+    const phase =
+      ((time + (i * params.rampSeconds) / n) % params.rampSeconds) /
+      params.rampSeconds;
+    const mult = 2 ** phase; // BPM 倍率 1→2→1
+    const bpm = params.baseBpm * mult;
+    const beats = (time * bpm) / 60;
+    const beatIdx = Math.floor(beats);
+    const beatFrac = beats - beatIdx;
+    const envelope = Math.sin(phase * Math.PI);
+    const rad = params.radius * (1 - phase * 0.7);
+    const hue = params.hueStart + phase * params.hueRange;
+    const angle = -Math.PI / 2 + beatFrac * Math.PI * 2;
+    if (lastBeatPerLayer[i] !== beatIdx) {
+      lastBeatPerLayer[i] = beatIdx;
+      pulses.push({
+        x: cx + Math.cos(-Math.PI / 2) * rad,
+        y: cy + Math.sin(-Math.PI / 2) * rad,
+        t: 0,
+        hue,
+      });
+    }
+    // スパイラル軌道
+    if (params.showSpiral) {
+      ctx.strokeStyle = `hsla(${hue}, 60%, 55%, ${0.15 + envelope * 0.35})`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    const bx = cx + Math.cos(angle) * rad;
+    const by = cy + Math.sin(angle) * rad;
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, ${envelope * params.glow})`;
+    ctx.beginPath();
+    ctx.arc(bx, by, params.ballSize * envelope + 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  pulses = pulses.filter((p) => p.t < 1);
+  for (const p of pulses) {
+    p.t += 0.05;
+    ctx.strokeStyle = `hsla(${p.hue}, 100%, 80%, ${(1 - p.t) * params.glow})`;
+    ctx.lineWidth = params.ringWidth;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 4 + p.t * 50, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Risset Rhythm',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'layers', 2, 12, 1);
+gui.add(params, 'baseBpm', 20, 120, 1);
+gui.add(params, 'rampSeconds', 3, 30, 0.5);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'ballSize', 4, 20, 0.5);
+gui.add(params, 'ringWidth', 0.5, 5, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.3, 0.01);
+gui.add(params, 'glow', 0.2, 1, 0.01);
+gui.add(params, 'showSpiral');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.layers = rand(4, 10, 1);
+  params.baseBpm = rand(40, 100, 1);
+  params.rampSeconds = rand(6, 20, 0.5);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  lastBeatPerLayer = [];
+  gui.updateDisplay();
+});

--- a/public/risset-rhythm/style.css
+++ b/public/risset-rhythm/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/schooling-fish/index.html
+++ b/public/schooling-fish/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Schooling Fish | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/schooling-fish/main.js
+++ b/public/schooling-fish/main.js
@@ -1,0 +1,227 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 群泳する魚：Boid アルゴリズムで魚の群泳を表現。
+// 分離・整列・結合の3ルールで自然な群れ行動を生成する。
+
+const params = {
+  count: 150, // 魚の数
+  separateDist: 25, // 分離距離
+  alignDist: 60, // 整列距離
+  cohesionDist: 80, // 結合距離
+  separateForce: 1.5, // 分離力
+  alignForce: 0.8, // 整列力
+  cohesionForce: 0.5, // 結合力
+  maxSpeed: 3.5, // 最高速度
+  fishHue: 190, // 魚の色相
+  trailFade: 0.15, // フェード強度
+  fishSize: 7, // 魚のサイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, vx: number, vy: number }} Fish */
+
+/** @type {Fish[]} */
+let fishes = [];
+
+/**
+ * 魚の群れを初期化する
+ */
+function initFishes() {
+  fishes = [];
+  for (let i = 0; i < params.count; i++) {
+    fishes.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      vx: (Math.random() - 0.5) * params.maxSpeed,
+      vy: (Math.random() - 0.5) * params.maxSpeed,
+    });
+  }
+}
+initFishes();
+
+/**
+ * 2点間の距離を計算する
+ * @param {Fish} a
+ * @param {Fish} b
+ * @returns {number}
+ */
+function dist(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+/**
+ * 各魚にBoidルールを適用して速度を更新する
+ */
+function updateFishes() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  for (const fish of fishes) {
+    let sepX = 0;
+    let sepY = 0;
+    let aliVx = 0;
+    let aliVy = 0;
+    let cohX = 0;
+    let cohY = 0;
+    let sepN = 0;
+    let aliN = 0;
+    let cohN = 0;
+
+    for (const other of fishes) {
+      if (other === fish) continue;
+      const d = dist(fish, other);
+      if (d < params.separateDist) {
+        sepX += fish.x - other.x;
+        sepY += fish.y - other.y;
+        sepN++;
+      }
+      if (d < params.alignDist) {
+        aliVx += other.vx;
+        aliVy += other.vy;
+        aliN++;
+      }
+      if (d < params.cohesionDist) {
+        cohX += other.x;
+        cohY += other.y;
+        cohN++;
+      }
+    }
+
+    if (sepN > 0) {
+      fish.vx += (sepX / sepN) * params.separateForce * 0.05;
+      fish.vy += (sepY / sepN) * params.separateForce * 0.05;
+    }
+    if (aliN > 0) {
+      fish.vx += (aliVx / aliN - fish.vx) * params.alignForce * 0.05;
+      fish.vy += (aliVy / aliN - fish.vy) * params.alignForce * 0.05;
+    }
+    if (cohN > 0) {
+      fish.vx += (cohX / cohN - fish.x) * params.cohesionForce * 0.001;
+      fish.vy += (cohY / cohN - fish.y) * params.cohesionForce * 0.001;
+    }
+
+    // 速度制限
+    const speed = Math.hypot(fish.vx, fish.vy);
+    if (speed > params.maxSpeed) {
+      fish.vx = (fish.vx / speed) * params.maxSpeed;
+      fish.vy = (fish.vy / speed) * params.maxSpeed;
+    }
+
+    fish.x += fish.vx;
+    fish.y += fish.vy;
+
+    // 画面折り返し
+    if (fish.x < 0) fish.x += w;
+    if (fish.x > w) fish.x -= w;
+    if (fish.y < 0) fish.y += h;
+    if (fish.y > h) fish.y -= h;
+  }
+}
+
+/**
+ * 魚を描く（魚形の三角形）
+ * @param {Fish} fish
+ */
+function drawFish(fish) {
+  const angle = Math.atan2(fish.vy, fish.vx);
+  const s = params.fishSize;
+  ctx.save();
+  ctx.translate(fish.x, fish.y);
+  ctx.rotate(angle);
+  ctx.beginPath();
+  ctx.moveTo(s, 0);
+  ctx.lineTo(-s * 0.6, -s * 0.4);
+  ctx.lineTo(-s * 0.6, s * 0.4);
+  ctx.closePath();
+  const speed = Math.hypot(fish.vx, fish.vy) / params.maxSpeed;
+  const hue = params.fishHue + speed * 40;
+  ctx.fillStyle = `hsl(${hue}, 70%, ${50 + speed * 20}%)`;
+  ctx.fill();
+  ctx.restore();
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, w, h);
+
+  updateFishes();
+  for (const fish of fishes) drawFish(fish);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Schooling Fish',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 20, 400, 10).onChange(initFishes);
+gui.add(params, 'separateDist', 5, 80, 1);
+gui.add(params, 'alignDist', 20, 150, 1);
+gui.add(params, 'cohesionDist', 20, 200, 1);
+gui.add(params, 'separateForce', 0, 5, 0.1);
+gui.add(params, 'alignForce', 0, 3, 0.05);
+gui.add(params, 'cohesionForce', 0, 3, 0.05);
+gui.add(params, 'maxSpeed', 0.5, 8, 0.1);
+gui.add(params, 'fishHue', 0, 360, 1);
+gui.add(params, 'fishSize', 2, 20, 0.5);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.separateDist = rand(10, 50, 1);
+  params.alignDist = rand(30, 100, 1);
+  params.cohesionDist = rand(40, 150, 1);
+  params.separateForce = rand(0.5, 4, 0.1);
+  params.alignForce = rand(0.2, 2, 0.05);
+  params.cohesionForce = rand(0.1, 2, 0.05);
+  params.maxSpeed = rand(1, 6, 0.1);
+  params.fishHue = rand(0, 360, 1);
+  initFishes();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initFishes();
+  gui.updateDisplay();
+});

--- a/public/schooling-fish/style.css
+++ b/public/schooling-fish/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/slime-mold/index.html
+++ b/public/slime-mold/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Slime Mold | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/slime-mold/main.js
+++ b/public/slime-mold/main.js
@@ -1,0 +1,229 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 粘菌ネットワーク：化学物質勾配に従って移動するエージェントが
+// 粘菌のような自己組織化ネットワークを形成する。
+
+const params = {
+  agentCount: 1500, // エージェント数
+  sensorAngle: 45, // センサー角度（度）
+  sensorDist: 20, // センサー距離
+  turnSpeed: 0.35, // 旋回速度
+  trailDecay: 0.98, // トレイル減衰率
+  depositRate: 0.8, // 化学物質放出量
+  agentSpeed: 1.5, // エージェント速度
+  hueBase: 150, // 基本色相
+  hueVar: 80, // 色相ばらつき
+  trailBrightness: 65, // トレイル輝度
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+// 化学物質グリッド（低解像度）
+const SCALE = 3;
+let gridW = 0;
+let gridH = 0;
+/** @type {Float32Array} */
+let trail = new Float32Array(1);
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  gridW = Math.ceil(canvas.width / SCALE);
+  gridH = Math.ceil(canvas.height / SCALE);
+  trail = new Float32Array(gridW * gridH);
+  initAgents();
+}
+window.addEventListener('resize', resize);
+
+/** @typedef {{ x: number, y: number, angle: number, hue: number }} Agent */
+/** @type {Agent[]} */
+let agents = [];
+
+/**
+ * エージェントを初期化する（中心付近に配置）
+ */
+function initAgents() {
+  agents = [];
+  const w = canvas.width;
+  const h = canvas.height;
+  for (let i = 0; i < params.agentCount; i++) {
+    const a = Math.random() * Math.PI * 2;
+    const r = Math.random() * Math.min(w, h) * 0.3;
+    agents.push({
+      x: w / 2 + Math.cos(a) * r,
+      y: h / 2 + Math.sin(a) * r,
+      angle: a + Math.PI,
+      hue: params.hueBase + (Math.random() - 0.5) * params.hueVar,
+    });
+  }
+}
+
+resize();
+
+/**
+ * グリッド座標の化学物質量を取得する
+ * @param {number} gx
+ * @param {number} gy
+ * @returns {number}
+ */
+function sampleTrail(gx, gy) {
+  const x = Math.max(0, Math.min(gridW - 1, Math.round(gx)));
+  const y = Math.max(0, Math.min(gridH - 1, Math.round(gy)));
+  return trail[y * gridW + x];
+}
+
+/**
+ * エージェントを1ステップ更新する
+ * @param {Agent} agent
+ */
+function updateAgent(agent) {
+  const w = canvas.width;
+  const h = canvas.height;
+  const sa = (params.sensorAngle * Math.PI) / 180;
+  const sd = params.sensorDist;
+
+  // 前方・左・右のセンサー
+  const fl = agent.angle - sa;
+  const fr = agent.angle + sa;
+  const fa = agent.angle;
+
+  const sLeft = sampleTrail(
+    (agent.x + Math.cos(fl) * sd) / SCALE,
+    (agent.y + Math.sin(fl) * sd) / SCALE,
+  );
+  const sRight = sampleTrail(
+    (agent.x + Math.cos(fr) * sd) / SCALE,
+    (agent.y + Math.sin(fr) * sd) / SCALE,
+  );
+  const sForward = sampleTrail(
+    (agent.x + Math.cos(fa) * sd) / SCALE,
+    (agent.y + Math.sin(fa) * sd) / SCALE,
+  );
+
+  if (sForward > sLeft && sForward > sRight) {
+    // 前方が最強 → 直進
+  } else if (sLeft > sRight) {
+    agent.angle -= params.turnSpeed;
+  } else if (sRight > sLeft) {
+    agent.angle += params.turnSpeed;
+  } else {
+    agent.angle += (Math.random() - 0.5) * params.turnSpeed;
+  }
+
+  agent.x += Math.cos(agent.angle) * params.agentSpeed;
+  agent.y += Math.sin(agent.angle) * params.agentSpeed;
+
+  // 壁反射
+  if (agent.x < 0 || agent.x > w) {
+    agent.angle = Math.PI - agent.angle;
+    agent.x = Math.max(0, Math.min(w, agent.x));
+  }
+  if (agent.y < 0 || agent.y > h) {
+    agent.angle = -agent.angle;
+    agent.y = Math.max(0, Math.min(h, agent.y));
+  }
+
+  // 化学物質を放出
+  const gx = Math.floor(agent.x / SCALE);
+  const gy = Math.floor(agent.y / SCALE);
+  if (gx >= 0 && gx < gridW && gy >= 0 && gy < gridH) {
+    trail[gy * gridW + gx] = Math.min(
+      1,
+      trail[gy * gridW + gx] + params.depositRate * 0.05,
+    );
+  }
+}
+
+function draw() {
+  const w = canvas.width;
+  const h = canvas.height;
+
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.15)';
+  ctx.fillRect(0, 0, w, h);
+
+  // グリッドのトレイルを描画 & 減衰
+  for (let gy = 0; gy < gridH; gy++) {
+    for (let gx = 0; gx < gridW; gx++) {
+      const v = trail[gy * gridW + gx];
+      if (v > 0.02) {
+        const hue = params.hueBase;
+        ctx.fillStyle = `hsla(${hue}, 70%, ${params.trailBrightness}%, ${v * 0.8})`;
+        ctx.fillRect(gx * SCALE, gy * SCALE, SCALE, SCALE);
+        trail[gy * gridW + gx] *= params.trailDecay;
+      }
+    }
+  }
+
+  // エージェントを更新
+  for (const agent of agents) {
+    updateAgent(agent);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Slime Mold',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'agentCount', 200, 5000, 100).onChange(initAgents);
+gui.add(params, 'sensorAngle', 5, 90, 1);
+gui.add(params, 'sensorDist', 5, 50, 1);
+gui.add(params, 'turnSpeed', 0.05, 1.5, 0.01);
+gui.add(params, 'trailDecay', 0.9, 0.9999, 0.001);
+gui.add(params, 'depositRate', 0.1, 3, 0.05);
+gui.add(params, 'agentSpeed', 0.5, 5, 0.1);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'trailBrightness', 20, 90, 1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.sensorAngle = rand(10, 75, 1);
+  params.sensorDist = rand(8, 35, 1);
+  params.turnSpeed = rand(0.1, 1, 0.01);
+  params.trailDecay = rand(0.93, 0.999, 0.001);
+  params.depositRate = rand(0.2, 2, 0.05);
+  params.agentSpeed = rand(0.8, 4, 0.1);
+  params.hueBase = rand(0, 360, 1);
+  trail.fill(0);
+  initAgents();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  trail.fill(0);
+  initAgents();
+  gui.updateDisplay();
+});

--- a/public/slime-mold/style.css
+++ b/public/slime-mold/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/spectrogram-painter/index.html
+++ b/public/spectrogram-painter/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Spectrogram Painter | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/spectrogram-painter/main.js
+++ b/public/spectrogram-painter/main.js
@@ -1,0 +1,125 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  bands: 64, // 周波数帯の数
+  scrollSpeed: 1.4,
+  noiseAmount: 0.25,
+  tone1: 0.5, // トーン 1 ベース
+  tone2: 1.3,
+  tone3: 2.1,
+  wobble: 0.5, // 周波数の揺らぎ
+  hueBase: 200,
+  hueRange: 160,
+  gamma: 1.6,
+  decay: 0.04,
+  intensity: 1,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  // 既存画像を左へスクロール
+  const shift = Math.max(1, Math.round(params.scrollSpeed));
+  const img = ctx.getImageData(shift, 0, canvas.width - shift, canvas.height);
+  ctx.putImageData(img, 0, 0);
+  // 右端を黒で塗る
+  ctx.fillStyle = `rgba(11, 10, 7, ${0.6 + params.decay})`;
+  ctx.fillRect(canvas.width - shift, 0, shift, canvas.height);
+
+  // 新しい列（右端）にスペクトル縞を描画
+  const n = Math.round(params.bands);
+  const bandH = canvas.height / n;
+  for (let i = 0; i < n; i++) {
+    const f = (i + 0.5) / n;
+    const freq1 =
+      params.tone1 * (1 + Math.sin(time * 0.9 + f * 6) * params.wobble);
+    const freq2 =
+      params.tone2 * (1 + Math.cos(time * 1.3 + f * 4) * params.wobble);
+    const freq3 =
+      params.tone3 * (1 + Math.sin(time * 0.6 + f * 2) * params.wobble);
+    const formant =
+      Math.exp(-((f - 0.15) * (f - 0.15)) / 0.02) +
+      Math.exp(-((f - 0.4) * (f - 0.4)) / 0.05) * 0.8 +
+      Math.exp(-((f - 0.7) * (f - 0.7)) / 0.1) * 0.5;
+    const mod =
+      (Math.sin(time * freq1 * 4 + f * 20) * 0.5 + 0.5) *
+      (Math.sin(time * freq2 * 3 + f * 12) * 0.5 + 0.5) *
+      (Math.sin(time * freq3 * 2 + f * 6) * 0.5 + 0.5);
+    const noise = (Math.random() - 0.5) * params.noiseAmount;
+    let v = (formant * mod + noise) * params.intensity;
+    v = Math.max(0, Math.min(1, v));
+    v = v ** (1 / params.gamma);
+    const hue = params.hueBase + f * params.hueRange;
+    const a = v * 0.95;
+    ctx.fillStyle = `hsla(${hue}, 90%, ${20 + v * 60}%, ${a})`;
+    ctx.fillRect(canvas.width - shift, i * bandH, shift, bandH + 0.5);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Spectrogram Painter',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'bands', 16, 128, 1);
+gui.add(params, 'scrollSpeed', 0.5, 5, 0.1);
+gui.add(params, 'noiseAmount', 0, 1, 0.01);
+gui.add(params, 'tone1', 0.1, 3, 0.01);
+gui.add(params, 'tone2', 0.1, 3, 0.01);
+gui.add(params, 'tone3', 0.1, 3, 0.01);
+gui.add(params, 'wobble', 0, 1.5, 0.01);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'gamma', 0.5, 3, 0.05);
+gui.add(params, 'decay', 0, 0.3, 0.01);
+gui.add(params, 'intensity', 0.2, 2, 0.05);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.tone1 = rand(0.3, 1.5, 0.01);
+  params.tone2 = rand(0.5, 2, 0.01);
+  params.tone3 = rand(1, 2.5, 0.01);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(60, 240, 1);
+  params.wobble = rand(0.2, 0.9, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+});

--- a/public/spectrogram-painter/style.css
+++ b/public/spectrogram-painter/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/t-square-fractal/index.html
+++ b/public/t-square-fractal/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>T-Square Fractal | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/t-square-fractal/main.js
+++ b/public/t-square-fractal/main.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 7,
+  initialSize: 380,
+  ratio: 0.5,
+  hueStart: 200,
+  hueEnd: 40,
+  saturation: 70,
+  lightness: 55,
+  alpha: 0.9,
+  strokeAlpha: 0.4,
+  rotation: 0,
+  rotSpeed: 0.05,
+  shrink: 0,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 正方形を描き、各辺の中点にスケールした子正方形を配置
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} size
+ * @param {number} depth
+ */
+function tSquare(cx, cy, size, depth) {
+  if (depth <= 0 || size < 1) return;
+  const t = 1 - depth / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.fillStyle = `hsla(${hue}, ${params.saturation}%, ${params.lightness}%, ${params.alpha})`;
+  ctx.strokeStyle = `hsla(${hue}, 90%, 75%, ${params.strokeAlpha})`;
+  ctx.lineWidth = 0.8;
+  const half = size / 2;
+  ctx.fillRect(cx - half, cy - half, size, size);
+  ctx.strokeRect(cx - half, cy - half, size, size);
+
+  const child = size * params.ratio - params.shrink;
+  // 4 辺の中点に子正方形
+  tSquare(cx - half, cy, child, depth - 1); // 左
+  tSquare(cx + half, cy, child, depth - 1); // 右
+  tSquare(cx, cy - half, child, depth - 1); // 上
+  tSquare(cx, cy + half, child, depth - 1); // 下
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.18)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const ang = params.rotation + time * params.rotSpeed;
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(ang);
+  tSquare(0, 0, params.initialSize, Math.round(params.depth));
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'T-Square Fractal',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 1, 9, 1);
+gui.add(params, 'initialSize', 100, 600, 1);
+gui.add(params, 'ratio', 0.3, 0.6, 0.01);
+gui.add(params, 'shrink', 0, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 20, 80, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(5, 8, 1);
+  params.initialSize = rand(200, 500, 1);
+  params.ratio = rand(0.42, 0.55, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.saturation = rand(40, 90, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/t-square-fractal/style.css
+++ b/public/t-square-fractal/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/tornado-vortex/index.html
+++ b/public/tornado-vortex/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Tornado Vortex | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/tornado-vortex/main.js
+++ b/public/tornado-vortex/main.js
@@ -1,0 +1,184 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+// 竜巻の渦を模したパーティクルシステム。
+// 高さによって回転半径と速度が変化し、竜巻らしい形状を生成する。
+
+const params = {
+  count: 1200, // パーティクル数
+  height: 0.85, // 竜巻の高さ比率
+  baseRadius: 0.18, // 底部の半径比率
+  topRadius: 0.03, // 頂部の半径比率
+  rotSpeed: 1.8, // 回転速度
+  riseSpeed: 0.6, // 上昇速度
+  turbulence: 0.4, // 乱流強度
+  hueBase: 200, // 基本色相（青系）
+  hueRange: 60, // 色相の範囲
+  fadeAlpha: 0.15, // フェード強度
+  particleSize: 2.2, // パーティクルサイズ
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @typedef {{ x: number, y: number, z: number, angle: number, speed: number, hue: number }} Particle */
+
+/** @type {Particle[]} */
+let particles = [];
+
+/**
+ * パーティクルを初期化する
+ */
+function initParticles() {
+  particles = [];
+  for (let i = 0; i < params.count; i++) {
+    const z = Math.random(); // 0=底、1=上
+    const angle = Math.random() * Math.PI * 2;
+    const r = params.baseRadius + (params.topRadius - params.baseRadius) * z;
+    const noise = (Math.random() - 0.5) * 0.05;
+    particles.push({
+      x: Math.cos(angle) * (r + noise),
+      y: Math.sin(angle) * (r + noise),
+      z,
+      angle,
+      speed: 0.5 + Math.random() * 0.5,
+      hue: params.hueBase + Math.random() * params.hueRange,
+    });
+  }
+}
+
+initParticles();
+
+let time = 0;
+
+/**
+ * パーティクルを1ステップ更新する
+ * @param {Particle} p
+ */
+function updateParticle(p) {
+  // 高さに応じた回転半径（底が広く、上が狭い）
+  const r = params.baseRadius + (params.topRadius - params.baseRadius) * p.z;
+  // 高さに応じた角速度（上に行くほど速い）
+  const omega = params.rotSpeed * (0.5 + p.z) * p.speed;
+  p.angle += omega * 0.016;
+
+  // 乱流ノイズ
+  const nx = (Math.random() - 0.5) * params.turbulence * 0.01;
+  const ny = (Math.random() - 0.5) * params.turbulence * 0.01;
+
+  p.x = Math.cos(p.angle) * r + nx;
+  p.y = Math.sin(p.angle) * r + ny;
+
+  // 上昇
+  p.z += params.riseSpeed * 0.002 * p.speed;
+  if (p.z > 1) {
+    // 底からリセット
+    p.z = 0;
+    p.angle = Math.random() * Math.PI * 2;
+  }
+}
+
+function draw() {
+  time += 0.016;
+  const w = canvas.width;
+  const h = canvas.height;
+
+  // フェード
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, w, h);
+
+  const cx = w / 2;
+  const baseY = h * 0.9;
+  const tornadoH = h * params.height;
+
+  for (const p of particles) {
+    updateParticle(p);
+
+    // 3D -> 2D 投影
+    const screenX = cx + p.x * w;
+    const screenY = baseY - p.z * tornadoH;
+
+    // 高さに応じて明るさと透明度変化
+    const brightness = 45 + p.z * 35;
+    const alpha = 0.5 + p.z * 0.5;
+    ctx.fillStyle = `hsla(${p.hue}, 70%, ${brightness}%, ${alpha})`;
+    const size = params.particleSize * (0.5 + p.z * 0.8);
+    ctx.beginPath();
+    ctx.arc(screenX, screenY, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Tornado Vortex',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 200, 3000, 100).onChange(initParticles);
+gui.add(params, 'height', 0.3, 1.0, 0.01);
+gui.add(params, 'baseRadius', 0.05, 0.4, 0.01);
+gui.add(params, 'topRadius', 0.01, 0.15, 0.005);
+gui.add(params, 'rotSpeed', 0.2, 5.0, 0.1);
+gui.add(params, 'riseSpeed', 0.1, 2.0, 0.05);
+gui.add(params, 'turbulence', 0, 2.0, 0.05);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 180, 1);
+gui.add(params, 'fadeAlpha', 0.02, 0.5, 0.01);
+gui.add(params, 'particleSize', 0.5, 6, 0.1);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.rotSpeed = rand(0.5, 4.0, 0.1);
+  params.riseSpeed = rand(0.2, 1.5, 0.05);
+  params.turbulence = rand(0.1, 1.5, 0.05);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(20, 120, 1);
+  params.baseRadius = rand(0.08, 0.3, 0.01);
+  params.topRadius = rand(0.01, 0.08, 0.005);
+  params.particleSize = rand(0.8, 4.0, 0.1);
+  initParticles();
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  initParticles();
+  gui.updateDisplay();
+});

--- a/public/tornado-vortex/main.js
+++ b/public/tornado-vortex/main.js
@@ -62,8 +62,6 @@ function initParticles() {
 
 initParticles();
 
-let time = 0;
-
 /**
  * パーティクルを1ステップ更新する
  * @param {Particle} p
@@ -92,7 +90,6 @@ function updateParticle(p) {
 }
 
 function draw() {
-  time += 0.016;
   const w = canvas.width;
   const h = canvas.height;
 

--- a/public/tornado-vortex/style.css
+++ b/public/tornado-vortex/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/virus-capsid/index.html
+++ b/public/virus-capsid/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Virus Capsid | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/virus-capsid/main.js
+++ b/public/virus-capsid/main.js
@@ -1,0 +1,265 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 20 面体ウイルスカプシド。icosahedron の頂点を球面上に配置し、面を三角形パッチで描く。
+const params = {
+  subdivisions: 1, // 1=icosa, 2=geodesic, 3=高解像度
+  radius: 240,
+  rotX: 0.01,
+  rotY: 0.03,
+  rotZ: 0.005,
+  hueStart: 120,
+  hueRange: 100,
+  strokeAlpha: 0.7,
+  fillAlpha: 0.6,
+  spikeLength: 30,
+  spikeCount: 20,
+  trailFade: 0.15,
+  pulse: 0.12,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+// 正 20 面体の頂点・面を生成
+function makeIcosahedron() {
+  const t = (1 + Math.sqrt(5)) / 2;
+  const verts = [
+    [-1, t, 0],
+    [1, t, 0],
+    [-1, -t, 0],
+    [1, -t, 0],
+    [0, -1, t],
+    [0, 1, t],
+    [0, -1, -t],
+    [0, 1, -t],
+    [t, 0, -1],
+    [t, 0, 1],
+    [-t, 0, -1],
+    [-t, 0, 1],
+  ].map((v) => {
+    const len = Math.hypot(v[0], v[1], v[2]);
+    return [v[0] / len, v[1] / len, v[2] / len];
+  });
+  const faces = [
+    [0, 11, 5],
+    [0, 5, 1],
+    [0, 1, 7],
+    [0, 7, 10],
+    [0, 10, 11],
+    [1, 5, 9],
+    [5, 11, 4],
+    [11, 10, 2],
+    [10, 7, 6],
+    [7, 1, 8],
+    [3, 9, 4],
+    [3, 4, 2],
+    [3, 2, 6],
+    [3, 6, 8],
+    [3, 8, 9],
+    [4, 9, 5],
+    [2, 4, 11],
+    [6, 2, 10],
+    [8, 6, 7],
+    [9, 8, 1],
+  ];
+  return { verts, faces };
+}
+
+function subdivide(mesh, depth) {
+  for (let d = 0; d < depth; d++) {
+    const newFaces = [];
+    for (const [a, b, c] of mesh.faces) {
+      const ab = mid(mesh.verts[a], mesh.verts[b]);
+      const bc = mid(mesh.verts[b], mesh.verts[c]);
+      const ca = mid(mesh.verts[c], mesh.verts[a]);
+      const iab = mesh.verts.push(ab) - 1;
+      const ibc = mesh.verts.push(bc) - 1;
+      const ica = mesh.verts.push(ca) - 1;
+      newFaces.push([a, iab, ica]);
+      newFaces.push([b, ibc, iab]);
+      newFaces.push([c, ica, ibc]);
+      newFaces.push([iab, ibc, ica]);
+    }
+    mesh.faces = newFaces;
+  }
+  return mesh;
+}
+
+function mid(a, b) {
+  const m = [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+  const len = Math.hypot(m[0], m[1], m[2]);
+  return [m[0] / len, m[1] / len, m[2] / len];
+}
+
+let mesh = makeIcosahedron();
+let currentSub = 1;
+
+function rebuild() {
+  mesh = makeIcosahedron();
+  subdivide(mesh, Math.max(0, Math.round(params.subdivisions) - 1));
+  currentSub = Math.round(params.subdivisions);
+}
+rebuild();
+
+let rx = 0;
+let ry = 0;
+let rz = 0;
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  if (currentSub !== Math.round(params.subdivisions)) rebuild();
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  rx += params.rotX;
+  ry += params.rotY;
+  rz += params.rotZ;
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const R = params.radius * (1 + Math.sin(time * 2) * params.pulse);
+
+  // 回転行列を適用しつつスクリーン座標算出
+  const cosX = Math.cos(rx);
+  const sinX = Math.sin(rx);
+  const cosY = Math.cos(ry);
+  const sinY = Math.sin(ry);
+  const cosZ = Math.cos(rz);
+  const sinZ = Math.sin(rz);
+  const projected = mesh.verts.map((v) => {
+    let [x, y, z] = v;
+    // X
+    let ny = y * cosX - z * sinX;
+    let nz = y * sinX + z * cosX;
+    y = ny;
+    z = nz;
+    // Y
+    let nx = x * cosY + z * sinY;
+    nz = -x * sinY + z * cosY;
+    x = nx;
+    z = nz;
+    // Z
+    nx = x * cosZ - y * sinZ;
+    ny = x * sinZ + y * cosZ;
+    x = nx;
+    y = ny;
+    const persp = 600 / (600 + z * R);
+    return { x: cx + x * R * persp, y: cy + y * R * persp, z, depth: z };
+  });
+
+  // 面を z ソート
+  const faceOrder = mesh.faces.map((f, idx) => ({
+    f,
+    idx,
+    z: (projected[f[0]].z + projected[f[1]].z + projected[f[2]].z) / 3,
+  }));
+  faceOrder.sort((a, b) => a.z - b.z);
+
+  for (const { f, z } of faceOrder) {
+    const [a, b, c] = f;
+    const p1 = projected[a];
+    const p2 = projected[b];
+    const p3 = projected[c];
+    const light = (1 - z) * 0.5;
+    const hue = params.hueStart + light * params.hueRange;
+    ctx.fillStyle = `hsla(${hue}, 80%, ${30 + light * 40}%, ${params.fillAlpha})`;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 80%, ${params.strokeAlpha})`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(p1.x, p1.y);
+    ctx.lineTo(p2.x, p2.y);
+    ctx.lineTo(p3.x, p3.y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  }
+
+  // スパイク（外側の棘）
+  const spikeIndices = [];
+  const sc = Math.round(params.spikeCount);
+  for (let i = 0; i < sc; i++) {
+    spikeIndices.push(Math.floor((i * mesh.verts.length) / sc));
+  }
+  for (const idx of spikeIndices) {
+    const p = projected[idx];
+    const outer = {
+      x: cx + ((p.x - cx) / R) * (R + params.spikeLength),
+      y: cy + ((p.y - cy) / R) * (R + params.spikeLength),
+    };
+    const hue = params.hueStart + params.hueRange * 0.5;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 70%, 0.8)`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(outer.x, outer.y);
+    ctx.stroke();
+    ctx.fillStyle = `hsla(${hue}, 100%, 80%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(outer.x, outer.y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Virus Capsid',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'subdivisions', 1, 4, 1);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'rotX', -0.05, 0.05, 0.001);
+gui.add(params, 'rotY', -0.05, 0.05, 0.001);
+gui.add(params, 'rotZ', -0.05, 0.05, 0.001);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'fillAlpha', 0.1, 1, 0.01);
+gui.add(params, 'spikeLength', 0, 60, 1);
+gui.add(params, 'spikeCount', 0, 40, 1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'pulse', 0, 0.3, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.subdivisions = rand(1, 3, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(30, 200, 1);
+  params.rotX = rand(-0.03, 0.03, 0.001);
+  params.rotY = rand(-0.03, 0.03, 0.001);
+  params.rotZ = rand(-0.03, 0.03, 0.001);
+  params.spikeLength = rand(15, 45, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/virus-capsid/style.css
+++ b/public/virus-capsid/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

Issue #153 のサブ issue から 30 件分のページを追加。

## Closes

Closes #98
Closes #111
Closes #112
Closes #113
Closes #114
Closes #115
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #125
Closes #128
Closes #129
Closes #130
Closes #131
Closes #132
Closes #133
Closes #134
Closes #135
Closes #136
Closes #137
Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
Closes #144
Closes #145

## Test plan

- [ ] 各ページが開ける
- [ ] TileUI コントロールが動作する
- [ ] Random / Reset が動作する