### PR TITLE
feat: TileUI ジェネラティブアートページを 30 件追加 (v3)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@
 | `/gosper-island/` | Gosper Island（ゴスパー島） |
 | `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
 | `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
+| `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,6 +135,7 @@
 | `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
 | `/leaf-venation/` | Leaf Venation（葉脈形成） |
 | `/coral-growth/` | Coral Growth（サンゴの成長） |
+| `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,6 +130,7 @@
 | `/beat-interference/` | Beat Interference（ビート干渉） |
 | `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
 | `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
+| `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,7 @@
 | `/dna-helix/` | DNA Helix（DNAヘリックス） |
 | `/cell-division/` | Cell Division（細胞分裂） |
 | `/virus-capsid/` | Virus Capsid（ウイルスカプシド） |
+| `/chromatic-aberration/` | Chromatic Aberration（色収差） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,7 @@
 | `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
 | `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
 | `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
+| `/beat-interference/` | Beat Interference（ビート干渉） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -131,6 +131,7 @@
 | `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
 | `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
 | `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
+| `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@
 | `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
 | `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
 | `/leaf-venation/` | Leaf Venation（葉脈形成） |
+| `/coral-growth/` | Coral Growth（サンゴの成長） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,7 @@
 | `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
 | `/dna-helix/` | DNA Helix（DNAヘリックス） |
 | `/cell-division/` | Cell Division（細胞分裂） |
+| `/virus-capsid/` | Virus Capsid（ウイルスカプシド） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,6 +125,7 @@
 | `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
 | `/chord-wheel/` | Chord Wheel（コードホイール） |
 | `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
+| `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,6 +117,7 @@
 | `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
 | `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
 | `/gosper-island/` | Gosper Island（ゴスパー島） |
+| `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,6 +118,7 @@
 | `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
 | `/gosper-island/` | Gosper Island（ゴスパー島） |
 | `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
+| `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,6 +136,7 @@
 | `/leaf-venation/` | Leaf Venation（葉脈形成） |
 | `/coral-growth/` | Coral Growth（サンゴの成長） |
 | `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
+| `/dna-helix/` | DNA Helix（DNAヘリックス） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,7 @@
 | `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
 | `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
 | `/h-tree/` | H Tree（H木フラクタル） |
+| `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,6 +120,7 @@
 | `/menger-slice/` | Menger Slice（メンガースポンジ断面） |
 | `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
 | `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
+| `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,7 @@
 | `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
 | `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
 | `/beat-interference/` | Beat Interference（ビート干渉） |
+| `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,6 +129,7 @@
 | `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
 | `/beat-interference/` | Beat Interference（ビート干渉） |
 | `/risset-rhythm/` | Risset Rhythm（リセのリズム） |
+| `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,6 +140,7 @@
 | `/cell-division/` | Cell Division（細胞分裂） |
 | `/virus-capsid/` | Virus Capsid（ウイルスカプシド） |
 | `/chromatic-aberration/` | Chromatic Aberration（色収差） |
+| `/diffraction-grating/` | Diffraction Grating（回折格子） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,6 +132,7 @@
 | `/reaction-diffusion/` | Reaction Diffusion（反応拡散系） |
 | `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
 | `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
+| `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,7 @@
 | `/spectrogram-painter/` | Spectrogram Painter（スペクトログラム描画） |
 | `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
 | `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
+| `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -116,6 +116,7 @@
 | `/h-tree/` | H Tree（H木フラクタル） |
 | `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
 | `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
+| `/gosper-island/` | Gosper Island（ゴスパー島） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,6 +122,7 @@
 | `/circular-sequencer/` | Circular Sequencer（円形シーケンサー） |
 | `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
 | `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
+| `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -124,6 +124,7 @@
 | `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
 | `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
 | `/chord-wheel/` | Chord Wheel（コードホイール） |
+| `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,7 @@
 | `/burning-ship/` | Burning Ship（燃える船フラクタル） |
 | `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
 | `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
+| `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@
 | `/mandelbrot-zoom/` | Mandelbrot Zoom（マンデルブロ集合ズーム） |
 | `/burning-ship/` | Burning Ship（燃える船フラクタル） |
 | `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
+| `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,7 @@
 | `/chord-wheel/` | Chord Wheel（コードホイール） |
 | `/fm-synthesis-visualizer/` | FM Synthesis Visualizer（FM 合成ビジュアライザ） |
 | `/karplus-strong-strings/` | Karplus-Strong Strings（カープラス・ストロング弦） |
+| `/granular-cloud/` | Granular Cloud（グラニュラークラウド） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,7 @@
 | `/newton-fractal/` | Newton Fractal（ニュートン法フラクタル） |
 | `/barnsley-fern/` | Barnsley Fern（バーンズリーのシダ） |
 | `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
+| `/h-tree/` | H Tree（H木フラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,7 @@
 | `/phase-shift-metronome/` | Phase Shift Metronome（位相シフトメトロノーム） |
 | `/euclidean-rhythm/` | Euclidean Rhythm（ユークリッドリズム） |
 | `/polyrhythm-wheel/` | Polyrhythm Wheel（ポリリズム円盤） |
+| `/chord-wheel/` | Chord Wheel（コードホイール） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,6 +133,7 @@
 | `/gray-scott-model/` | Gray-Scott Model（Gray-Scott モデル） |
 | `/genetic-creatures/` | Genetic Creatures（遺伝的生物） |
 | `/neural-network-viz/` | Neural Network Viz（ニューラルネット可視化） |
+| `/leaf-venation/` | Leaf Venation（葉脈形成） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,6 +115,7 @@
 | `/apollonian-gasket/` | Apollonian Gasket（アポロニウスのガスケット） |
 | `/h-tree/` | H Tree（H木フラクタル） |
 | `/pythagoras-tree/` | Pythagoras Tree（ピタゴラスの木） |
+| `/t-square-fractal/` | T-Square Fractal（T-スクエアフラクタル） |
 
 ## トップページ仕様
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,7 @@
 | `/coral-growth/` | Coral Growth（サンゴの成長） |
 | `/mycelium-network/` | Mycelium Network（菌糸ネットワーク） |
 | `/dna-helix/` | DNA Helix（DNAヘリックス） |
+| `/cell-division/` | Cell Division（細胞分裂） |
 
 ## トップページ仕様
 

--- a/public/apollonian-gasket/index.html
+++ b/public/apollonian-gasket/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Apollonian Gasket | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/apollonian-gasket/main.js
+++ b/public/apollonian-gasket/main.js
@@ -1,0 +1,182 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  maxDepth: 6, // 再帰深さ
+  outerScale: 0.42, // 外接円の半径（画面に対する比）
+  strokeAlpha: 0.85, // 線の不透明度
+  fillAlpha: 0.12, // 塗りの不透明度
+  hueStart: 30,
+  hueRange: 200,
+  thickness: 1.4,
+  rotation: 0,
+  rotSpeed: 0.05,
+  innerRatio: 1, // 内部 3 円の配置係数
+  showInner: true,
+  zoom: 1,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 3 円に内接する円を求める（デカルトの円定理）
+ * @param {{x:number,y:number,r:number}} a
+ * @param {{x:number,y:number,r:number}} b
+ * @param {{x:number,y:number,r:number}} c
+ * @returns {{x:number,y:number,r:number}|null}
+ */
+function innerCircle(a, b, c) {
+  const ka = 1 / a.r;
+  const kb = 1 / b.r;
+  const kc = 1 / c.r;
+  const k4 = ka + kb + kc + 2 * Math.sqrt(ka * kb + kb * kc + kc * ka);
+  const r = 1 / k4;
+  // 中心をラプラス的重み付き平均で近似
+  const za = { x: a.x, y: a.y };
+  const zb = { x: b.x, y: b.y };
+  const zc = { x: c.x, y: c.y };
+  const wa = ka;
+  const wb = kb;
+  const wc = kc;
+  const ws = wa + wb + wc;
+  const cx = (za.x * wa + zb.x * wb + zc.x * wc) / ws;
+  const cy = (za.y * wa + zb.y * wb + zc.y * wc) / ws;
+  // 近似した中心から 3 円への距離を元に微調整
+  const dx = cx - a.x;
+  const dy = cy - a.y;
+  const dist = Math.hypot(dx, dy);
+  if (dist === 0) return null;
+  const nx = a.x + (dx / dist) * (a.r - r);
+  const ny = a.y + (dy / dist) * (a.r - r);
+  return { x: nx, y: ny, r };
+}
+
+/**
+ * @param {{x:number,y:number,r:number}} c
+ * @param {number} hue
+ */
+function drawCircle(c, hue) {
+  if (c.r < 0.5) return;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.strokeAlpha})`;
+  ctx.fillStyle = `hsla(${hue}, 70%, 50%, ${params.fillAlpha})`;
+  ctx.lineWidth = params.thickness;
+  ctx.beginPath();
+  ctx.arc(c.x, c.y, c.r, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+}
+
+/**
+ * @param {{x:number,y:number,r:number}} a
+ * @param {{x:number,y:number,r:number}} b
+ * @param {{x:number,y:number,r:number}} c
+ * @param {number} depth
+ */
+function recurse(a, b, c, depth) {
+  if (depth <= 0) return;
+  const inner = innerCircle(a, b, c);
+  if (!inner || inner.r < 1) return;
+  const hue =
+    (params.hueStart + (params.maxDepth - depth) * params.hueRange) % 360;
+  drawCircle(inner, hue);
+  recurse(a, b, inner, depth - 1);
+  recurse(b, c, inner, depth - 1);
+  recurse(a, c, inner, depth - 1);
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.15)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const R =
+    Math.min(canvas.width, canvas.height) * params.outerScale * params.zoom;
+  const ang = params.rotation + time * params.rotSpeed;
+
+  const outer = { x: cx, y: cy, r: R };
+  drawCircle(outer, params.hueStart);
+
+  // 外側の円の内部に 3 つの等しい円（三つ葉配置）
+  const r3 = (R / (2 + 2 / Math.sqrt(3))) * params.innerRatio;
+  const d = R - r3;
+  /** @type {{x:number,y:number,r:number}[]} */
+  const inner3 = [];
+  for (let i = 0; i < 3; i++) {
+    const a = ang + (i * 2 * Math.PI) / 3;
+    inner3.push({ x: cx + Math.cos(a) * d, y: cy + Math.sin(a) * d, r: r3 });
+  }
+  if (params.showInner) {
+    for (let i = 0; i < 3; i++) {
+      drawCircle(inner3[i], params.hueStart + 30 + i * 20);
+    }
+  }
+
+  // 外接円と内側 2 円で再帰（境界は半径が負の円として扱うと正確だが、ここでは簡易近似）
+  recurse(inner3[0], inner3[1], inner3[2], params.maxDepth);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Apollonian Gasket',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'maxDepth', 1, 8, 1);
+gui.add(params, 'outerScale', 0.2, 0.55, 0.01);
+gui.add(params, 'innerRatio', 0.8, 1.1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'fillAlpha', 0, 0.5, 0.01);
+gui.add(params, 'thickness', 0.2, 4, 0.1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -1, 1, 0.01);
+gui.add(params, 'zoom', 0.5, 1.5, 0.01);
+gui.add(params, 'showInner');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.maxDepth = rand(4, 7, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(30, 240, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  params.innerRatio = rand(0.9, 1.05, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/apollonian-gasket/style.css
+++ b/public/apollonian-gasket/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/barnsley-fern/index.html
+++ b/public/barnsley-fern/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Barnsley Fern | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/barnsley-fern/main.js
+++ b/public/barnsley-fern/main.js
@@ -1,0 +1,160 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// --- パラメータ ---
+
+const params = {
+  pointsPerFrame: 2000, // 1 フレームで描く点の数
+  scale: 60, // 拡大率
+  offsetX: 0, // 水平オフセット
+  offsetY: 0.05, // 垂直オフセット（下寄せ）
+  hueBase: 120, // 色相ベース
+  hueRange: 40, // 色相レンジ
+  saturation: 70, // 彩度
+  pointAlpha: 0.35, // 点の不透明度
+  pointSize: 0.8, // 点サイズ
+  fadeAlpha: 0.02, // 残像フェード
+  probF2: 85, // 主葉の確率（%）
+  variation: 0, // ゆらぎ（0:標準 Barnsley / 1〜: アレンジ）
+};
+
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+// --- 状態 ---
+
+let px = 0;
+let py = 0;
+let count = 0;
+
+function reset() {
+  px = 0;
+  py = 0;
+  count = 0;
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+// --- 反復関数系（バーンズリー） ---
+
+function step() {
+  const r = Math.random() * 100;
+  const v = params.variation * 0.02;
+  let nx;
+  let ny;
+  const p1 = 1;
+  const p2 = params.probF2;
+  const p3 = (100 - p2) / 2 + p2;
+  if (r < p1) {
+    nx = 0;
+    ny = 0.16 * py;
+  } else if (r < p2) {
+    nx = (0.85 + v) * px + 0.04 * py;
+    ny = -0.04 * px + (0.85 - v) * py + 1.6;
+  } else if (r < p3) {
+    nx = 0.2 * px - 0.26 * py;
+    ny = 0.23 * px + 0.22 * py + 1.6;
+  } else {
+    nx = -0.15 * px + 0.28 * py;
+    ny = 0.26 * px + 0.24 * py + 0.44;
+  }
+  px = nx;
+  py = ny;
+}
+
+function draw() {
+  // 残像フェード
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width * (0.5 + params.offsetX);
+  const cy = canvas.height * (1 - params.offsetY);
+  const s = params.scale;
+
+  for (let i = 0; i < params.pointsPerFrame; i++) {
+    step();
+    const sx = cx + px * s;
+    const sy = cy - py * s;
+    const hue = params.hueBase + Math.sin(count * 0.0001) * params.hueRange;
+    ctx.fillStyle = `hsla(${hue}, ${params.saturation}%, 55%, ${params.pointAlpha})`;
+    ctx.fillRect(sx, sy, params.pointSize, params.pointSize);
+    count++;
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+
+tick();
+
+// --- GUI ---
+
+const gui = new TileUI({
+  title: 'Barnsley Fern',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'pointsPerFrame', 200, 8000, 100);
+gui.add(params, 'scale', 20, 140, 1);
+gui.add(params, 'offsetX', -0.4, 0.4, 0.01);
+gui.add(params, 'offsetY', -0.2, 0.3, 0.01);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 120, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'pointAlpha', 0.05, 1, 0.01);
+gui.add(params, 'pointSize', 0.3, 3, 0.1);
+gui.add(params, 'fadeAlpha', 0, 0.1, 0.005);
+gui.add(params, 'probF2', 60, 95, 1);
+gui.add(params, 'variation', 0, 3, 0.01);
+
+/**
+ * @param {number} min
+ * @param {number} max
+ * @param {number} step
+ */
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.scale = rand(40, 110, 1);
+  params.hueBase = rand(60, 200, 1);
+  params.hueRange = rand(10, 80, 1);
+  params.saturation = rand(40, 90, 1);
+  params.pointAlpha = rand(0.2, 0.6, 0.01);
+  params.probF2 = rand(70, 90, 1);
+  params.variation = rand(0, 2, 0.01);
+  gui.updateDisplay();
+  reset();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+  reset();
+});

--- a/public/barnsley-fern/style.css
+++ b/public/barnsley-fern/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/beat-interference/index.html
+++ b/public/beat-interference/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Beat Interference | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/beat-interference/main.js
+++ b/public/beat-interference/main.js
@@ -1,0 +1,166 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 周波数の近い 2 つのサイン波の重ね合わせでうなり（beat）を視覚化
+const params = {
+  freqA: 4,
+  freqB: 4.3,
+  freqC: 0,
+  amplitudeA: 80,
+  amplitudeB: 80,
+  amplitudeC: 0,
+  waveSpeed: 1.2,
+  lineDensity: 3, // 1px あたりのサンプル数
+  hueA: 200,
+  hueB: 40,
+  hueC: 280,
+  sumHue: 120,
+  glow: 0.7,
+  showEnvelope: true,
+  lineWidth: 1.2,
+  trailFade: 0.15,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function waveY(phase, freq, amp) {
+  return Math.sin(phase * freq) * amp;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const W = canvas.width;
+  const H = canvas.height;
+  const baseY = H * 0.3;
+  const midY = H * 0.62;
+
+  const xs = Math.max(1, Math.round(params.lineDensity));
+  // 各波を上に並べる
+  const waves = [
+    { f: params.freqA, a: params.amplitudeA, hue: params.hueA, y: baseY },
+    { f: params.freqB, a: params.amplitudeB, hue: params.hueB, y: baseY + 100 },
+    { f: params.freqC, a: params.amplitudeC, hue: params.hueC, y: baseY + 200 },
+  ];
+  for (const w of waves) {
+    ctx.strokeStyle = `hsla(${w.hue}, 80%, 65%, 0.85)`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += xs) {
+      const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+      const y = w.y + waveY(phase, w.f, w.a);
+      if (x === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+
+  // 合成波（+エンベロープ）
+  ctx.strokeStyle = `hsla(${params.sumHue}, 90%, 70%, ${params.glow})`;
+  ctx.lineWidth = params.lineWidth + 0.6;
+  ctx.beginPath();
+  for (let x = 0; x <= W; x += xs) {
+    const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+    const y =
+      midY +
+      waveY(phase, params.freqA, params.amplitudeA) +
+      waveY(phase, params.freqB, params.amplitudeB) +
+      waveY(phase, params.freqC, params.amplitudeC);
+    if (x === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // エンベロープ
+  if (params.showEnvelope) {
+    const beatFreq = Math.abs(params.freqA - params.freqB);
+    const beatAmp = Math.min(params.amplitudeA, params.amplitudeB) * 2;
+    ctx.strokeStyle = `hsla(${params.sumHue + 30}, 90%, 80%, 0.5)`;
+    ctx.setLineDash([4, 4]);
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += xs) {
+      const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+      const env = beatAmp * Math.abs(Math.cos(phase * beatFreq * 0.5));
+      if (x === 0) {
+        ctx.moveTo(x, midY + env);
+      } else ctx.lineTo(x, midY + env);
+    }
+    ctx.stroke();
+    ctx.beginPath();
+    for (let x = 0; x <= W; x += xs) {
+      const phase = (x / W) * Math.PI * 2 + time * params.waveSpeed;
+      const env = beatAmp * Math.abs(Math.cos(phase * beatFreq * 0.5));
+      if (x === 0) ctx.moveTo(x, midY - env);
+      else ctx.lineTo(x, midY - env);
+    }
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Beat Interference',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'freqA', 0.5, 20, 0.05);
+gui.add(params, 'freqB', 0.5, 20, 0.05);
+gui.add(params, 'freqC', 0, 20, 0.05);
+gui.add(params, 'amplitudeA', 10, 200, 1);
+gui.add(params, 'amplitudeB', 10, 200, 1);
+gui.add(params, 'amplitudeC', 0, 200, 1);
+gui.add(params, 'waveSpeed', 0, 3, 0.01);
+gui.add(params, 'hueA', 0, 360, 1);
+gui.add(params, 'hueB', 0, 360, 1);
+gui.add(params, 'hueC', 0, 360, 1);
+gui.add(params, 'sumHue', 0, 360, 1);
+gui.add(params, 'glow', 0.2, 1, 0.01);
+gui.add(params, 'showEnvelope');
+gui.add(params, 'lineWidth', 0.3, 3, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.5, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  const f = rand(2, 8, 0.05);
+  params.freqA = f;
+  params.freqB = f + rand(-0.5, 0.5, 0.01);
+  params.freqC = f * 2 + rand(-0.3, 0.3, 0.01);
+  params.hueA = rand(0, 360, 1);
+  params.hueB = (params.hueA + 180) % 360;
+  params.hueC = rand(0, 360, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/beat-interference/style.css
+++ b/public/beat-interference/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/cell-division/index.html
+++ b/public/cell-division/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Cell Division | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/cell-division/main.js
+++ b/public/cell-division/main.js
@@ -1,0 +1,215 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 細胞分裂アニメーション: 一定時間ごとに分裂して増え、重なり合う。
+const params = {
+  divisionInterval: 3.5,
+  maxCells: 200,
+  startRadius: 28,
+  shrinkPerGeneration: 0.85,
+  drift: 10,
+  wobble: 0.4,
+  hueStart: 280,
+  hueRange: 200,
+  fillAlpha: 0.5,
+  strokeAlpha: 0.8,
+  trailFade: 0.1,
+  autoReset: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Cell
+ * @property {number} x
+ * @property {number} y
+ * @property {number} r
+ * @property {number} vx
+ * @property {number} vy
+ * @property {number} gen
+ * @property {number} phase // 0..1  分裂アニメ進捗
+ * @property {boolean} dividing
+ * @property {number} hue
+ */
+
+/** @type {Cell[]} */
+let cells = [];
+let time = 0;
+let lastDivision = 0;
+
+function reset() {
+  cells = [
+    {
+      x: canvas.width / 2,
+      y: canvas.height / 2,
+      r: params.startRadius,
+      vx: 0,
+      vy: 0,
+      gen: 0,
+      phase: 0,
+      dividing: false,
+      hue: params.hueStart,
+    },
+  ];
+}
+reset();
+
+function divide() {
+  /** @type {Cell[]} */
+  const next = [];
+  for (const c of cells) {
+    if (cells.length + next.length >= params.maxCells) {
+      next.push(c);
+      continue;
+    }
+    const a = Math.random() * Math.PI * 2;
+    const sep = c.r * 1.1;
+    const newR = c.r * params.shrinkPerGeneration;
+    const newHue = c.hue + (Math.random() - 0.5) * 30;
+    next.push({
+      x: c.x + Math.cos(a) * sep,
+      y: c.y + Math.sin(a) * sep,
+      r: newR,
+      vx: c.vx + Math.cos(a) * params.drift,
+      vy: c.vy + Math.sin(a) * params.drift,
+      gen: c.gen + 1,
+      phase: 0,
+      dividing: false,
+      hue: newHue,
+    });
+    next.push({
+      x: c.x - Math.cos(a) * sep,
+      y: c.y - Math.sin(a) * sep,
+      r: newR,
+      vx: c.vx - Math.cos(a) * params.drift,
+      vy: c.vy - Math.sin(a) * params.drift,
+      gen: c.gen + 1,
+      phase: 0,
+      dividing: false,
+      hue: newHue + params.hueRange / 6,
+    });
+  }
+  cells = next;
+}
+
+function draw() {
+  const dt = 1 / 60;
+  time += dt;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (time - lastDivision > params.divisionInterval) {
+    lastDivision = time;
+    if (cells.length < params.maxCells) divide();
+    else if (params.autoReset) reset();
+  }
+
+  for (const c of cells) {
+    // 移動
+    c.x += c.vx * dt;
+    c.y += c.vy * dt;
+    c.vx *= 0.985;
+    c.vy *= 0.985;
+    // 壁
+    if (c.x < c.r) {
+      c.x = c.r;
+      c.vx = Math.abs(c.vx);
+    }
+    if (c.x > canvas.width - c.r) {
+      c.x = canvas.width - c.r;
+      c.vx = -Math.abs(c.vx);
+    }
+    if (c.y < c.r) {
+      c.y = c.r;
+      c.vy = Math.abs(c.vy);
+    }
+    if (c.y > canvas.height - c.r) {
+      c.y = canvas.height - c.r;
+      c.vy = -Math.abs(c.vy);
+    }
+    const wob = Math.sin(time * 3 + c.x * 0.01) * params.wobble;
+    ctx.fillStyle = `hsla(${c.hue}, 80%, 60%, ${params.fillAlpha})`;
+    ctx.strokeStyle = `hsla(${c.hue}, 90%, 80%, ${params.strokeAlpha})`;
+    ctx.lineWidth = 1.4;
+    ctx.beginPath();
+    const segs = 24;
+    for (let i = 0; i <= segs; i++) {
+      const a = (i / segs) * Math.PI * 2;
+      const r = c.r * (1 + Math.sin(a * 3 + time * 2) * wob * 0.15);
+      const px = c.x + Math.cos(a) * r;
+      const py = c.y + Math.sin(a) * r;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+    // 核
+    ctx.fillStyle = `hsla(${c.hue}, 95%, 75%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(c.x, c.y, c.r * 0.2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Cell Division',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'divisionInterval', 1, 10, 0.1);
+gui.add(params, 'maxCells', 20, 400, 5);
+gui.add(params, 'startRadius', 10, 60, 1);
+gui.add(params, 'shrinkPerGeneration', 0.6, 1, 0.01);
+gui.add(params, 'drift', 0, 40, 0.5);
+gui.add(params, 'wobble', 0, 1, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'fillAlpha', 0.1, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'autoReset');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Divide', () => divide());
+gui.addButton('Random', () => {
+  params.divisionInterval = rand(2, 6, 0.1);
+  params.shrinkPerGeneration = rand(0.78, 0.95, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.drift = rand(5, 25, 0.5);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/cell-division/style.css
+++ b/public/cell-division/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/chord-wheel/index.html
+++ b/public/chord-wheel/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Chord Wheel | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/chord-wheel/main.js
+++ b/public/chord-wheel/main.js
@@ -1,0 +1,193 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 五度圏の上で和音構成音を結んで表示する。自動ルート遷移で和音が変化していく。
+const params = {
+  root: 0, // 0-11 (C,G,D,...の五度圏順)
+  chordType: 0, // 0:major 1:minor 2:dim 3:aug 4:sus4 5:maj7 6:7 7:m7
+  autoChange: true,
+  speed: 0.4,
+  radius: 280,
+  hueStart: 0,
+  hueRange: 360,
+  lineAlpha: 0.8,
+  fillAlpha: 0.18,
+  lineWidth: 2.2,
+  trailFade: 0.1,
+  bloom: 0.7,
+};
+const defaults = { ...params };
+
+const circleOfFifths = [
+  'C',
+  'G',
+  'D',
+  'A',
+  'E',
+  'B',
+  'F#',
+  'C#',
+  'G#',
+  'D#',
+  'A#',
+  'F',
+];
+const chordDefs = [
+  { name: 'maj', intervals: [0, 4, 7] },
+  { name: 'min', intervals: [0, 3, 7] },
+  { name: 'dim', intervals: [0, 3, 6] },
+  { name: 'aug', intervals: [0, 4, 8] },
+  { name: 'sus4', intervals: [0, 5, 7] },
+  { name: 'maj7', intervals: [0, 4, 7, 11] },
+  { name: '7', intervals: [0, 4, 7, 10] },
+  { name: 'm7', intervals: [0, 3, 7, 10] },
+];
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function chromaticToFifthIndex(chromatic) {
+  // 半音番号 0..11 を五度圏位置に変換
+  return (chromatic * 7) % 12;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  if (params.autoChange) {
+    const beat = Math.floor(time * params.speed);
+    params.root = beat % 12;
+    if (beat % 4 === 0)
+      params.chordType = Math.floor(beat / 4) % chordDefs.length;
+  }
+
+  const root = Math.round(params.root);
+  const cType = Math.round(params.chordType) % chordDefs.length;
+  const chord = chordDefs[cType];
+
+  // 五度圏 12 点
+  for (let i = 0; i < 12; i++) {
+    const a = -Math.PI / 2 + (i / 12) * Math.PI * 2;
+    const x = cx + Math.cos(a) * params.radius;
+    const y = cy + Math.sin(a) * params.radius;
+    const hue = params.hueStart + (i / 12) * params.hueRange;
+    ctx.fillStyle = `hsla(${hue}, 70%, 55%, 0.6)`;
+    ctx.beginPath();
+    ctx.arc(x, y, 8, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = 'rgba(230,230,230,0.9)';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(circleOfFifths[i], x, y - 22);
+  }
+
+  // 和音構成音を結ぶ
+  const notes = chord.intervals.map((iv) => (root + iv) % 12);
+  const positions = notes.map((n) => {
+    const fIdx = chromaticToFifthIndex(n);
+    const a = -Math.PI / 2 + (fIdx / 12) * Math.PI * 2;
+    return {
+      x: cx + Math.cos(a) * params.radius,
+      y: cy + Math.sin(a) * params.radius,
+    };
+  });
+
+  // 塗り
+  const rootHue =
+    params.hueStart + (chromaticToFifthIndex(root) / 12) * params.hueRange;
+  ctx.fillStyle = `hsla(${rootHue}, 80%, 55%, ${params.fillAlpha})`;
+  ctx.beginPath();
+  ctx.moveTo(positions[0].x, positions[0].y);
+  for (let i = 1; i < positions.length; i++)
+    ctx.lineTo(positions[i].x, positions[i].y);
+  ctx.closePath();
+  ctx.fill();
+
+  // 線
+  ctx.strokeStyle = `hsla(${rootHue}, 90%, 70%, ${params.lineAlpha})`;
+  ctx.lineWidth = params.lineWidth;
+  ctx.stroke();
+
+  // 構成音マーク
+  for (const p of positions) {
+    ctx.fillStyle = `hsla(${rootHue}, 100%, 80%, ${params.bloom})`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 12, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = `hsla(${rootHue}, 100%, 90%, 1)`;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // ラベル
+  ctx.fillStyle = 'rgba(230,230,230,0.9)';
+  ctx.font = '24px sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const rootName = circleOfFifths[chromaticToFifthIndex(root)];
+  ctx.fillText(`${rootName}${chord.name}`, cx, cy);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Chord Wheel',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'root', 0, 11, 1);
+gui.add(params, 'chordType', 0, 7, 1);
+gui.add(params, 'autoChange');
+gui.add(params, 'speed', 0.1, 2, 0.01);
+gui.add(params, 'radius', 150, 400, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'lineAlpha', 0.1, 1, 0.01);
+gui.add(params, 'fillAlpha', 0, 0.5, 0.01);
+gui.add(params, 'lineWidth', 0.5, 5, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'bloom', 0, 1, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.speed = rand(0.2, 1.2, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(120, 360, 1);
+  params.autoChange = true;
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/chord-wheel/style.css
+++ b/public/chord-wheel/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/chromatic-aberration/index.html
+++ b/public/chromatic-aberration/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Chromatic Aberration | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/chromatic-aberration/main.js
+++ b/public/chromatic-aberration/main.js
@@ -1,0 +1,148 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 色収差エフェクト。複数の図形の R/G/B チャンネルを左右にずらして描画することで色が分離。
+const params = {
+  aberration: 14,
+  shapeCount: 5,
+  shapeSize: 180,
+  rotationSpeed: 0.2,
+  waveSpeed: 1.1,
+  blurLayers: 3,
+  redShiftX: -1,
+  redShiftY: 0.2,
+  greenShiftX: 0,
+  greenShiftY: -0.2,
+  blueShiftX: 1,
+  blueShiftY: 0.2,
+  trailFade: 0.12,
+  lineWidth: 2.5,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function drawShape(cx, cy, r, angle, layer, channel) {
+  ctx.globalCompositeOperation = 'screen';
+  ctx.strokeStyle = channel;
+  ctx.lineWidth = params.lineWidth + layer * 0.3;
+  ctx.beginPath();
+  const segs = 6 + layer;
+  for (let i = 0; i <= segs; i++) {
+    const a = angle + (i / segs) * Math.PI * 2;
+    const rr = r * (1 + Math.sin(a * 3 + time * params.waveSpeed) * 0.1);
+    const x = cx + Math.cos(a) * rr;
+    const y = cy + Math.sin(a) * rr;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.stroke();
+  ctx.globalCompositeOperation = 'source-over';
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const n = Math.round(params.shapeCount);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  for (let i = 0; i < n; i++) {
+    const orbit = (i * Math.PI * 2) / n;
+    const ox = cx + Math.cos(orbit + time * params.rotationSpeed) * 150;
+    const oy = cy + Math.sin(orbit + time * params.rotationSpeed) * 150;
+    const baseAngle = time * (0.3 + i * 0.07);
+    for (let layer = 0; layer < params.blurLayers; layer++) {
+      const spread = (params.aberration * (layer + 1)) / params.blurLayers;
+      drawShape(
+        ox + params.redShiftX * spread,
+        oy + params.redShiftY * spread,
+        params.shapeSize * (0.7 + Math.sin(time + i) * 0.2),
+        baseAngle,
+        layer,
+        'rgba(255, 40, 80, 0.6)',
+      );
+      drawShape(
+        ox + params.greenShiftX * spread,
+        oy + params.greenShiftY * spread,
+        params.shapeSize * (0.7 + Math.sin(time + i) * 0.2),
+        baseAngle,
+        layer,
+        'rgba(40, 255, 120, 0.6)',
+      );
+      drawShape(
+        ox + params.blueShiftX * spread,
+        oy + params.blueShiftY * spread,
+        params.shapeSize * (0.7 + Math.sin(time + i) * 0.2),
+        baseAngle,
+        layer,
+        'rgba(80, 120, 255, 0.6)',
+      );
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Chromatic Aberration',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'aberration', 0, 60, 0.5);
+gui.add(params, 'shapeCount', 1, 12, 1);
+gui.add(params, 'shapeSize', 40, 400, 1);
+gui.add(params, 'rotationSpeed', -1, 1, 0.01);
+gui.add(params, 'waveSpeed', 0, 3, 0.01);
+gui.add(params, 'blurLayers', 1, 6, 1);
+gui.add(params, 'redShiftX', -2, 2, 0.05);
+gui.add(params, 'redShiftY', -2, 2, 0.05);
+gui.add(params, 'greenShiftX', -2, 2, 0.05);
+gui.add(params, 'greenShiftY', -2, 2, 0.05);
+gui.add(params, 'blueShiftX', -2, 2, 0.05);
+gui.add(params, 'blueShiftY', -2, 2, 0.05);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'lineWidth', 0.5, 6, 0.1);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.aberration = rand(5, 30, 0.5);
+  params.shapeCount = rand(3, 8, 1);
+  params.shapeSize = rand(80, 250, 1);
+  params.redShiftX = rand(-1.5, 1.5, 0.05);
+  params.redShiftY = rand(-1, 1, 0.05);
+  params.greenShiftX = rand(-1, 1, 0.05);
+  params.blueShiftX = rand(-1.5, 1.5, 0.05);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/chromatic-aberration/style.css
+++ b/public/chromatic-aberration/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/circular-sequencer/index.html
+++ b/public/circular-sequencer/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Circular Sequencer | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/circular-sequencer/main.js
+++ b/public/circular-sequencer/main.js
@@ -1,0 +1,180 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  steps: 16,
+  rings: 5,
+  bpm: 120,
+  radius: 280,
+  ringGap: 34,
+  density: 0.35, // 各リングで発音するステップの密度
+  hueStart: 30,
+  hueRange: 240,
+  pulseSize: 1.6,
+  trailFade: 0.2,
+  glow: 0.7,
+  reshuffle: 0,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {boolean[][]} */
+let grid = [];
+
+function rebuild() {
+  const s = Math.round(params.steps);
+  const r = Math.round(params.rings);
+  grid = [];
+  for (let i = 0; i < r; i++) {
+    const row = new Array(s);
+    for (let j = 0; j < s; j++) {
+      row[j] = Math.random() < params.density;
+    }
+    grid.push(row);
+  }
+}
+rebuild();
+
+let time = 0;
+let lastStep = -1;
+/** @type {{ring:number, step:number, t:number}[]} */
+let pulses = [];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const s = Math.round(params.steps);
+  const r = Math.round(params.rings);
+  const stepTime = 60 / params.bpm / 4; // 16分音符
+  const current = Math.floor(time / stepTime) % s;
+  if (current !== lastStep) {
+    lastStep = current;
+    for (let ri = 0; ri < r; ri++) {
+      if (grid[ri]?.[current]) {
+        pulses.push({ ring: ri, step: current, t: 0 });
+      }
+    }
+  }
+
+  // 背景リング
+  for (let ri = 0; ri < r; ri++) {
+    const rad = params.radius - ri * params.ringGap;
+    if (rad <= 4) continue;
+    ctx.strokeStyle = 'rgba(200,200,200,0.12)';
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+    ctx.stroke();
+    // 各ステップのドット
+    for (let si = 0; si < s; si++) {
+      const a = -Math.PI / 2 + (si / s) * Math.PI * 2;
+      const x = cx + Math.cos(a) * rad;
+      const y = cy + Math.sin(a) * rad;
+      const hue = params.hueStart + (ri / r) * params.hueRange;
+      const active = grid[ri]?.[si];
+      ctx.fillStyle = active
+        ? `hsla(${hue}, 80%, 65%, 0.85)`
+        : 'rgba(200,200,200,0.18)';
+      ctx.beginPath();
+      ctx.arc(x, y, active ? 4 : 1.8, 0, Math.PI * 2);
+      ctx.fill();
+      // 現在ステップ強調
+      if (si === current) {
+        ctx.strokeStyle = `hsla(${hue}, 90%, 75%, 0.9)`;
+        ctx.lineWidth = 1.2;
+        ctx.beginPath();
+        ctx.arc(x, y, 9, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
+  }
+
+  // パルス表示
+  pulses = pulses.filter((p) => p.t < 1);
+  for (const p of pulses) {
+    p.t += 0.04;
+    const rad = params.radius - p.ring * params.ringGap;
+    const a = -Math.PI / 2 + (p.step / s) * Math.PI * 2;
+    const x = cx + Math.cos(a) * rad;
+    const y = cy + Math.sin(a) * rad;
+    const hue = params.hueStart + (p.ring / r) * params.hueRange;
+    const sz = 6 + p.t * 60 * params.pulseSize;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 70%, ${(1 - p.t) * params.glow})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(x, y, sz, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.fillStyle = `hsla(${hue}, 90%, 75%, ${(1 - p.t) * params.glow})`;
+    ctx.beginPath();
+    ctx.arc(x, y, 5 + p.t * 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Circular Sequencer',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'steps', 8, 32, 1);
+gui.add(params, 'rings', 1, 10, 1);
+gui.add(params, 'bpm', 40, 240, 1);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'ringGap', 12, 60, 1);
+gui.add(params, 'density', 0.05, 0.8, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'pulseSize', 0.3, 3, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.5, 0.01);
+gui.add(params, 'glow', 0, 1, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.steps = rand(8, 24, 1);
+  params.rings = rand(3, 7, 1);
+  params.bpm = rand(80, 160, 1);
+  params.density = rand(0.2, 0.5, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Shuffle', () => {
+  rebuild();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/circular-sequencer/style.css
+++ b/public/circular-sequencer/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/coral-growth/index.html
+++ b/public/coral-growth/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Coral Growth | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/coral-growth/main.js
+++ b/public/coral-growth/main.js
@@ -1,0 +1,192 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// サンゴが上へ成長する DLA 風ジェネレーティブ。粒子が下から漂い、最上の枝に付着して固まっていく。
+const params = {
+  particlesPerFrame: 15,
+  particleSpeed: 1.4,
+  attachRadius: 7,
+  branchWidth: 5,
+  hueStart: 330,
+  hueEnd: 20,
+  darkFloor: 40, // 海底の色
+  drift: 0.5,
+  backgroundFade: 0.04,
+  maxNodes: 1500,
+  autoRegrow: true,
+  regrowInterval: 12,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {{x:number,y:number,depth:number}[]} */
+let nodes = [];
+/** @type {{x:number,y:number,vx:number,vy:number}[]} */
+let particles = [];
+let time = 0;
+let lastRegrow = 0;
+
+function reset() {
+  nodes = [];
+  particles = [];
+  ctx.fillStyle = '#04070d';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // 海底
+  const grad = ctx.createLinearGradient(
+    0,
+    canvas.height,
+    0,
+    canvas.height - 80,
+  );
+  grad.addColorStop(0, 'rgba(30, 40, 55, 0.9)');
+  grad.addColorStop(1, 'rgba(4, 7, 13, 0)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, canvas.height - 80, canvas.width, 80);
+  // シード
+  const seeds = 5;
+  for (let i = 0; i < seeds; i++) {
+    nodes.push({
+      x: canvas.width * ((i + 1) / (seeds + 1)),
+      y: canvas.height - 20,
+      depth: 0,
+    });
+  }
+  for (const s of nodes) {
+    ctx.fillStyle = `hsla(${params.hueStart}, 80%, 60%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, params.branchWidth, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+reset();
+
+function spawnParticle() {
+  particles.push({
+    x: Math.random() * canvas.width,
+    y: -10,
+    vx: (Math.random() - 0.5) * params.drift,
+    vy: params.particleSpeed,
+  });
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(4, 7, 13, ${params.backgroundFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (
+    params.autoRegrow &&
+    time - lastRegrow > params.regrowInterval &&
+    nodes.length > params.maxNodes
+  ) {
+    lastRegrow = time;
+    reset();
+  }
+
+  for (let i = 0; i < params.particlesPerFrame; i++) spawnParticle();
+
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.vx += (Math.random() - 0.5) * 0.3;
+    p.x += p.vx;
+    p.y += p.vy;
+    if (p.y > canvas.height || p.x < 0 || p.x > canvas.width) {
+      particles.splice(i, 1);
+      continue;
+    }
+    // ヒット判定（近傍ノードを検索：単純 O(N)）
+    if (nodes.length > params.maxNodes) {
+      particles.splice(i, 1);
+      continue;
+    }
+    let attached = false;
+    for (let j = nodes.length - 1; j >= Math.max(0, nodes.length - 80); j--) {
+      const n = nodes[j];
+      if (Math.hypot(p.x - n.x, p.y - n.y) < params.attachRadius) {
+        nodes.push({ x: p.x, y: p.y, depth: n.depth + 1 });
+        const k = Math.min(1, n.depth / 150);
+        const hue = params.hueStart + (params.hueEnd - params.hueStart) * k;
+        const sat = 80 - k * 20;
+        const light = 60 - k * 20;
+        ctx.fillStyle = `hsla(${hue}, ${sat}%, ${light}%, 0.9)`;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, params.branchWidth, 0, Math.PI * 2);
+        ctx.fill();
+        // 結線
+        ctx.strokeStyle = `hsla(${hue}, 70%, 50%, 0.6)`;
+        ctx.lineWidth = params.branchWidth * 0.6;
+        ctx.beginPath();
+        ctx.moveTo(n.x, n.y);
+        ctx.lineTo(p.x, p.y);
+        ctx.stroke();
+        attached = true;
+        break;
+      }
+    }
+    if (attached) {
+      particles.splice(i, 1);
+    } else {
+      ctx.fillStyle = 'rgba(180, 220, 230, 0.3)';
+      ctx.fillRect(p.x, p.y, 1, 1);
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Coral Growth',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'particlesPerFrame', 2, 40, 1);
+gui.add(params, 'particleSpeed', 0.3, 4, 0.1);
+gui.add(params, 'attachRadius', 3, 15, 0.5);
+gui.add(params, 'branchWidth', 2, 12, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'drift', 0, 3, 0.05);
+gui.add(params, 'backgroundFade', 0, 0.2, 0.005);
+gui.add(params, 'maxNodes', 300, 3000, 50);
+gui.add(params, 'autoRegrow');
+gui.add(params, 'regrowInterval', 5, 40, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.particlesPerFrame = rand(8, 25, 1);
+  params.drift = rand(0.1, 1.2, 0.05);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/coral-growth/style.css
+++ b/public/coral-growth/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/diffraction-grating/index.html
+++ b/public/diffraction-grating/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Diffraction Grating | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/diffraction-grating/main.js
+++ b/public/diffraction-grating/main.js
@@ -1,0 +1,171 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 回折格子: 格子間隔 d に対する角度 sin(θ) = m λ / d で次数 m の回折スペクトルを描く。
+const params = {
+  gratingLines: 40,
+  d: 16, // 格子間隔（ピクセル）
+  maxOrder: 3,
+  wavelengths: 7, // 可視光の分割数
+  spread: 420, // 画面上の広がり
+  sourceBrightness: 1.4,
+  lineAlpha: 0.6,
+  beamAngle: 0.05,
+  orderGap: 110,
+  trailFade: 0.15,
+  showGrating: true,
+  animate: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+// 波長 (nm) → HSL 色
+function wavelengthHue(wnm) {
+  // 380..780 nm → 280..0 hue (紫→赤)
+  const t = (wnm - 380) / (780 - 380);
+  return 280 - t * 280;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const gy = canvas.height * 0.5;
+  const beamY0 = gy - 250;
+
+  // 入射光源
+  const beamAngle = params.animate
+    ? params.beamAngle + Math.sin(time * 0.5) * 0.08
+    : params.beamAngle;
+  const sx = cx - Math.sin(beamAngle) * 250;
+  const sy = beamY0;
+  // 入射線
+  ctx.strokeStyle = `rgba(255, 255, 255, ${0.4 * params.sourceBrightness})`;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(sx, sy);
+  ctx.lineTo(cx, gy);
+  ctx.stroke();
+
+  // 格子の線
+  if (params.showGrating) {
+    const n = Math.round(params.gratingLines);
+    const halfW = (n * params.d) / 2;
+    ctx.strokeStyle = 'rgba(200, 220, 255, 0.6)';
+    ctx.lineWidth = 1;
+    for (let i = 0; i < n; i++) {
+      const x = cx - halfW + i * params.d;
+      ctx.beginPath();
+      ctx.moveTo(x, gy - 10);
+      ctx.lineTo(x, gy + 10);
+      ctx.stroke();
+    }
+    ctx.strokeStyle = 'rgba(180, 200, 230, 0.8)';
+    ctx.beginPath();
+    ctx.moveTo(cx - halfW - 10, gy);
+    ctx.lineTo(cx + halfW + 10, gy);
+    ctx.stroke();
+  }
+
+  // 回折次数ごとにスペクトル
+  const W = Math.round(params.wavelengths);
+  for (let m = -params.maxOrder; m <= params.maxOrder; m++) {
+    if (m === 0) continue;
+    for (let wi = 0; wi < W; wi++) {
+      const wnm = 380 + (wi + 0.5) * (400 / W); // 380..780 nm
+      // sin(θ) = m * λ / d  (ピクセル単位に換算するため λ ~= wnm/30 とする)
+      const lambda = wnm / 30;
+      const sinT = (m * lambda) / params.d;
+      if (Math.abs(sinT) > 1) continue;
+      const theta = Math.asin(sinT) + beamAngle;
+      const tx = cx + Math.sin(theta) * params.spread;
+      const ty = gy + Math.cos(theta) * params.spread;
+      const hue = wavelengthHue(wnm);
+      ctx.strokeStyle = `hsla(${hue}, 90%, 65%, ${params.lineAlpha})`;
+      ctx.lineWidth = 1.8;
+      ctx.beginPath();
+      ctx.moveTo(cx, gy);
+      ctx.lineTo(tx, ty);
+      ctx.stroke();
+      ctx.fillStyle = `hsla(${hue}, 100%, 75%, 0.8)`;
+      ctx.beginPath();
+      ctx.arc(tx, ty, 4, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // 次数ラベルのスペース
+  }
+
+  // 0 次光（中心の白）
+  ctx.strokeStyle = `rgba(255, 255, 255, ${0.7 * params.sourceBrightness})`;
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(cx, gy);
+  ctx.lineTo(
+    cx + Math.sin(beamAngle) * params.spread,
+    gy + Math.cos(beamAngle) * params.spread,
+  );
+  ctx.stroke();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Diffraction Grating',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'gratingLines', 5, 120, 1);
+gui.add(params, 'd', 4, 40, 0.5);
+gui.add(params, 'maxOrder', 1, 6, 1);
+gui.add(params, 'wavelengths', 3, 20, 1);
+gui.add(params, 'spread', 100, 800, 1);
+gui.add(params, 'sourceBrightness', 0.3, 2, 0.05);
+gui.add(params, 'lineAlpha', 0.1, 1, 0.01);
+gui.add(params, 'beamAngle', -0.5, 0.5, 0.01);
+gui.add(params, 'orderGap', 40, 200, 1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'showGrating');
+gui.add(params, 'animate');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.d = rand(6, 28, 0.5);
+  params.maxOrder = rand(2, 5, 1);
+  params.wavelengths = rand(5, 14, 1);
+  params.spread = rand(260, 600, 1);
+  params.beamAngle = rand(-0.3, 0.3, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/diffraction-grating/style.css
+++ b/public/diffraction-grating/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/dna-helix/index.html
+++ b/public/dna-helix/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>DNA Helix | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/dna-helix/main.js
+++ b/public/dna-helix/main.js
@@ -1,0 +1,162 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 二重螺旋 DNA。4 色の塩基対（A/T/G/C）が階段状に連結される。
+const params = {
+  rungs: 40, // 塩基対の数
+  amplitude: 120,
+  spacing: 18,
+  twistSpeed: 0.4,
+  twistFreq: 0.08, // y 方向の角速度
+  hueA: 0,
+  hueT: 60,
+  hueG: 200,
+  hueC: 140,
+  strandWidth: 4,
+  rungWidth: 3,
+  trailFade: 0.12,
+  rotation: 0,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/** 塩基の乱数列（再生成抑制） */
+let bases = /** @type {number[]} */ ([]);
+function rebuildBases() {
+  bases = [];
+  for (let i = 0; i < 300; i++) bases.push(Math.floor(Math.random() * 4));
+}
+rebuildBases();
+
+const baseHues = () => [params.hueA, params.hueT, params.hueG, params.hueC];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const topY = 40;
+  const n = Math.round(params.rungs);
+  const totalH = n * params.spacing;
+  const startY = Math.max(topY, canvas.height / 2 - totalH / 2);
+  ctx.save();
+  ctx.translate(cx, canvas.height / 2);
+  ctx.rotate(params.rotation);
+  ctx.translate(-cx, -canvas.height / 2);
+
+  /** @type {{x:number,y:number,x2:number,y2:number,base:number}[]} */
+  const rungPoints = [];
+
+  for (let i = 0; i < n; i++) {
+    const y = startY + i * params.spacing;
+    const phase = y * params.twistFreq + time * params.twistSpeed * Math.PI * 2;
+    const x1 = cx + Math.cos(phase) * params.amplitude;
+    const x2 = cx + Math.cos(phase + Math.PI) * params.amplitude;
+    // 深度（後ろの線は暗く）
+    const depth1 = (Math.cos(phase) + 1) * 0.5;
+    const depth2 = (Math.cos(phase + Math.PI) + 1) * 0.5;
+    rungPoints.push({ x: x1, y, x2, y2: y, base: bases[i % bases.length] });
+    // ストランドの点
+    const hues = baseHues();
+    const h = hues[bases[i % bases.length]];
+    // 塩基対接続
+    ctx.strokeStyle = `hsla(${h}, 80%, ${45 + Math.min(depth1, depth2) * 40}%, 0.9)`;
+    ctx.lineWidth = params.rungWidth;
+    ctx.beginPath();
+    ctx.moveTo(x1, y);
+    ctx.lineTo(x2, y);
+    ctx.stroke();
+    // ストランドの球
+    ctx.fillStyle = `hsla(${h}, 90%, ${40 + depth1 * 50}%, 0.95)`;
+    ctx.beginPath();
+    ctx.arc(x1, y, 5 + depth1 * 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = `hsla(${(h + 180) % 360}, 90%, ${40 + depth2 * 50}%, 0.95)`;
+    ctx.beginPath();
+    ctx.arc(x2, y, 5 + depth2 * 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // 2 本の糖リン酸バックボーンを線でつなぐ
+  for (let side = 0; side < 2; side++) {
+    ctx.strokeStyle = `hsla(${side === 0 ? 200 : 20}, 60%, 70%, 0.5)`;
+    ctx.lineWidth = params.strandWidth;
+    ctx.beginPath();
+    for (let i = 0; i < rungPoints.length; i++) {
+      const p = rungPoints[i];
+      const x = side === 0 ? p.x : p.x2;
+      if (i === 0) ctx.moveTo(x, p.y);
+      else ctx.lineTo(x, p.y);
+    }
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'DNA Helix',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'rungs', 10, 100, 1);
+gui.add(params, 'amplitude', 30, 250, 1);
+gui.add(params, 'spacing', 6, 40, 0.5);
+gui.add(params, 'twistSpeed', -2, 2, 0.01);
+gui.add(params, 'twistFreq', 0.01, 0.3, 0.005);
+gui.add(params, 'hueA', 0, 360, 1);
+gui.add(params, 'hueT', 0, 360, 1);
+gui.add(params, 'hueG', 0, 360, 1);
+gui.add(params, 'hueC', 0, 360, 1);
+gui.add(params, 'strandWidth', 1, 8, 0.1);
+gui.add(params, 'rungWidth', 1, 8, 0.1);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.rungs = rand(25, 60, 1);
+  params.amplitude = rand(80, 200, 1);
+  params.spacing = rand(10, 25, 0.5);
+  params.twistSpeed = rand(-0.8, 0.8, 0.01);
+  params.hueA = rand(0, 360, 1);
+  params.hueT = rand(0, 360, 1);
+  params.hueG = rand(0, 360, 1);
+  params.hueC = rand(0, 360, 1);
+  rebuildBases();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuildBases();
+  gui.updateDisplay();
+});

--- a/public/dna-helix/style.css
+++ b/public/dna-helix/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/euclidean-rhythm/index.html
+++ b/public/euclidean-rhythm/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Euclidean Rhythm | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/euclidean-rhythm/main.js
+++ b/public/euclidean-rhythm/main.js
@@ -1,0 +1,191 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  steps: 16, // ステップ数
+  pulses: 5, // パルス数
+  rotate: 0, // 回転
+  layers: 3, // レイヤー数
+  bpm: 120,
+  radius: 260,
+  ringGap: 36,
+  hueStart: 160,
+  hueRange: 180,
+  pulseGlow: 0.8,
+  trailFade: 0.18,
+  dotSize: 8,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * Bjorklund のユークリッドリズム
+ * @param {number} steps
+ * @param {number} pulses
+ * @returns {boolean[]}
+ */
+function euclid(steps, pulses) {
+  pulses = Math.min(steps, Math.max(0, pulses));
+  /** @type {string[]} */
+  let groups = [];
+  for (let i = 0; i < pulses; i++) groups.push('1');
+  for (let i = 0; i < steps - pulses; i++) groups.push('0');
+  while (true) {
+    const ones = groups.filter((g) => g.startsWith('1'));
+    const zeros = groups.filter((g) => g.startsWith('0'));
+    if (zeros.length <= 1) break;
+    const merge = Math.min(ones.length, zeros.length);
+    /** @type {string[]} */
+    const next = [];
+    for (let i = 0; i < merge; i++) next.push(ones[i] + zeros[i]);
+    for (let i = merge; i < ones.length; i++) next.push(ones[i]);
+    for (let i = merge; i < zeros.length; i++) next.push(zeros[i]);
+    groups = next;
+    if (ones.length === 0 || zeros.length === 0) break;
+  }
+  const s = groups.join('');
+  const out = [];
+  for (const ch of s) out.push(ch === '1');
+  return out;
+}
+
+let time = 0;
+let lastStep = -1;
+/** @type {{layer:number, step:number, t:number}[]} */
+let pulseAnim = [];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const s = Math.round(params.steps);
+  const L = Math.round(params.layers);
+  const stepTime = 60 / params.bpm / 4;
+  const current = Math.floor(time / stepTime) % s;
+
+  const patterns = [];
+  for (let li = 0; li < L; li++) {
+    const p = Math.max(1, Math.round(params.pulses) - li);
+    const pat = euclid(s, p);
+    const rot = Math.round(params.rotate) + li;
+    // rotate
+    const rotated = pat.slice(-rot % s).concat(pat.slice(0, -rot % s || 0));
+    patterns.push(rotated);
+  }
+
+  if (current !== lastStep) {
+    lastStep = current;
+    for (let li = 0; li < L; li++) {
+      if (patterns[li][current])
+        pulseAnim.push({ layer: li, step: current, t: 0 });
+    }
+  }
+
+  for (let li = 0; li < L; li++) {
+    const rad = params.radius - li * params.ringGap;
+    if (rad <= 4) continue;
+    const hue = params.hueStart + (li / L) * params.hueRange;
+    ctx.strokeStyle = `hsla(${hue}, 60%, 50%, 0.2)`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+    ctx.stroke();
+    for (let si = 0; si < s; si++) {
+      const a = -Math.PI / 2 + (si / s) * Math.PI * 2;
+      const x = cx + Math.cos(a) * rad;
+      const y = cy + Math.sin(a) * rad;
+      const on = patterns[li][si];
+      ctx.fillStyle = on
+        ? `hsla(${hue}, 85%, 65%, 0.9)`
+        : 'rgba(180,180,180,0.2)';
+      ctx.beginPath();
+      ctx.arc(x, y, on ? params.dotSize * 0.5 : 2, 0, Math.PI * 2);
+      ctx.fill();
+      if (si === current) {
+        ctx.strokeStyle = `hsla(${hue}, 100%, 80%, 0.9)`;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.arc(x, y, params.dotSize + 2, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
+  }
+
+  pulseAnim = pulseAnim.filter((p) => p.t < 1);
+  for (const p of pulseAnim) {
+    p.t += 0.05;
+    const rad = params.radius - p.layer * params.ringGap;
+    const a = -Math.PI / 2 + (p.step / s) * Math.PI * 2;
+    const x = cx + Math.cos(a) * rad;
+    const y = cy + Math.sin(a) * rad;
+    const hue = params.hueStart + (p.layer / L) * params.hueRange;
+    ctx.strokeStyle = `hsla(${hue}, 100%, 70%, ${(1 - p.t) * params.pulseGlow})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(x, y, 4 + p.t * 30, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Euclidean Rhythm',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'steps', 4, 32, 1);
+gui.add(params, 'pulses', 1, 24, 1);
+gui.add(params, 'rotate', 0, 31, 1);
+gui.add(params, 'layers', 1, 6, 1);
+gui.add(params, 'bpm', 40, 240, 1);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'ringGap', 14, 60, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'pulseGlow', 0, 1, 0.01);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'dotSize', 4, 20, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.steps = rand(8, 24, 1);
+  params.pulses = rand(3, Math.min(12, params.steps - 1), 1);
+  params.rotate = rand(0, params.steps - 1, 1);
+  params.layers = rand(2, 5, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.bpm = rand(80, 160, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/euclidean-rhythm/style.css
+++ b/public/euclidean-rhythm/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/fm-synthesis-visualizer/index.html
+++ b/public/fm-synthesis-visualizer/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>FM Synthesis Visualizer | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/fm-synthesis-visualizer/main.js
+++ b/public/fm-synthesis-visualizer/main.js
@@ -1,0 +1,142 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// y(t) = sin( carrier*t + I * sin( modulator*t ) ) をリサージュ風に 2D プロット
+const params = {
+  carrier: 3,
+  modulator: 2,
+  index: 3.2,
+  ratioY: 2,
+  modulatorY: 5,
+  indexY: 2.4,
+  samples: 2000,
+  scale: 320,
+  hueStart: 200,
+  hueRange: 160,
+  strokeAlpha: 0.45,
+  lineWidth: 1.2,
+  autoMorph: true,
+  morphSpeed: 0.2,
+  trailFade: 0.08,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+
+  const idx = params.autoMorph
+    ? params.index + Math.sin(time * params.morphSpeed) * 1.5
+    : params.index;
+  const idy = params.autoMorph
+    ? params.indexY + Math.cos(time * params.morphSpeed * 0.8) * 1.5
+    : params.indexY;
+
+  ctx.beginPath();
+  const n = Math.round(params.samples);
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2;
+    const x = Math.sin(
+      params.carrier * t + idx * Math.sin(params.modulator * t),
+    );
+    const y = Math.sin(
+      params.ratioY * t + idy * Math.sin(params.modulatorY * t + time * 0.5),
+    );
+    const sx = cx + x * params.scale;
+    const sy = cy + y * params.scale;
+    if (i === 0) ctx.moveTo(sx, sy);
+    else ctx.lineTo(sx, sy);
+  }
+  const hue = params.hueStart + Math.sin(time * 0.3) * params.hueRange * 0.5;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 70%, ${params.strokeAlpha})`;
+  ctx.lineWidth = params.lineWidth;
+  ctx.stroke();
+
+  // 色違いでもう一重
+  ctx.beginPath();
+  for (let i = 0; i < n; i++) {
+    const t = (i / n) * Math.PI * 2 + time * 0.1;
+    const x = Math.sin(
+      params.carrier * t + idx * Math.sin(params.modulator * t),
+    );
+    const y = Math.sin(
+      params.ratioY * t + idy * Math.sin(params.modulatorY * t),
+    );
+    const sx = cx + x * params.scale;
+    const sy = cy + y * params.scale;
+    if (i === 0) ctx.moveTo(sx, sy);
+    else ctx.lineTo(sx, sy);
+  }
+  ctx.strokeStyle = `hsla(${(hue + params.hueRange * 0.5) % 360}, 90%, 65%, ${params.strokeAlpha * 0.6})`;
+  ctx.stroke();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'FM Synthesis Visualizer',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'carrier', 1, 10, 1);
+gui.add(params, 'modulator', 1, 10, 1);
+gui.add(params, 'index', 0, 8, 0.05);
+gui.add(params, 'ratioY', 1, 10, 1);
+gui.add(params, 'modulatorY', 1, 10, 1);
+gui.add(params, 'indexY', 0, 8, 0.05);
+gui.add(params, 'samples', 300, 4000, 50);
+gui.add(params, 'scale', 80, 500, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'lineWidth', 0.3, 3, 0.1);
+gui.add(params, 'autoMorph');
+gui.add(params, 'morphSpeed', 0, 1, 0.01);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.carrier = rand(1, 7, 1);
+  params.modulator = rand(1, 7, 1);
+  params.ratioY = rand(1, 7, 1);
+  params.modulatorY = rand(1, 7, 1);
+  params.index = rand(0.5, 5, 0.05);
+  params.indexY = rand(0.5, 5, 0.05);
+  params.hueStart = rand(0, 360, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/fm-synthesis-visualizer/style.css
+++ b/public/fm-synthesis-visualizer/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/genetic-creatures/index.html
+++ b/public/genetic-creatures/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Genetic Creatures | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/genetic-creatures/main.js
+++ b/public/genetic-creatures/main.js
@@ -1,0 +1,262 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 遺伝的アルゴリズムで育つ生き物の群れ。遺伝子は形状（サイズ・色相・曲率）、速さ、振動数。
+const params = {
+  population: 40,
+  mutationRate: 0.08,
+  selectionPressure: 0.5,
+  foodRate: 2.0,
+  wiggleAmp: 1.2,
+  generationSeconds: 6,
+  hueStart: 120,
+  hueRange: 200,
+  trailFade: 0.1,
+  bodyAlpha: 0.9,
+  tailLength: 18,
+  showFood: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Gene
+ * @property {number} size
+ * @property {number} hue
+ * @property {number} speed
+ * @property {number} wiggle
+ * @property {number} curvature
+ */
+/**
+ * @typedef {object} Creature
+ * @property {number} x
+ * @property {number} y
+ * @property {number} vx
+ * @property {number} vy
+ * @property {number} age
+ * @property {number} fitness
+ * @property {Gene} gene
+ * @property {number[]} tail
+ */
+
+function randGene() {
+  return {
+    size: 4 + Math.random() * 14,
+    hue: params.hueStart + Math.random() * params.hueRange,
+    speed: 30 + Math.random() * 100,
+    wiggle: 0.5 + Math.random() * 3,
+    curvature: Math.random() * 2 - 1,
+  };
+}
+
+/** @param {Gene} g */
+function makeCreature(g) {
+  return {
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+    vx: (Math.random() - 0.5) * g.speed,
+    vy: (Math.random() - 0.5) * g.speed,
+    age: 0,
+    fitness: 0,
+    gene: g,
+    tail: [],
+  };
+}
+
+/** @type {Creature[]} */
+let creatures = [];
+/** @type {{x:number,y:number}[]} */
+let foods = [];
+let time = 0;
+let genTimer = 0;
+
+function reset() {
+  creatures = [];
+  for (let i = 0; i < Math.round(params.population); i++) {
+    creatures.push(makeCreature(randGene()));
+  }
+  foods = [];
+}
+reset();
+
+function spawnFood() {
+  foods.push({
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+  });
+  if (foods.length > 200) foods.shift();
+}
+
+function evolve() {
+  creatures.sort((a, b) => b.fitness - a.fitness);
+  const keep = Math.max(
+    2,
+    Math.round(creatures.length * (1 - params.selectionPressure)),
+  );
+  const elites = creatures.slice(0, keep);
+  const next = [];
+  while (next.length < creatures.length) {
+    const p1 = elites[Math.floor(Math.random() * elites.length)];
+    const p2 = elites[Math.floor(Math.random() * elites.length)];
+    /** @type {Gene} */
+    const child = {
+      size: (p1.gene.size + p2.gene.size) / 2,
+      hue: (p1.gene.hue + p2.gene.hue) / 2,
+      speed: (p1.gene.speed + p2.gene.speed) / 2,
+      wiggle: (p1.gene.wiggle + p2.gene.wiggle) / 2,
+      curvature: (p1.gene.curvature + p2.gene.curvature) / 2,
+    };
+    if (Math.random() < params.mutationRate)
+      child.size += (Math.random() - 0.5) * 4;
+    if (Math.random() < params.mutationRate)
+      child.hue += (Math.random() - 0.5) * 40;
+    if (Math.random() < params.mutationRate)
+      child.speed += (Math.random() - 0.5) * 30;
+    if (Math.random() < params.mutationRate)
+      child.wiggle += (Math.random() - 0.5) * 1;
+    if (Math.random() < params.mutationRate)
+      child.curvature += (Math.random() - 0.5) * 0.5;
+    child.size = Math.max(3, Math.min(20, child.size));
+    child.speed = Math.max(10, Math.min(180, child.speed));
+    next.push(makeCreature(child));
+  }
+  creatures = next;
+}
+
+function draw() {
+  const dt = 1 / 60;
+  time += dt;
+  genTimer += dt;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (Math.random() < params.foodRate * dt) spawnFood();
+  if (genTimer > params.generationSeconds) {
+    genTimer = 0;
+    evolve();
+  }
+
+  if (params.showFood) {
+    for (const f of foods) {
+      ctx.fillStyle = 'rgba(250, 230, 120, 0.7)';
+      ctx.beginPath();
+      ctx.arc(f.x, f.y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  for (const c of creatures) {
+    c.age += dt;
+    // wiggle 付き移動
+    const wig = Math.sin(time * c.gene.wiggle * 3 + c.age) * params.wiggleAmp;
+    c.vx += (Math.cos(c.age * c.gene.curvature) * 10 + wig * 10) * dt;
+    c.vy += (Math.sin(c.age * c.gene.curvature) * 10 + wig * 10) * dt;
+    const sp = Math.hypot(c.vx, c.vy) || 1;
+    c.vx = (c.vx / sp) * c.gene.speed;
+    c.vy = (c.vy / sp) * c.gene.speed;
+    c.x += c.vx * dt;
+    c.y += c.vy * dt;
+    if (c.x < 0) c.x += canvas.width;
+    if (c.x > canvas.width) c.x -= canvas.width;
+    if (c.y < 0) c.y += canvas.height;
+    if (c.y > canvas.height) c.y -= canvas.height;
+    c.tail.push(c.x, c.y);
+    const maxPairs = params.tailLength * 2;
+    while (c.tail.length > maxPairs) c.tail.shift();
+    // 食べる
+    for (let i = foods.length - 1; i >= 0; i--) {
+      const f = foods[i];
+      if (Math.hypot(f.x - c.x, f.y - c.y) < c.gene.size + 4) {
+        foods.splice(i, 1);
+        c.fitness += 1;
+      }
+    }
+    // 描画: 尾
+    ctx.strokeStyle = `hsla(${c.gene.hue}, 80%, 60%, 0.4)`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let i = 0; i < c.tail.length; i += 2) {
+      const tx = c.tail[i];
+      const ty = c.tail[i + 1];
+      if (i === 0) ctx.moveTo(tx, ty);
+      else ctx.lineTo(tx, ty);
+    }
+    ctx.stroke();
+    // 本体
+    ctx.fillStyle = `hsla(${c.gene.hue}, 85%, 65%, ${params.bodyAlpha})`;
+    ctx.beginPath();
+    ctx.arc(c.x, c.y, c.gene.size, 0, Math.PI * 2);
+    ctx.fill();
+    // 目
+    ctx.fillStyle = '#fff';
+    ctx.beginPath();
+    ctx.arc(
+      c.x + Math.cos(Math.atan2(c.vy, c.vx)) * c.gene.size * 0.4,
+      c.y + Math.sin(Math.atan2(c.vy, c.vx)) * c.gene.size * 0.4,
+      c.gene.size * 0.18,
+      0,
+      Math.PI * 2,
+    );
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Genetic Creatures',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'population', 10, 100, 1);
+gui.add(params, 'mutationRate', 0, 0.3, 0.01);
+gui.add(params, 'selectionPressure', 0.1, 0.9, 0.05);
+gui.add(params, 'foodRate', 0.2, 8, 0.1);
+gui.add(params, 'wiggleAmp', 0, 3, 0.05);
+gui.add(params, 'generationSeconds', 2, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'bodyAlpha', 0.3, 1, 0.01);
+gui.add(params, 'tailLength', 4, 40, 1);
+gui.add(params, 'showFood');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.population = rand(20, 80, 1);
+  params.mutationRate = rand(0.03, 0.2, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/genetic-creatures/style.css
+++ b/public/genetic-creatures/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/gosper-island/index.html
+++ b/public/gosper-island/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Gosper Island | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/gosper-island/main.js
+++ b/public/gosper-island/main.js
@@ -1,0 +1,179 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  iterations: 3,
+  initialSize: 300,
+  ratio: 1 / Math.sqrt(7), // Gosper の縮小比
+  hueStart: 180,
+  hueEnd: 80,
+  strokeAlpha: 0.9,
+  fillAlpha: 0.15,
+  thickness: 1.4,
+  rotation: 0,
+  rotSpeed: 0.05,
+  bloom: 0.3,
+  showOutline: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+// Gosper 曲線 (flowsnake) を L-System 的に生成
+// Rules: A -> A-B--B+A++AA+B-  /  B -> +A-BB--B-A++A+B
+// 基本 angle = 60 度
+function generateGosper(depth) {
+  let s = 'A';
+  for (let i = 0; i < depth; i++) {
+    let next = '';
+    for (const c of s) {
+      if (c === 'A') next += 'A-B--B+A++AA+B-';
+      else if (c === 'B') next += '+A-BB--B-A++A+B';
+      else next += c;
+    }
+    s = next;
+  }
+  return s;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.2)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const ang = params.rotation + time * params.rotSpeed;
+
+  const depth = Math.round(params.iterations);
+  const s = generateGosper(depth);
+  const step = params.initialSize * params.ratio ** depth;
+  const turn = (60 * Math.PI) / 180;
+
+  // 先に構築（中心合わせのため）
+  /** @type {{x:number,y:number}[]} */
+  const pts = [];
+  let x = 0;
+  let y = 0;
+  let a = 0;
+  pts.push({ x, y });
+  for (const c of s) {
+    if (c === 'A' || c === 'B') {
+      x += Math.cos(a) * step;
+      y += Math.sin(a) * step;
+      pts.push({ x, y });
+    } else if (c === '+') a += turn;
+    else if (c === '-') a -= turn;
+  }
+  // bbox 中心
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of pts) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  const ox = (minX + maxX) / 2;
+  const oy = (minY + maxY) / 2;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(ang);
+  ctx.beginPath();
+  const p0 = pts[0];
+  ctx.moveTo(p0.x - ox, p0.y - oy);
+  for (let i = 1; i < pts.length; i++) {
+    const t = i / pts.length;
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+    ctx.strokeStyle = `hsla(${hue}, 80%, 60%, ${params.strokeAlpha})`;
+    ctx.lineWidth = params.thickness;
+    ctx.beginPath();
+    ctx.moveTo(pts[i - 1].x - ox, pts[i - 1].y - oy);
+    ctx.lineTo(pts[i].x - ox, pts[i].y - oy);
+    ctx.stroke();
+  }
+
+  if (params.showOutline) {
+    // 全体を閉じて塗り
+    ctx.fillStyle = `hsla(${params.hueStart}, 80%, 50%, ${params.fillAlpha})`;
+    ctx.beginPath();
+    ctx.moveTo(pts[0].x - ox, pts[0].y - oy);
+    for (let i = 1; i < pts.length; i++) {
+      ctx.lineTo(pts[i].x - ox, pts[i].y - oy);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+
+  if (params.bloom > 0) {
+    ctx.fillStyle = `hsla(${params.hueEnd}, 90%, 70%, ${params.bloom})`;
+    ctx.beginPath();
+    ctx.arc(p0.x - ox, p0.y - oy, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Gosper Island',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'iterations', 0, 4, 1);
+gui.add(params, 'initialSize', 120, 500, 1);
+gui.add(params, 'ratio', 0.2, 0.6, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'fillAlpha', 0, 0.6, 0.01);
+gui.add(params, 'thickness', 0.3, 4, 0.1);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+gui.add(params, 'bloom', 0, 1, 0.01);
+gui.add(params, 'showOutline');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.iterations = rand(2, 4, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  params.fillAlpha = rand(0.05, 0.35, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/gosper-island/style.css
+++ b/public/gosper-island/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/granular-cloud/index.html
+++ b/public/granular-cloud/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Granular Cloud | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/granular-cloud/main.js
+++ b/public/granular-cloud/main.js
@@ -1,0 +1,152 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// グラニュラーシンセの粒を視覚化。ソース波形からランダムに小さい粒をサンプリングして空間にばらまく。
+const params = {
+  grainRate: 60, // 1 秒あたりのグレイン生成数
+  grainLifetime: 1.8,
+  grainSize: 4,
+  sourceFreq: 0.5,
+  scatterX: 400,
+  scatterY: 280,
+  driftY: 20,
+  hueStart: 30,
+  hueRange: 300,
+  alpha: 0.8,
+  trailFade: 0.08,
+  pitchJitter: 0.6,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {{x:number,y:number,vx:number,vy:number,t:number,life:number,hue:number,size:number}[]} */
+let grains = [];
+let time = 0;
+let spawnBudget = 0;
+
+function spawn() {
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const dx = (Math.random() - 0.5) * params.scatterX;
+  const dy = (Math.random() - 0.5) * params.scatterY;
+  const pitch = 1 + (Math.random() - 0.5) * params.pitchJitter;
+  const hue =
+    params.hueStart +
+    (Math.sin(time * params.sourceFreq) + 1) * 0.5 * params.hueRange +
+    pitch * 20;
+  grains.push({
+    x: cx + dx,
+    y: cy + dy,
+    vx: (Math.random() - 0.5) * 20,
+    vy: -Math.random() * params.driftY,
+    t: 0,
+    life: params.grainLifetime * (0.7 + Math.random() * 0.6),
+    hue,
+    size: params.grainSize * (0.6 + Math.random() * 0.8) * pitch,
+  });
+}
+
+function draw() {
+  const dt = 1 / 60;
+  time += dt;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  spawnBudget += params.grainRate * dt;
+  while (spawnBudget >= 1) {
+    spawn();
+    spawnBudget--;
+  }
+
+  grains = grains.filter((g) => g.t < g.life);
+  for (const g of grains) {
+    g.t += dt;
+    g.x += g.vx * dt;
+    g.y += g.vy * dt;
+    g.vy -= 5 * dt; // ふわっと上昇
+    const k = g.t / g.life;
+    const a = params.alpha * Math.sin(k * Math.PI); // 包絡
+    ctx.fillStyle = `hsla(${g.hue}, 90%, 70%, ${a})`;
+    ctx.beginPath();
+    ctx.arc(g.x, g.y, g.size * (1 - k * 0.3), 0, Math.PI * 2);
+    ctx.fill();
+    // グロー
+    ctx.fillStyle = `hsla(${g.hue}, 100%, 80%, ${a * 0.4})`;
+    ctx.beginPath();
+    ctx.arc(g.x, g.y, g.size * 2.2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // ソース波形の線（装飾）
+  ctx.strokeStyle = `hsla(${params.hueStart + 180}, 60%, 60%, 0.3)`;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  const mid = canvas.height / 2;
+  const amp = 60;
+  for (let x = 0; x < canvas.width; x += 3) {
+    const y = mid + Math.sin(x * 0.02 + time * params.sourceFreq * 3) * amp;
+    if (x === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Granular Cloud',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'grainRate', 10, 300, 1);
+gui.add(params, 'grainLifetime', 0.3, 5, 0.05);
+gui.add(params, 'grainSize', 1, 15, 0.1);
+gui.add(params, 'sourceFreq', 0.05, 2, 0.01);
+gui.add(params, 'scatterX', 50, 800, 1);
+gui.add(params, 'scatterY', 30, 500, 1);
+gui.add(params, 'driftY', 0, 80, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+gui.add(params, 'pitchJitter', 0, 2, 0.05);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.grainRate = rand(30, 150, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  params.sourceFreq = rand(0.2, 1.2, 0.01);
+  params.driftY = rand(5, 60, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  grains = [];
+  gui.updateDisplay();
+});

--- a/public/granular-cloud/style.css
+++ b/public/granular-cloud/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/gray-scott-model/index.html
+++ b/public/gray-scott-model/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Gray-Scott Model | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/gray-scott-model/main.js
+++ b/public/gray-scott-model/main.js
@@ -1,0 +1,239 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Gray-Scott モデルのプリセット探索版。パラメータ一覧でパターン分類を切り替え。
+const params = {
+  presetIdx: 0, // 0:spots 1:stripes 2:mitosis 3:bubbles 4:worms 5:chaos
+  feed: 0.036,
+  kill: 0.06,
+  dA: 1,
+  dB: 0.5,
+  gridScale: 5,
+  iterPerFrame: 8,
+  hueA: 40,
+  hueB: 220,
+  brightness: 1.5,
+  seedRadius: 14,
+  multiSeed: 5,
+  flowBias: 0,
+};
+const defaults = { ...params };
+
+const presets = [
+  { name: 'Spots', feed: 0.036, kill: 0.06 },
+  { name: 'Stripes', feed: 0.042, kill: 0.063 },
+  { name: 'Mitosis', feed: 0.0367, kill: 0.0649 },
+  { name: 'Bubbles', feed: 0.098, kill: 0.057 },
+  { name: 'Worms', feed: 0.058, kill: 0.065 },
+  { name: 'Chaos', feed: 0.026, kill: 0.051 },
+];
+
+function applyPreset(i) {
+  const p = presets[i % presets.length];
+  params.feed = p.feed;
+  params.kill = p.kill;
+}
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** @type {Float32Array} */
+let A;
+/** @type {Float32Array} */
+let B;
+/** @type {Float32Array} */
+let A2;
+/** @type {Float32Array} */
+let B2;
+let gw = 0;
+let gh = 0;
+
+function rebuild() {
+  gw = Math.max(40, Math.floor(canvas.width / params.gridScale));
+  gh = Math.max(40, Math.floor(canvas.height / params.gridScale));
+  A = new Float32Array(gw * gh);
+  B = new Float32Array(gw * gh);
+  A2 = new Float32Array(gw * gh);
+  B2 = new Float32Array(gw * gh);
+  for (let i = 0; i < A.length; i++) A[i] = 1;
+  const m = Math.max(1, Math.round(params.multiSeed));
+  for (let i = 0; i < m; i++) {
+    seed(Math.random() * gw, Math.random() * gh);
+  }
+}
+
+function seed(cx, cy) {
+  const r = Math.round(params.seedRadius);
+  for (let y = -r; y <= r; y++) {
+    for (let x = -r; x <= r; x++) {
+      const px = Math.floor(cx + x);
+      const py = Math.floor(cy + y);
+      if (px < 0 || py < 0 || px >= gw || py >= gh) continue;
+      if (x * x + y * y <= r * r) B[py * gw + px] = 1;
+    }
+  }
+}
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  rebuild();
+}
+window.addEventListener('resize', resize);
+resize();
+
+function laplacian(buf, x, y) {
+  const idx = y * gw + x;
+  const xm = (x - 1 + gw) % gw;
+  const xp = (x + 1) % gw;
+  const ym = (y - 1 + gh) % gh;
+  const yp = (y + 1) % gh;
+  return (
+    buf[ym * gw + xm] * 0.05 +
+    buf[ym * gw + x] * 0.2 +
+    buf[ym * gw + xp] * 0.05 +
+    buf[y * gw + xm] * 0.2 +
+    buf[idx] * -1 +
+    buf[y * gw + xp] * 0.2 +
+    buf[yp * gw + xm] * 0.05 +
+    buf[yp * gw + x] * 0.2 +
+    buf[yp * gw + xp] * 0.05
+  );
+}
+
+function iterate() {
+  const F = params.feed;
+  const K = params.kill;
+  const bias = params.flowBias;
+  for (let y = 0; y < gh; y++) {
+    for (let x = 0; x < gw; x++) {
+      const idx = y * gw + x;
+      const av = A[idx];
+      const bv = B[idx];
+      const abb = av * bv * bv;
+      A2[idx] = av + (params.dA * laplacian(A, x, y) - abb + F * (1 - av));
+      B2[idx] =
+        bv +
+        (params.dB * laplacian(B, x, y) + abb - (K + F) * bv) +
+        bias * 0.001 * (x / gw - 0.5);
+      if (A2[idx] < 0) A2[idx] = 0;
+      if (A2[idx] > 1) A2[idx] = 1;
+      if (B2[idx] < 0) B2[idx] = 0;
+      if (B2[idx] > 1) B2[idx] = 1;
+    }
+  }
+  [A, A2] = [A2, A];
+  [B, B2] = [B2, B];
+}
+
+let lastPreset = -1;
+
+function draw() {
+  if (Math.round(params.presetIdx) !== lastPreset) {
+    lastPreset = Math.round(params.presetIdx);
+    applyPreset(lastPreset);
+  }
+  const iters = Math.round(params.iterPerFrame);
+  for (let i = 0; i < iters; i++) iterate();
+
+  const img = ctx.createImageData(canvas.width, canvas.height);
+  const data = img.data;
+  const sx = canvas.width / gw;
+  const sy = canvas.height / gh;
+  for (let py = 0; py < canvas.height; py++) {
+    const gy = Math.min(gh - 1, Math.floor(py / sy));
+    for (let px = 0; px < canvas.width; px++) {
+      const gx = Math.min(gw - 1, Math.floor(px / sx));
+      const i = gy * gw + gx;
+      const av = A[i];
+      const bv = B[i] * params.brightness;
+      const t = Math.min(1, bv);
+      const hue = params.hueA * (1 - t) + params.hueB * t;
+      const h = (hue % 360) / 60;
+      const c = t;
+      const x = c * (1 - Math.abs((h % 2) - 1));
+      let r = 0;
+      let g = 0;
+      let bb = 0;
+      if (h < 1) {
+        r = c;
+        g = x;
+      } else if (h < 2) {
+        r = x;
+        g = c;
+      } else if (h < 3) {
+        g = c;
+        bb = x;
+      } else if (h < 4) {
+        g = x;
+        bb = c;
+      } else if (h < 5) {
+        r = x;
+        bb = c;
+      } else {
+        r = c;
+        bb = x;
+      }
+      const m = av * 0.2;
+      const off = (py * canvas.width + px) * 4;
+      data[off] = Math.floor((r + m) * 255);
+      data[off + 1] = Math.floor((g + m) * 255);
+      data[off + 2] = Math.floor((bb + m) * 255);
+      data[off + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Gray-Scott Model',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'presetIdx', 0, presets.length - 1, 1);
+gui.add(params, 'feed', 0.02, 0.1, 0.001);
+gui.add(params, 'kill', 0.04, 0.075, 0.001);
+gui.add(params, 'dA', 0.5, 1.5, 0.01);
+gui.add(params, 'dB', 0.2, 1, 0.01);
+gui.add(params, 'gridScale', 3, 10, 1);
+gui.add(params, 'iterPerFrame', 2, 20, 1);
+gui.add(params, 'hueA', 0, 360, 1);
+gui.add(params, 'hueB', 0, 360, 1);
+gui.add(params, 'brightness', 0.5, 3, 0.05);
+gui.add(params, 'seedRadius', 3, 40, 1);
+gui.add(params, 'multiSeed', 1, 15, 1);
+gui.add(params, 'flowBias', -5, 5, 0.1);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.presetIdx = rand(0, presets.length - 1, 1);
+  params.hueA = rand(0, 360, 1);
+  params.hueB = rand(0, 360, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reseed', () => rebuild());
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/gray-scott-model/style.css
+++ b/public/gray-scott-model/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/h-tree/index.html
+++ b/public/h-tree/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>H Tree | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/h-tree/main.js
+++ b/public/h-tree/main.js
@@ -1,0 +1,196 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 9,
+  initialLength: 260,
+  ratio: Math.SQRT1_2,
+  thickness: 3,
+  thickDecay: 0.72,
+  hueStart: 200,
+  hueEnd: 320,
+  alpha: 0.9,
+  rotation: 0,
+  rotSpeed: 0.08,
+  fade: 0.18,
+  bloom: 0.7,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 水平もしくは垂直の「H」形を再帰描画
+ * @param {number} x
+ * @param {number} y
+ * @param {number} length
+ * @param {boolean} horizontal
+ * @param {number} depth
+ * @param {number} thickness
+ */
+function hTree(x, y, length, horizontal, depth, thickness) {
+  if (depth <= 0 || length < 1) return;
+  const t = 1 - depth / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.alpha})`;
+  ctx.lineWidth = Math.max(0.1, thickness);
+
+  const half = length / 2;
+  let x1;
+  let y1;
+  let x2;
+  let y2;
+  let x3;
+  let y3;
+  let x4;
+  let y4;
+  if (horizontal) {
+    // 水平棒
+    x1 = x - half;
+    y1 = y;
+    x2 = x + half;
+    y2 = y;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+    // 左右の垂直棒
+    x3 = x1;
+    y3 = y - half;
+    x4 = x1;
+    y4 = y + half;
+    ctx.beginPath();
+    ctx.moveTo(x3, y3);
+    ctx.lineTo(x4, y4);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x2, y - half);
+    ctx.lineTo(x2, y + half);
+    ctx.stroke();
+    const nl = length * params.ratio;
+    const nt = thickness * params.thickDecay;
+    hTree(x1, y - half, nl, !horizontal, depth - 1, nt);
+    hTree(x1, y + half, nl, !horizontal, depth - 1, nt);
+    hTree(x2, y - half, nl, !horizontal, depth - 1, nt);
+    hTree(x2, y + half, nl, !horizontal, depth - 1, nt);
+  } else {
+    x1 = x;
+    y1 = y - half;
+    x2 = x;
+    y2 = y + half;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x - half, y1);
+    ctx.lineTo(x + half, y1);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(x - half, y2);
+    ctx.lineTo(x + half, y2);
+    ctx.stroke();
+    const nl = length * params.ratio;
+    const nt = thickness * params.thickDecay;
+    hTree(x - half, y1, nl, !horizontal, depth - 1, nt);
+    hTree(x + half, y1, nl, !horizontal, depth - 1, nt);
+    hTree(x - half, y2, nl, !horizontal, depth - 1, nt);
+    hTree(x + half, y2, nl, !horizontal, depth - 1, nt);
+  }
+
+  if (depth === 1 && params.bloom > 0) {
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, ${params.bloom})`;
+    ctx.beginPath();
+    ctx.arc(x, y, thickness + 1, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const ang = params.rotation + time * params.rotSpeed;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(ang);
+  ctx.lineCap = 'round';
+  hTree(
+    0,
+    0,
+    params.initialLength,
+    true,
+    Math.round(params.depth),
+    params.thickness,
+  );
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'H Tree',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 2, 12, 1);
+gui.add(params, 'initialLength', 80, 400, 1);
+gui.add(params, 'ratio', 0.4, 0.8, 0.01);
+gui.add(params, 'thickness', 0.5, 8, 0.1);
+gui.add(params, 'thickDecay', 0.5, 0.95, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'alpha', 0.1, 1, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+gui.add(params, 'fade', 0, 0.5, 0.01);
+gui.add(params, 'bloom', 0, 1, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(6, 10, 1);
+  params.initialLength = rand(160, 320, 1);
+  params.ratio = rand(0.55, 0.75, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  params.bloom = rand(0.3, 0.9, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/h-tree/style.css
+++ b/public/h-tree/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -823,6 +823,12 @@
               <span class="nav-description">メンガースポンジ断面</span>
             </a>
           </li>
+          <li>
+            <a href="/spectrogram-painter/">
+              Spectrogram Painter
+              <span class="nav-description">スペクトログラム描画</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -907,6 +907,12 @@
               <span class="nav-description">遺伝的生物</span>
             </a>
           </li>
+          <li>
+            <a href="/neural-network-viz/">
+              Neural Network Viz
+              <span class="nav-description">ニューラルネット可視化</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -877,6 +877,12 @@
               <span class="nav-description">グラニュラークラウド</span>
             </a>
           </li>
+          <li>
+            <a href="/beat-interference/">
+              Beat Interference
+              <span class="nav-description">ビート干渉</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -895,6 +895,12 @@
               <span class="nav-description">反応拡散系</span>
             </a>
           </li>
+          <li>
+            <a href="/gray-scott-model/">
+              Gray-Scott Model
+              <span class="nav-description">Gray-Scott モデル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -841,6 +841,12 @@
               <span class="nav-description">位相シフトメトロノーム</span>
             </a>
           </li>
+          <li>
+            <a href="/euclidean-rhythm/">
+              Euclidean Rhythm
+              <span class="nav-description">ユークリッドリズム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -937,6 +937,12 @@
               <span class="nav-description">DNAヘリックス</span>
             </a>
           </li>
+          <li>
+            <a href="/cell-division/">
+              Cell Division
+              <span class="nav-description">細胞分裂</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -919,6 +919,12 @@
               <span class="nav-description">葉脈形成</span>
             </a>
           </li>
+          <li>
+            <a href="/coral-growth/">
+              Coral Growth
+              <span class="nav-description">サンゴの成長</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -931,6 +931,12 @@
               <span class="nav-description">菌糸ネットワーク</span>
             </a>
           </li>
+          <li>
+            <a href="/dna-helix/">
+              DNA Helix
+              <span class="nav-description">DNAヘリックス</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -901,6 +901,12 @@
               <span class="nav-description">Gray-Scott モデル</span>
             </a>
           </li>
+          <li>
+            <a href="/genetic-creatures/">
+              Genetic Creatures
+              <span class="nav-description">遺伝的生物</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -889,6 +889,12 @@
               <span class="nav-description">リセのリズム</span>
             </a>
           </li>
+          <li>
+            <a href="/reaction-diffusion/">
+              Reaction Diffusion
+              <span class="nav-description">反応拡散系</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -829,6 +829,12 @@
               <span class="nav-description">スペクトログラム描画</span>
             </a>
           </li>
+          <li>
+            <a href="/circular-sequencer/">
+              Circular Sequencer
+              <span class="nav-description">円形シーケンサー</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -853,6 +853,12 @@
               <span class="nav-description">ポリリズム円盤</span>
             </a>
           </li>
+          <li>
+            <a href="/chord-wheel/">
+              Chord Wheel
+              <span class="nav-description">コードホイール</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -817,6 +817,12 @@
               <span class="nav-description">ゴスパー島</span>
             </a>
           </li>
+          <li>
+            <a href="/menger-slice/">
+              Menger Slice
+              <span class="nav-description">メンガースポンジ断面</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -925,6 +925,12 @@
               <span class="nav-description">サンゴの成長</span>
             </a>
           </li>
+          <li>
+            <a href="/mycelium-network/">
+              Mycelium Network
+              <span class="nav-description">菌糸ネットワーク</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -883,6 +883,12 @@
               <span class="nav-description">ビート干渉</span>
             </a>
           </li>
+          <li>
+            <a href="/risset-rhythm/">
+              Risset Rhythm
+              <span class="nav-description">リセのリズム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -835,6 +835,12 @@
               <span class="nav-description">円形シーケンサー</span>
             </a>
           </li>
+          <li>
+            <a href="/phase-shift-metronome/">
+              Phase Shift Metronome
+              <span class="nav-description">位相シフトメトロノーム</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -781,6 +781,12 @@
               <span class="nav-description">ニュートン法フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/barnsley-fern/">
+              Barnsley Fern
+              <span class="nav-description">バーンズリーのシダ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -787,6 +787,12 @@
               <span class="nav-description">バーンズリーのシダ</span>
             </a>
           </li>
+          <li>
+            <a href="/apollonian-gasket/">
+              Apollonian Gasket
+              <span class="nav-description">アポロニウスのガスケット</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -943,6 +943,12 @@
               <span class="nav-description">細胞分裂</span>
             </a>
           </li>
+          <li>
+            <a href="/virus-capsid/">
+              Virus Capsid
+              <span class="nav-description">ウイルスカプシド</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -859,6 +859,12 @@
               <span class="nav-description">コードホイール</span>
             </a>
           </li>
+          <li>
+            <a href="/fm-synthesis-visualizer/">
+              FM Synthesis Visualizer
+              <span class="nav-description">FM 合成ビジュアライザ</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -913,6 +913,12 @@
               <span class="nav-description">ニューラルネット可視化</span>
             </a>
           </li>
+          <li>
+            <a href="/leaf-venation/">
+              Leaf Venation
+              <span class="nav-description">葉脈形成</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -793,6 +793,12 @@
               <span class="nav-description">アポロニウスのガスケット</span>
             </a>
           </li>
+          <li>
+            <a href="/h-tree/">
+              H Tree
+              <span class="nav-description">H木フラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -949,6 +949,12 @@
               <span class="nav-description">ウイルスカプシド</span>
             </a>
           </li>
+          <li>
+            <a href="/chromatic-aberration/">
+              Chromatic Aberration
+              <span class="nav-description">色収差</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -865,6 +865,12 @@
               <span class="nav-description">FM 合成ビジュアライザ</span>
             </a>
           </li>
+          <li>
+            <a href="/karplus-strong-strings/">
+              Karplus-Strong Strings
+              <span class="nav-description">カープラス・ストロング弦</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -811,6 +811,12 @@
               <span class="nav-description">T-スクエアフラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/gosper-island/">
+              Gosper Island
+              <span class="nav-description">ゴスパー島</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -799,6 +799,12 @@
               <span class="nav-description">H木フラクタル</span>
             </a>
           </li>
+          <li>
+            <a href="/pythagoras-tree/">
+              Pythagoras Tree
+              <span class="nav-description">ピタゴラスの木</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -847,6 +847,12 @@
               <span class="nav-description">ユークリッドリズム</span>
             </a>
           </li>
+          <li>
+            <a href="/polyrhythm-wheel/">
+              Polyrhythm Wheel
+              <span class="nav-description">ポリリズム円盤</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -805,6 +805,12 @@
               <span class="nav-description">ピタゴラスの木</span>
             </a>
           </li>
+          <li>
+            <a href="/t-square-fractal/">
+              T-Square Fractal
+              <span class="nav-description">T-スクエアフラクタル</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -955,6 +955,12 @@
               <span class="nav-description">色収差</span>
             </a>
           </li>
+          <li>
+            <a href="/diffraction-grating/">
+              Diffraction Grating
+              <span class="nav-description">回折格子</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/index.html
+++ b/public/index.html
@@ -871,6 +871,12 @@
               <span class="nav-description">カープラス・ストロング弦</span>
             </a>
           </li>
+          <li>
+            <a href="/granular-cloud/">
+              Granular Cloud
+              <span class="nav-description">グラニュラークラウド</span>
+            </a>
+          </li>
         </ul>
       </nav>
     </main>

--- a/public/karplus-strong-strings/index.html
+++ b/public/karplus-strong-strings/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Karplus-Strong Strings | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/karplus-strong-strings/main.js
+++ b/public/karplus-strong-strings/main.js
@@ -1,0 +1,171 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 物理モデル合成の Karplus-Strong を可視化（音は出さず、弦の波形アニメーション）
+const params = {
+  strings: 6, // 弦の本数
+  length: 600, // 弦の長さ（ドット数）
+  damping: 0.993, // 減衰
+  pluckInterval: 0.7,
+  pluckStrength: 0.9,
+  stringGap: 60,
+  hueStart: 20,
+  hueRange: 300,
+  amplitude: 35,
+  strokeAlpha: 0.9,
+  lineWidth: 1.6,
+  trailFade: 0.08,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Float32Array[]} */
+let strings = [];
+
+function rebuild() {
+  const n = Math.round(params.strings);
+  const L = Math.round(params.length);
+  strings = [];
+  for (let i = 0; i < n; i++) {
+    strings.push(new Float32Array(L));
+  }
+}
+rebuild();
+
+/**
+ * 弦を撥弦（ランダム振動で初期化）
+ * @param {number} i
+ */
+function pluck(i) {
+  const buf = strings[i];
+  if (!buf) return;
+  for (let k = 0; k < buf.length; k++) {
+    buf[k] = (Math.random() * 2 - 1) * params.pluckStrength;
+  }
+}
+
+let time = 0;
+let lastPluck = 0;
+
+function step() {
+  // Karplus-Strong: buf[k] = damping * (buf[k] + buf[k-1]) / 2
+  for (const buf of strings) {
+    const L = buf.length;
+    let prev = buf[L - 1];
+    for (let k = 0; k < L; k++) {
+      const cur = buf[k];
+      buf[k] = params.damping * ((cur + prev) / 2);
+      prev = cur;
+    }
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  if (time - lastPluck > params.pluckInterval) {
+    lastPluck = time;
+    const i = Math.floor(Math.random() * strings.length);
+    pluck(i);
+  }
+
+  for (let iter = 0; iter < 4; iter++) step();
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const n = strings.length;
+  const totalH = (n - 1) * params.stringGap;
+  const startY = cy - totalH / 2;
+  for (let i = 0; i < n; i++) {
+    const y0 = startY + i * params.stringGap;
+    const hue = params.hueStart + (i / Math.max(1, n - 1)) * params.hueRange;
+    const buf = strings[i];
+    const L = buf.length;
+    const w = Math.min(canvas.width - 80, L);
+    const x0 = cx - w / 2;
+    ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.strokeAlpha})`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    for (let k = 0; k < L; k += 2) {
+      const sx = x0 + (k / L) * w;
+      const sy = y0 + buf[k] * params.amplitude;
+      if (k === 0) ctx.moveTo(sx, sy);
+      else ctx.lineTo(sx, sy);
+    }
+    ctx.stroke();
+    // 両端のピン
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(x0, y0, 4, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.beginPath();
+    ctx.arc(x0 + w, y0, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Karplus-Strong Strings',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'strings', 1, 10, 1);
+gui.add(params, 'length', 100, 1000, 10);
+gui.add(params, 'damping', 0.9, 0.999, 0.001);
+gui.add(params, 'pluckInterval', 0.1, 3, 0.05);
+gui.add(params, 'pluckStrength', 0.2, 1.5, 0.05);
+gui.add(params, 'stringGap', 20, 120, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'amplitude', 5, 80, 1);
+gui.add(params, 'strokeAlpha', 0.2, 1, 0.01);
+gui.add(params, 'lineWidth', 0.5, 4, 0.1);
+gui.add(params, 'trailFade', 0.02, 0.3, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Pluck', () => {
+  for (let i = 0; i < strings.length; i++) pluck(i);
+});
+gui.addButton('Random', () => {
+  params.strings = rand(3, 8, 1);
+  params.damping = rand(0.985, 0.998, 0.001);
+  params.pluckInterval = rand(0.3, 1.2, 0.05);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/karplus-strong-strings/style.css
+++ b/public/karplus-strong-strings/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/leaf-venation/index.html
+++ b/public/leaf-venation/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Leaf Venation | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/leaf-venation/main.js
+++ b/public/leaf-venation/main.js
@@ -1,0 +1,221 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Space Colonization 法で葉脈を成長させる。葉の輪郭内に魅力点を散布し、枝が最近傍で伸びる。
+const params = {
+  attractors: 600,
+  killDistance: 8,
+  influenceRadius: 60,
+  stepLength: 4,
+  maxSteps: 1500,
+  leafWidth: 480,
+  leafHeight: 700,
+  hueStart: 90,
+  hueEnd: 40,
+  fadeAlpha: 0,
+  lineWidth: 1.2,
+  autoRegrow: true,
+  regrowInterval: 8,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Node
+ * @property {number} x
+ * @property {number} y
+ * @property {Node|null} parent
+ * @property {number} depth
+ */
+
+/** @type {{x:number,y:number}[]} */
+let attractors = [];
+/** @type {Node[]} */
+let nodes = [];
+let stepCount = 0;
+let time = 0;
+let lastRegrow = 0;
+
+function isInLeaf(x, y, cx, cy) {
+  // 葉の形: 両端がすぼむ楕円 (0.5 * (1 - cos(t)) で y 方向の幅を変える)
+  const u = (y - (cy - params.leafHeight / 2)) / params.leafHeight; // 0..1
+  if (u < 0 || u > 1) return false;
+  const w = Math.sin(u * Math.PI) * params.leafWidth * 0.5;
+  const dx = x - cx;
+  return Math.abs(dx) <= w;
+}
+
+function reset() {
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  attractors = [];
+  for (let i = 0; i < params.attractors; i++) {
+    let x;
+    let y;
+    let tries = 0;
+    do {
+      x = cx + (Math.random() - 0.5) * params.leafWidth;
+      y = cy + (Math.random() - 0.5) * params.leafHeight;
+      tries++;
+    } while (!isInLeaf(x, y, cx, cy) && tries < 20);
+    attractors.push({ x, y });
+  }
+  nodes = [{ x: cx, y: cy + params.leafHeight / 2, parent: null, depth: 0 }];
+  stepCount = 0;
+  // 背景クリア
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  // 葉の輪郭
+  const seg = 80;
+  ctx.strokeStyle = 'rgba(140, 180, 100, 0.18)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 0; i <= seg; i++) {
+    const u = i / seg;
+    const w = Math.sin(u * Math.PI) * params.leafWidth * 0.5;
+    const y = cy - params.leafHeight / 2 + u * params.leafHeight;
+    if (i === 0) ctx.moveTo(cx + w, y);
+    else ctx.lineTo(cx + w, y);
+  }
+  for (let i = seg; i >= 0; i--) {
+    const u = i / seg;
+    const w = Math.sin(u * Math.PI) * params.leafWidth * 0.5;
+    const y = cy - params.leafHeight / 2 + u * params.leafHeight;
+    ctx.lineTo(cx - w, y);
+  }
+  ctx.closePath();
+  ctx.stroke();
+}
+reset();
+
+function step() {
+  if (stepCount > params.maxSteps || attractors.length === 0) return;
+  /** @type {Map<number, {dx:number, dy:number, count:number}>} */
+  const influences = new Map();
+  for (const a of attractors) {
+    let nearest = -1;
+    let minD = Infinity;
+    for (let i = 0; i < nodes.length; i++) {
+      const d = Math.hypot(a.x - nodes[i].x, a.y - nodes[i].y);
+      if (d < params.influenceRadius && d < minD) {
+        minD = d;
+        nearest = i;
+      }
+    }
+    if (nearest >= 0) {
+      const inf = influences.get(nearest) ?? { dx: 0, dy: 0, count: 0 };
+      const dx = a.x - nodes[nearest].x;
+      const dy = a.y - nodes[nearest].y;
+      const len = Math.hypot(dx, dy) || 1;
+      inf.dx += dx / len;
+      inf.dy += dy / len;
+      inf.count++;
+      influences.set(nearest, inf);
+    }
+  }
+  /** @type {Node[]} */
+  const newNodes = [];
+  for (const [idx, inf] of influences) {
+    const base = nodes[idx];
+    const len = Math.hypot(inf.dx, inf.dy) || 1;
+    const nx = base.x + (inf.dx / len) * params.stepLength;
+    const ny = base.y + (inf.dy / len) * params.stepLength;
+    /** @type {Node} */
+    const nn = { x: nx, y: ny, parent: base, depth: base.depth + 1 };
+    newNodes.push(nn);
+    // 描画（新しい枝）
+    const k = Math.min(1, nn.depth / 80);
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * k;
+    ctx.strokeStyle = `hsla(${hue}, 70%, 55%, 0.85)`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(base.x, base.y);
+    ctx.lineTo(nx, ny);
+    ctx.stroke();
+  }
+  nodes.push(...newNodes);
+  // 到達済みアトラクタを削除
+  attractors = attractors.filter((a) => {
+    for (const n of nodes) {
+      if (Math.hypot(a.x - n.x, a.y - n.y) < params.killDistance) return false;
+    }
+    return true;
+  });
+  stepCount++;
+}
+
+function draw() {
+  time += 1 / 60;
+  for (let i = 0; i < 2; i++) step();
+
+  if (params.autoRegrow && time - lastRegrow > params.regrowInterval) {
+    lastRegrow = time;
+    reset();
+  }
+
+  // 枝先の光
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fadeAlpha})`;
+  if (params.fadeAlpha > 0) ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Leaf Venation',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'attractors', 100, 1500, 10);
+gui.add(params, 'killDistance', 3, 20, 0.5);
+gui.add(params, 'influenceRadius', 20, 150, 1);
+gui.add(params, 'stepLength', 1, 10, 0.5);
+gui.add(params, 'maxSteps', 100, 3000, 50);
+gui.add(params, 'leafWidth', 200, 800, 5);
+gui.add(params, 'leafHeight', 300, 900, 5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'lineWidth', 0.5, 3, 0.1);
+gui.add(params, 'fadeAlpha', 0, 0.1, 0.005);
+gui.add(params, 'autoRegrow');
+gui.add(params, 'regrowInterval', 3, 30, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.attractors = rand(300, 1000, 10);
+  params.hueStart = rand(60, 160, 1);
+  params.hueEnd = rand(20, 80, 1);
+  params.leafWidth = rand(300, 600, 5);
+  params.leafHeight = rand(500, 800, 5);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/leaf-venation/style.css
+++ b/public/leaf-venation/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/menger-slice/index.html
+++ b/public/menger-slice/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Menger Slice | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/menger-slice/main.js
+++ b/public/menger-slice/main.js
@@ -1,0 +1,145 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 4,
+  size: 520,
+  zSlice: 0.5, // 断面の位置（0-1）
+  zAnimate: true,
+  sliceSpeed: 0.08,
+  hueStart: 20,
+  hueEnd: 280,
+  alpha: 0.95,
+  rotation: 0,
+  rotSpeed: 0.04,
+  strokeAlpha: 0.5,
+  showGrid: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 指定位置 (u,v,w) が Menger スポンジ内部かどうか
+ * @param {number} u 0-1
+ * @param {number} v 0-1
+ * @param {number} w 0-1
+ * @param {number} depth
+ */
+function isSolid(u, v, w, depth) {
+  for (let i = 0; i < depth; i++) {
+    const x = Math.floor(u * 3) % 3;
+    const y = Math.floor(v * 3) % 3;
+    const z = Math.floor(w * 3) % 3;
+    // 中央面 2 個以上で 1 になると穴
+    let mids = 0;
+    if (x === 1) mids++;
+    if (y === 1) mids++;
+    if (z === 1) mids++;
+    if (mids >= 2) return false;
+    u = (u * 3) % 1;
+    v = (v * 3) % 1;
+    w = (w * 3) % 1;
+  }
+  return true;
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.25)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const depth = Math.round(params.depth);
+  const n = 3 ** depth;
+  const cell = params.size / n;
+  const wSlice = params.zAnimate
+    ? (Math.sin(time * params.sliceSpeed) + 1) * 0.5
+    : params.zSlice;
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(params.rotation + time * params.rotSpeed);
+  ctx.translate(-params.size / 2, -params.size / 2);
+
+  for (let iy = 0; iy < n; iy++) {
+    for (let ix = 0; ix < n; ix++) {
+      const u = (ix + 0.5) / n;
+      const v = (iy + 0.5) / n;
+      if (isSolid(u, v, wSlice, depth)) {
+        const dist = Math.hypot(u - 0.5, v - 0.5, wSlice - 0.5);
+        const hue =
+          params.hueStart + (params.hueEnd - params.hueStart) * (1 - dist * 2);
+        ctx.fillStyle = `hsla(${hue}, 75%, 55%, ${params.alpha})`;
+        ctx.fillRect(ix * cell, iy * cell, cell + 0.5, cell + 0.5);
+        if (params.showGrid && cell > 3) {
+          ctx.strokeStyle = `hsla(${hue}, 85%, 75%, ${params.strokeAlpha})`;
+          ctx.lineWidth = 0.5;
+          ctx.strokeRect(ix * cell, iy * cell, cell, cell);
+        }
+      }
+    }
+  }
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Menger Slice',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 1, 5, 1);
+gui.add(params, 'size', 200, 700, 1);
+gui.add(params, 'zSlice', 0, 1, 0.001);
+gui.add(params, 'zAnimate');
+gui.add(params, 'sliceSpeed', 0, 0.5, 0.01);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+gui.add(params, 'showGrid');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.depth = rand(3, 5, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.sliceSpeed = rand(0.03, 0.2, 0.01);
+  params.rotSpeed = rand(-0.15, 0.15, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/menger-slice/style.css
+++ b/public/menger-slice/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/mycelium-network/index.html
+++ b/public/mycelium-network/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Mycelium Network | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/mycelium-network/main.js
+++ b/public/mycelium-network/main.js
@@ -1,0 +1,207 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 菌糸ネットワーク：先端がランダムに曲がりながら伸び、一定確率で分岐、既存の糸に近づくと結合する。
+const params = {
+  seeds: 6,
+  maxTips: 220,
+  stepLength: 2.4,
+  wanderAmt: 0.18,
+  branchProb: 0.012,
+  terminateProb: 0.002,
+  connectRadius: 8,
+  hueStart: 40,
+  hueEnd: 320,
+  lineWidth: 1.1,
+  fade: 0.015,
+  glowAlpha: 0.35,
+  autoRegrow: true,
+  regrowInterval: 14,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/**
+ * @typedef {object} Tip
+ * @property {number} x
+ * @property {number} y
+ * @property {number} angle
+ * @property {number} depth
+ * @property {number} age
+ */
+
+/** @type {Tip[]} */
+let tips = [];
+/** @type {{x:number, y:number}[]} */
+let trace = [];
+let time = 0;
+let lastRegrow = 0;
+
+function reset() {
+  tips = [];
+  trace = [];
+  for (let i = 0; i < Math.round(params.seeds); i++) {
+    tips.push({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      angle: Math.random() * Math.PI * 2,
+      depth: 0,
+      age: 0,
+    });
+  }
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+reset();
+
+function nearestDistance(x, y, ignoreIdx) {
+  let minD = Infinity;
+  for (let i = 0; i < trace.length; i++) {
+    if (i === ignoreIdx) continue;
+    const p = trace[i];
+    const d = Math.hypot(x - p.x, y - p.y);
+    if (d < minD) minD = d;
+  }
+  return minD;
+}
+
+function step() {
+  /** @type {Tip[]} */
+  const newTips = [];
+  for (const tip of tips) {
+    tip.angle += (Math.random() - 0.5) * params.wanderAmt;
+    const nx = tip.x + Math.cos(tip.angle) * params.stepLength;
+    const ny = tip.y + Math.sin(tip.angle) * params.stepLength;
+    // 画面外なら折り返し
+    if (nx < 0 || nx > canvas.width || ny < 0 || ny > canvas.height) {
+      tip.angle += Math.PI;
+      continue;
+    }
+    const k = Math.min(1, tip.depth / 300);
+    const hue = params.hueStart + (params.hueEnd - params.hueStart) * k;
+    ctx.strokeStyle = `hsla(${hue}, 70%, 60%, 0.85)`;
+    ctx.lineWidth = params.lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(tip.x, tip.y);
+    ctx.lineTo(nx, ny);
+    ctx.stroke();
+    // グロー
+    ctx.fillStyle = `hsla(${hue}, 90%, 80%, ${params.glowAlpha})`;
+    ctx.beginPath();
+    ctx.arc(nx, ny, 2.4, 0, Math.PI * 2);
+    ctx.fill();
+
+    tip.x = nx;
+    tip.y = ny;
+    tip.depth++;
+    tip.age++;
+    trace.push({ x: nx, y: ny });
+    if (trace.length > 3000) trace.shift();
+
+    // 近傍結合（終端）
+    if (tip.depth > 8) {
+      const minD = nearestDistance(nx, ny, trace.length - 1);
+      if (minD < params.connectRadius) {
+        continue; // tip 削除
+      }
+    }
+    // 分岐
+    if (
+      tips.length + newTips.length < params.maxTips &&
+      Math.random() < params.branchProb
+    ) {
+      newTips.push({
+        x: nx,
+        y: ny,
+        angle: tip.angle + (Math.random() - 0.5) * 1.2,
+        depth: tip.depth,
+        age: 0,
+      });
+    }
+    // 終端
+    if (Math.random() < params.terminateProb) continue;
+    newTips.push(tip);
+  }
+  tips = newTips;
+}
+
+function draw() {
+  time += 1 / 60;
+  if (params.fade > 0) {
+    ctx.fillStyle = `rgba(11, 10, 7, ${params.fade})`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  step();
+  if (params.autoRegrow) {
+    if (
+      (tips.length === 0 || time - lastRegrow > params.regrowInterval) &&
+      time > 1
+    ) {
+      lastRegrow = time;
+      reset();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Mycelium Network',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'seeds', 1, 20, 1);
+gui.add(params, 'maxTips', 30, 500, 5);
+gui.add(params, 'stepLength', 0.5, 6, 0.1);
+gui.add(params, 'wanderAmt', 0, 0.6, 0.01);
+gui.add(params, 'branchProb', 0, 0.1, 0.001);
+gui.add(params, 'terminateProb', 0, 0.02, 0.0005);
+gui.add(params, 'connectRadius', 2, 25, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'lineWidth', 0.3, 2.5, 0.1);
+gui.add(params, 'fade', 0, 0.05, 0.001);
+gui.add(params, 'glowAlpha', 0, 1, 0.01);
+gui.add(params, 'autoRegrow');
+gui.add(params, 'regrowInterval', 5, 40, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.seeds = rand(3, 12, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.branchProb = rand(0.005, 0.03, 0.001);
+  params.wanderAmt = rand(0.08, 0.3, 0.01);
+  reset();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  reset();
+  gui.updateDisplay();
+});

--- a/public/mycelium-network/style.css
+++ b/public/mycelium-network/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/neural-network-viz/index.html
+++ b/public/neural-network-viz/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Neural Network Viz | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/neural-network-viz/main.js
+++ b/public/neural-network-viz/main.js
@@ -1,0 +1,199 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 全結合多層ニューラルネットの活性伝播を可視化する。重みと活性を変化させながら描画。
+const params = {
+  inputs: 5,
+  hidden: 8,
+  hidden2: 6,
+  outputs: 4,
+  waveSpeed: 1.3,
+  weightPulse: 0.6,
+  lineAlpha: 0.5,
+  nodeSize: 14,
+  hueStart: 180,
+  hueRange: 180,
+  pulseSpeed: 2,
+  trailFade: 0.1,
+  thickness: 1.2,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Float32Array[][]} */
+let weights = [];
+/** @type {number[][]} */
+let activations = [];
+
+function rebuild() {
+  const layers = [
+    Math.round(params.inputs),
+    Math.round(params.hidden),
+    Math.round(params.hidden2),
+    Math.round(params.outputs),
+  ];
+  weights = [];
+  activations = layers.map((n) => new Array(n).fill(0));
+  for (let i = 0; i < layers.length - 1; i++) {
+    const w = [];
+    for (let j = 0; j < layers[i]; j++) {
+      const row = new Float32Array(layers[i + 1]);
+      for (let k = 0; k < layers[i + 1]; k++) row[k] = Math.random() * 2 - 1;
+      w.push(row);
+    }
+    weights.push(w);
+  }
+}
+rebuild();
+
+let time = 0;
+
+function sigmoid(x) {
+  return 1 / (1 + Math.exp(-x));
+}
+
+function step() {
+  const inputLen = activations[0].length;
+  for (let i = 0; i < inputLen; i++) {
+    activations[0][i] = (Math.sin(time * params.waveSpeed + i * 1.3) + 1) * 0.5;
+  }
+  for (let l = 1; l < activations.length; l++) {
+    for (let k = 0; k < activations[l].length; k++) {
+      let sum = 0;
+      for (let j = 0; j < activations[l - 1].length; j++) {
+        sum += activations[l - 1][j] * weights[l - 1][j][k];
+      }
+      activations[l][k] = sigmoid(sum);
+    }
+  }
+}
+
+function draw() {
+  time += 1 / 60;
+  step();
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const L = activations.length;
+  const margin = 80;
+  const usableW = canvas.width - margin * 2;
+  for (let l = 0; l < L; l++) {
+    const x = margin + (usableW * l) / Math.max(1, L - 1);
+    const n = activations[l].length;
+    const totalH = 500;
+    const startY = canvas.height / 2 - totalH / 2;
+    for (let i = 0; i < n; i++) {
+      const y = startY + (totalH * i) / Math.max(1, n - 1);
+      // 結線
+      if (l < L - 1) {
+        const nNext = activations[l + 1].length;
+        const xNext = margin + (usableW * (l + 1)) / Math.max(1, L - 1);
+        for (let k = 0; k < nNext; k++) {
+          const yNext = startY + (totalH * k) / Math.max(1, nNext - 1);
+          const w = weights[l][i][k];
+          const pulse =
+            0.5 +
+            0.5 *
+              Math.sin(
+                time * params.pulseSpeed * 2 * Math.PI + (l + i + k) * 0.3,
+              );
+          const act = activations[l][i] * Math.abs(w);
+          const alpha =
+            params.lineAlpha *
+            Math.min(1, act + 0.1) *
+            (0.5 + params.weightPulse * pulse);
+          const hue = params.hueStart + (w > 0 ? 40 : 280);
+          ctx.strokeStyle = `hsla(${hue}, 80%, 60%, ${alpha})`;
+          ctx.lineWidth = params.thickness * (0.5 + Math.abs(w));
+          ctx.beginPath();
+          ctx.moveTo(x, y);
+          ctx.lineTo(xNext, yNext);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  // ノード（重ねて描画）
+  for (let l = 0; l < L; l++) {
+    const x = margin + (usableW * l) / Math.max(1, L - 1);
+    const n = activations[l].length;
+    const totalH = 500;
+    const startY = canvas.height / 2 - totalH / 2;
+    for (let i = 0; i < n; i++) {
+      const y = startY + (totalH * i) / Math.max(1, n - 1);
+      const a = activations[l][i];
+      const hue = params.hueStart + (l / Math.max(1, L - 1)) * params.hueRange;
+      ctx.fillStyle = `hsla(${hue}, 85%, ${30 + a * 50}%, 0.95)`;
+      ctx.beginPath();
+      ctx.arc(x, y, params.nodeSize, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = `hsla(${hue}, 90%, 80%, 0.9)`;
+      ctx.lineWidth = 1.2;
+      ctx.stroke();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Neural Network Viz',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'inputs', 2, 12, 1);
+gui.add(params, 'hidden', 2, 16, 1);
+gui.add(params, 'hidden2', 2, 16, 1);
+gui.add(params, 'outputs', 2, 10, 1);
+gui.add(params, 'waveSpeed', 0.1, 4, 0.05);
+gui.add(params, 'weightPulse', 0, 1, 0.01);
+gui.add(params, 'lineAlpha', 0.1, 1, 0.01);
+gui.add(params, 'nodeSize', 6, 25, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'pulseSpeed', 0.1, 5, 0.05);
+gui.add(params, 'trailFade', 0.05, 0.3, 0.01);
+gui.add(params, 'thickness', 0.3, 3, 0.1);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.inputs = rand(3, 8, 1);
+  params.hidden = rand(5, 12, 1);
+  params.hidden2 = rand(4, 10, 1);
+  params.outputs = rand(3, 6, 1);
+  params.hueStart = rand(0, 360, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reseed', () => rebuild());
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/neural-network-viz/style.css
+++ b/public/neural-network-viz/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/phase-shift-metronome/index.html
+++ b/public/phase-shift-metronome/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Phase Shift Metronome | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/phase-shift-metronome/main.js
+++ b/public/phase-shift-metronome/main.js
@@ -1,0 +1,128 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Steve Reich の phase music 風。複数のメトロノームが少しずつ位相をずらしながら叩く。
+const params = {
+  count: 8, // メトロノーム数
+  baseBpm: 90,
+  drift: 2.5, // BPM差の最大値
+  lineLength: 520,
+  amplitude: 280, // 振幅
+  hueStart: 30,
+  hueRange: 300,
+  trailFade: 0.08,
+  ballSize: 8,
+  glow: 0.8,
+  showLines: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const n = Math.round(params.count);
+  const rowH = params.lineLength / Math.max(1, n - 1);
+
+  for (let i = 0; i < n; i++) {
+    const t = n === 1 ? 0 : i / (n - 1);
+    const bpm = params.baseBpm + (t - 0.5) * 2 * params.drift;
+    const freq = bpm / 60 / 2; // 半周期 = 1 拍
+    const phase = time * freq * Math.PI;
+    const x = cx + Math.sin(phase) * params.amplitude;
+    const y = cy - params.lineLength / 2 + i * rowH;
+    const hue = params.hueStart + t * params.hueRange;
+
+    if (params.showLines) {
+      ctx.strokeStyle = `hsla(${hue}, 60%, 40%, 0.3)`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(cx - params.amplitude, y);
+      ctx.lineTo(cx + params.amplitude, y);
+      ctx.stroke();
+    }
+
+    // 振動ボール
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, ${params.glow})`;
+    ctx.beginPath();
+    ctx.arc(x, y, params.ballSize, 0, Math.PI * 2);
+    ctx.fill();
+    // ハイライト
+    ctx.fillStyle = `hsla(${hue}, 100%, 85%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(x - 1.5, y - 1.5, params.ballSize * 0.4, 0, Math.PI * 2);
+    ctx.fill();
+    // 拍を打つ瞬間の強調（端で折り返す時）
+    const edge = Math.abs(Math.sin(phase));
+    if (edge > 0.995) {
+      ctx.strokeStyle = `hsla(${hue}, 100%, 75%, 0.8)`;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(x, y, params.ballSize + 6, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Phase Shift Metronome',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'count', 2, 20, 1);
+gui.add(params, 'baseBpm', 40, 200, 1);
+gui.add(params, 'drift', 0, 10, 0.1);
+gui.add(params, 'lineLength', 100, 800, 1);
+gui.add(params, 'amplitude', 60, 500, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'trailFade', 0, 0.3, 0.01);
+gui.add(params, 'ballSize', 3, 20, 0.5);
+gui.add(params, 'glow', 0.3, 1, 0.01);
+gui.add(params, 'showLines');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.count = rand(5, 14, 1);
+  params.baseBpm = rand(60, 140, 1);
+  params.drift = rand(1, 6, 0.1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/phase-shift-metronome/style.css
+++ b/public/phase-shift-metronome/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/polyrhythm-wheel/index.html
+++ b/public/polyrhythm-wheel/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Polyrhythm Wheel | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/polyrhythm-wheel/main.js
+++ b/public/polyrhythm-wheel/main.js
@@ -1,0 +1,161 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  bpm: 90,
+  division1: 3,
+  division2: 4,
+  division3: 5,
+  division4: 7,
+  showWheel4: true,
+  radius: 280,
+  gap: 50,
+  hueStart: 40,
+  hueStep: 80,
+  pulseGlow: 0.9,
+  trailFade: 0.15,
+  ballSize: 8,
+  lineAlpha: 0.4,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+/** @type {{x:number,y:number,t:number,hue:number}[]} */
+let pulses = [];
+
+/** @type {Map<string, number>} */
+const lastBeat = new Map();
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const barSec = 240 / params.bpm; // 1 小節 4 拍で 240/bpm 秒
+  const tBar = (time % barSec) / barSec;
+
+  const divs = [
+    Math.round(params.division1),
+    Math.round(params.division2),
+    Math.round(params.division3),
+  ];
+  if (params.showWheel4) divs.push(Math.round(params.division4));
+
+  for (let i = 0; i < divs.length; i++) {
+    const n = Math.max(1, divs[i]);
+    const rad = params.radius - i * params.gap;
+    if (rad <= 4) continue;
+    const hue = params.hueStart + i * params.hueStep;
+    // 背景円
+    ctx.strokeStyle = `hsla(${hue}, 60%, 45%, ${params.lineAlpha})`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+    ctx.stroke();
+    // 拍点
+    for (let k = 0; k < n; k++) {
+      const a = -Math.PI / 2 + (k / n) * Math.PI * 2;
+      const x = cx + Math.cos(a) * rad;
+      const y = cy + Math.sin(a) * rad;
+      ctx.fillStyle = `hsla(${hue}, 80%, 60%, 0.8)`;
+      ctx.beginPath();
+      ctx.arc(x, y, 4, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    // 回転ボール
+    const angle = -Math.PI / 2 + tBar * Math.PI * 2 * n;
+    const bx = cx + Math.cos(angle) * rad;
+    const by = cy + Math.sin(angle) * rad;
+    ctx.fillStyle = `hsla(${hue}, 95%, 75%, 1)`;
+    ctx.beginPath();
+    ctx.arc(bx, by, params.ballSize, 0, Math.PI * 2);
+    ctx.fill();
+    // 拍打ち判定
+    const currentBeat = Math.floor(tBar * n);
+    const key = `${i}`;
+    if (lastBeat.get(key) !== currentBeat) {
+      lastBeat.set(key, currentBeat);
+      const bangAngle = -Math.PI / 2 + (currentBeat / n) * Math.PI * 2;
+      pulses.push({
+        x: cx + Math.cos(bangAngle) * rad,
+        y: cy + Math.sin(bangAngle) * rad,
+        t: 0,
+        hue,
+      });
+    }
+  }
+
+  pulses = pulses.filter((p) => p.t < 1);
+  for (const p of pulses) {
+    p.t += 0.04;
+    ctx.strokeStyle = `hsla(${p.hue}, 100%, 75%, ${(1 - p.t) * params.pulseGlow})`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 6 + p.t * 40, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Polyrhythm Wheel',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'bpm', 30, 200, 1);
+gui.add(params, 'division1', 2, 16, 1);
+gui.add(params, 'division2', 2, 16, 1);
+gui.add(params, 'division3', 2, 16, 1);
+gui.add(params, 'division4', 2, 16, 1);
+gui.add(params, 'showWheel4');
+gui.add(params, 'radius', 150, 400, 1);
+gui.add(params, 'gap', 20, 80, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueStep', 20, 180, 1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'ballSize', 4, 16, 0.5);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  const opts = [3, 4, 5, 6, 7, 8, 9, 11, 13];
+  params.division1 = opts[Math.floor(Math.random() * opts.length)];
+  params.division2 = opts[Math.floor(Math.random() * opts.length)];
+  params.division3 = opts[Math.floor(Math.random() * opts.length)];
+  params.division4 = opts[Math.floor(Math.random() * opts.length)];
+  params.bpm = rand(60, 140, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueStep = rand(40, 150, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/polyrhythm-wheel/style.css
+++ b/public/polyrhythm-wheel/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/pythagoras-tree/index.html
+++ b/public/pythagoras-tree/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Pythagoras Tree | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/pythagoras-tree/main.js
+++ b/public/pythagoras-tree/main.js
@@ -1,0 +1,150 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 10,
+  baseSize: 90,
+  angle: 45, // 分岐角
+  leftRatio: Math.SQRT1_2, // 左子の大きさ比
+  rightRatio: Math.SQRT1_2, // 右子の大きさ比
+  asymmetry: 0,
+  hueStart: 120,
+  hueEnd: 30,
+  alpha: 0.85,
+  fade: 0.12,
+  sway: 0.15,
+  swaySpeed: 0.6,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 正方形を描いて左右に子の正方形を再帰
+ * @param {number} x 底辺左端 x
+ * @param {number} y 底辺左端 y
+ * @param {number} size 一辺
+ * @param {number} rot 回転（ラジアン、底辺の向き）
+ * @param {number} depth
+ */
+function drawSquare(x, y, size, rot, depth) {
+  if (depth <= 0 || size < 1) return;
+  const t = 1 - depth / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.fillStyle = `hsla(${hue}, 70%, 55%, ${params.alpha * 0.3})`;
+  ctx.strokeStyle = `hsla(${hue}, 80%, 65%, ${params.alpha})`;
+  ctx.lineWidth = Math.max(0.5, 1.2);
+
+  const cosR = Math.cos(rot);
+  const sinR = Math.sin(rot);
+  // 4 頂点（底辺左から時計回り）
+  const p1 = { x, y };
+  const p2 = { x: x + cosR * size, y: y + sinR * size };
+  const up = { x: -sinR, y: cosR };
+  const p3 = { x: p2.x + up.x * size, y: p2.y + up.y * size };
+  const p4 = { x: p1.x + up.x * size, y: p1.y + up.y * size };
+
+  ctx.beginPath();
+  ctx.moveTo(p1.x, p1.y);
+  ctx.lineTo(p2.x, p2.y);
+  ctx.lineTo(p3.x, p3.y);
+  ctx.lineTo(p4.x, p4.y);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+
+  // 屋根の頂点を角度で決める
+  const sway =
+    Math.sin(time * params.swaySpeed + depth * 0.5) * params.sway * 8;
+  const aL = ((params.angle + params.asymmetry + sway) * Math.PI) / 180;
+  const aR = ((params.angle - params.asymmetry - sway) * Math.PI) / 180;
+  // 左子: 上辺左端 (p4) を底辺左端、長さは size * cos(aL) に比例
+  const lSize = size * Math.cos(aL) * params.leftRatio;
+  const lRot = rot - aL;
+  drawSquare(p4.x, p4.y, lSize, lRot, depth - 1);
+
+  // 右子: 屋根の頂点から p3 まで。
+  const rSize = size * Math.sin(aL) * params.rightRatio;
+  // 屋根頂点 = p4 + (cos(aL), sin(aL)) in 回転座標で size*cos(aL)
+  const apex = {
+    x:
+      p4.x + (cosR * Math.cos(aL) + -sinR * Math.sin(aL)) * size * Math.cos(aL),
+    y: p4.y + (sinR * Math.cos(aL) + cosR * Math.sin(aL)) * size * Math.cos(aL),
+  };
+  const rRot = rot + (Math.PI / 2 - aR);
+  drawSquare(apex.x, apex.y, rSize, rRot, depth - 1);
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.fade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const x0 = canvas.width / 2 - params.baseSize / 2;
+  const y0 = canvas.height * 0.92;
+  drawSquare(x0, y0, params.baseSize, 0, Math.round(params.depth));
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Pythagoras Tree',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 3, 13, 1);
+gui.add(params, 'baseSize', 30, 180, 1);
+gui.add(params, 'angle', 10, 80, 1);
+gui.add(params, 'leftRatio', 0.5, 1, 0.01);
+gui.add(params, 'rightRatio', 0.5, 1, 0.01);
+gui.add(params, 'asymmetry', -20, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'fade', 0, 0.4, 0.01);
+gui.add(params, 'sway', 0, 0.6, 0.01);
+gui.add(params, 'swaySpeed', 0, 2, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(7, 11, 1);
+  params.angle = rand(25, 60, 1);
+  params.leftRatio = rand(0.6, 0.85, 0.01);
+  params.rightRatio = rand(0.6, 0.85, 0.01);
+  params.asymmetry = rand(-10, 10, 0.5);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.sway = rand(0.05, 0.3, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/pythagoras-tree/style.css
+++ b/public/pythagoras-tree/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/reaction-diffusion/index.html
+++ b/public/reaction-diffusion/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Reaction Diffusion | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/reaction-diffusion/main.js
+++ b/public/reaction-diffusion/main.js
@@ -1,0 +1,198 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 簡易 Gray-Scott 反応拡散系（格子 160x100 程度でリアルタイム）
+const params = {
+  gridScale: 5, // 画面ピクセルあたりの格子サイズ
+  feed: 0.055,
+  kill: 0.062,
+  dA: 1.0,
+  dB: 0.5,
+  iterPerFrame: 8,
+  hueStart: 180,
+  hueRange: 160,
+  brightness: 1.3,
+  seedSize: 12,
+  seedSpawn: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+/** @type {Float32Array} */
+let a;
+/** @type {Float32Array} */
+let b;
+let gw = 0;
+let gh = 0;
+
+function rebuild() {
+  gw = Math.max(40, Math.floor(canvas.width / params.gridScale));
+  gh = Math.max(40, Math.floor(canvas.height / params.gridScale));
+  a = new Float32Array(gw * gh);
+  b = new Float32Array(gw * gh);
+  for (let i = 0; i < a.length; i++) a[i] = 1;
+  seed(gw / 2, gh / 2);
+}
+
+function seed(cx, cy) {
+  const r = Math.round(params.seedSize);
+  for (let y = -r; y <= r; y++) {
+    for (let x = -r; x <= r; x++) {
+      const px = Math.floor(cx + x);
+      const py = Math.floor(cy + y);
+      if (px < 0 || py < 0 || px >= gw || py >= gh) continue;
+      if (x * x + y * y <= r * r) b[py * gw + px] = 1;
+    }
+  }
+}
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  rebuild();
+}
+window.addEventListener('resize', resize);
+resize();
+
+/** @type {Float32Array} */
+let a2;
+/** @type {Float32Array} */
+let b2;
+
+function laplacian(buf, x, y) {
+  const idx = y * gw + x;
+  const xm = (x - 1 + gw) % gw;
+  const xp = (x + 1) % gw;
+  const ym = (y - 1 + gh) % gh;
+  const yp = (y + 1) % gh;
+  return (
+    buf[ym * gw + xm] * 0.05 +
+    buf[ym * gw + x] * 0.2 +
+    buf[ym * gw + xp] * 0.05 +
+    buf[y * gw + xm] * 0.2 +
+    buf[idx] * -1 +
+    buf[y * gw + xp] * 0.2 +
+    buf[yp * gw + xm] * 0.05 +
+    buf[yp * gw + x] * 0.2 +
+    buf[yp * gw + xp] * 0.05
+  );
+}
+
+function iterate() {
+  if (!a2 || a2.length !== a.length) {
+    a2 = new Float32Array(a.length);
+    b2 = new Float32Array(b.length);
+  }
+  const F = params.feed;
+  const K = params.kill;
+  for (let y = 0; y < gh; y++) {
+    for (let x = 0; x < gw; x++) {
+      const idx = y * gw + x;
+      const av = a[idx];
+      const bv = b[idx];
+      const abb = av * bv * bv;
+      a2[idx] = av + (params.dA * laplacian(a, x, y) - abb + F * (1 - av));
+      b2[idx] = bv + (params.dB * laplacian(b, x, y) + abb - (K + F) * bv);
+      if (a2[idx] < 0) a2[idx] = 0;
+      if (a2[idx] > 1) a2[idx] = 1;
+      if (b2[idx] < 0) b2[idx] = 0;
+      if (b2[idx] > 1) b2[idx] = 1;
+    }
+  }
+  [a, a2] = [a2, a];
+  [b, b2] = [b2, b];
+}
+
+let spawnTimer = 0;
+
+function draw() {
+  if (params.seedSpawn) {
+    spawnTimer++;
+    if (spawnTimer > 240) {
+      spawnTimer = 0;
+      seed(Math.random() * gw, Math.random() * gh);
+    }
+  }
+  const iters = Math.round(params.iterPerFrame);
+  for (let i = 0; i < iters; i++) iterate();
+
+  const img = ctx.createImageData(canvas.width, canvas.height);
+  const data = img.data;
+  const sx = canvas.width / gw;
+  const sy = canvas.height / gh;
+  for (let py = 0; py < canvas.height; py++) {
+    const gy = Math.min(gh - 1, Math.floor(py / sy));
+    for (let px = 0; px < canvas.width; px++) {
+      const gx = Math.min(gw - 1, Math.floor(px / sx));
+      const v = Math.min(1, b[gy * gw + gx] * params.brightness);
+      const hue = params.hueStart + v * params.hueRange;
+      const l = Math.floor(v * 255);
+      const rr = Math.floor(l * 0.8 + 20);
+      const gg = Math.floor(
+        l * (0.5 + Math.sin((hue * Math.PI) / 180) * 0.3) + 10,
+      );
+      const bb = Math.floor(
+        l * (0.3 + Math.cos((hue * Math.PI) / 180) * 0.3) + 10,
+      );
+      const off = (py * canvas.width + px) * 4;
+      data[off] = rr;
+      data[off + 1] = gg;
+      data[off + 2] = bb;
+      data[off + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Reaction Diffusion',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'gridScale', 3, 10, 1);
+gui.add(params, 'feed', 0.02, 0.1, 0.001);
+gui.add(params, 'kill', 0.04, 0.075, 0.001);
+gui.add(params, 'dA', 0.5, 1.5, 0.01);
+gui.add(params, 'dB', 0.2, 1, 0.01);
+gui.add(params, 'iterPerFrame', 2, 20, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'brightness', 0.5, 3, 0.05);
+gui.add(params, 'seedSize', 3, 30, 1);
+gui.add(params, 'seedSpawn');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.feed = rand(0.03, 0.08, 0.001);
+  params.kill = rand(0.05, 0.068, 0.001);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Seed', () => seed(Math.random() * gw, Math.random() * gh));
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/reaction-diffusion/style.css
+++ b/public/reaction-diffusion/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/risset-rhythm/index.html
+++ b/public/risset-rhythm/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Risset Rhythm | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/risset-rhythm/main.js
+++ b/public/risset-rhythm/main.js
@@ -1,0 +1,142 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// Risset のリズム錯覚: 複数層が加速しつつ音量が徐々にフェードする。見かけ上無限に加速していく。
+const params = {
+  layers: 6,
+  baseBpm: 60,
+  rampSeconds: 10, // 1 オクターブ分加速するのにかかる時間
+  radius: 260,
+  hueStart: 180,
+  hueRange: 200,
+  ballSize: 10,
+  ringWidth: 2,
+  trailFade: 0.15,
+  glow: 0.7,
+  showSpiral: true,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+/** @type {{x:number,y:number,t:number,hue:number}[]} */
+let pulses = [];
+/** @type {number[]} */
+let lastBeatPerLayer = [];
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const n = Math.round(params.layers);
+
+  for (let i = 0; i < n; i++) {
+    // 各レイヤーは位相 (time + i * rampSeconds / n) / rampSeconds で 0→1 のオクターブランプ
+    const phase =
+      ((time + (i * params.rampSeconds) / n) % params.rampSeconds) /
+      params.rampSeconds;
+    const mult = 2 ** phase; // BPM 倍率 1→2→1
+    const bpm = params.baseBpm * mult;
+    const beats = (time * bpm) / 60;
+    const beatIdx = Math.floor(beats);
+    const beatFrac = beats - beatIdx;
+    const envelope = Math.sin(phase * Math.PI);
+    const rad = params.radius * (1 - phase * 0.7);
+    const hue = params.hueStart + phase * params.hueRange;
+    const angle = -Math.PI / 2 + beatFrac * Math.PI * 2;
+    if (lastBeatPerLayer[i] !== beatIdx) {
+      lastBeatPerLayer[i] = beatIdx;
+      pulses.push({
+        x: cx + Math.cos(-Math.PI / 2) * rad,
+        y: cy + Math.sin(-Math.PI / 2) * rad,
+        t: 0,
+        hue,
+      });
+    }
+    // スパイラル軌道
+    if (params.showSpiral) {
+      ctx.strokeStyle = `hsla(${hue}, 60%, 55%, ${0.15 + envelope * 0.35})`;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.arc(cx, cy, rad, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+    const bx = cx + Math.cos(angle) * rad;
+    const by = cy + Math.sin(angle) * rad;
+    ctx.fillStyle = `hsla(${hue}, 90%, 70%, ${envelope * params.glow})`;
+    ctx.beginPath();
+    ctx.arc(bx, by, params.ballSize * envelope + 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  pulses = pulses.filter((p) => p.t < 1);
+  for (const p of pulses) {
+    p.t += 0.05;
+    ctx.strokeStyle = `hsla(${p.hue}, 100%, 80%, ${(1 - p.t) * params.glow})`;
+    ctx.lineWidth = params.ringWidth;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 4 + p.t * 50, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Risset Rhythm',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'layers', 2, 12, 1);
+gui.add(params, 'baseBpm', 20, 120, 1);
+gui.add(params, 'rampSeconds', 3, 30, 0.5);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'ballSize', 4, 20, 0.5);
+gui.add(params, 'ringWidth', 0.5, 5, 0.1);
+gui.add(params, 'trailFade', 0.05, 0.3, 0.01);
+gui.add(params, 'glow', 0.2, 1, 0.01);
+gui.add(params, 'showSpiral');
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.layers = rand(4, 10, 1);
+  params.baseBpm = rand(40, 100, 1);
+  params.rampSeconds = rand(6, 20, 0.5);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(60, 300, 1);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  lastBeatPerLayer = [];
+  gui.updateDisplay();
+});

--- a/public/risset-rhythm/style.css
+++ b/public/risset-rhythm/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/spectrogram-painter/index.html
+++ b/public/spectrogram-painter/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Spectrogram Painter | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/spectrogram-painter/main.js
+++ b/public/spectrogram-painter/main.js
@@ -1,0 +1,125 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  bands: 64, // 周波数帯の数
+  scrollSpeed: 1.4,
+  noiseAmount: 0.25,
+  tone1: 0.5, // トーン 1 ベース
+  tone2: 1.3,
+  tone3: 2.1,
+  wobble: 0.5, // 周波数の揺らぎ
+  hueBase: 200,
+  hueRange: 160,
+  gamma: 1.6,
+  decay: 0.04,
+  intensity: 1,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  // 既存画像を左へスクロール
+  const shift = Math.max(1, Math.round(params.scrollSpeed));
+  const img = ctx.getImageData(shift, 0, canvas.width - shift, canvas.height);
+  ctx.putImageData(img, 0, 0);
+  // 右端を黒で塗る
+  ctx.fillStyle = `rgba(11, 10, 7, ${0.6 + params.decay})`;
+  ctx.fillRect(canvas.width - shift, 0, shift, canvas.height);
+
+  // 新しい列（右端）にスペクトル縞を描画
+  const n = Math.round(params.bands);
+  const bandH = canvas.height / n;
+  for (let i = 0; i < n; i++) {
+    const f = (i + 0.5) / n;
+    const freq1 =
+      params.tone1 * (1 + Math.sin(time * 0.9 + f * 6) * params.wobble);
+    const freq2 =
+      params.tone2 * (1 + Math.cos(time * 1.3 + f * 4) * params.wobble);
+    const freq3 =
+      params.tone3 * (1 + Math.sin(time * 0.6 + f * 2) * params.wobble);
+    const formant =
+      Math.exp(-((f - 0.15) * (f - 0.15)) / 0.02) +
+      Math.exp(-((f - 0.4) * (f - 0.4)) / 0.05) * 0.8 +
+      Math.exp(-((f - 0.7) * (f - 0.7)) / 0.1) * 0.5;
+    const mod =
+      (Math.sin(time * freq1 * 4 + f * 20) * 0.5 + 0.5) *
+      (Math.sin(time * freq2 * 3 + f * 12) * 0.5 + 0.5) *
+      (Math.sin(time * freq3 * 2 + f * 6) * 0.5 + 0.5);
+    const noise = (Math.random() - 0.5) * params.noiseAmount;
+    let v = (formant * mod + noise) * params.intensity;
+    v = Math.max(0, Math.min(1, v));
+    v = v ** (1 / params.gamma);
+    const hue = params.hueBase + f * params.hueRange;
+    const a = v * 0.95;
+    ctx.fillStyle = `hsla(${hue}, 90%, ${20 + v * 60}%, ${a})`;
+    ctx.fillRect(canvas.width - shift, i * bandH, shift, bandH + 0.5);
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Spectrogram Painter',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'bands', 16, 128, 1);
+gui.add(params, 'scrollSpeed', 0.5, 5, 0.1);
+gui.add(params, 'noiseAmount', 0, 1, 0.01);
+gui.add(params, 'tone1', 0.1, 3, 0.01);
+gui.add(params, 'tone2', 0.1, 3, 0.01);
+gui.add(params, 'tone3', 0.1, 3, 0.01);
+gui.add(params, 'wobble', 0, 1.5, 0.01);
+gui.add(params, 'hueBase', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'gamma', 0.5, 3, 0.05);
+gui.add(params, 'decay', 0, 0.3, 0.01);
+gui.add(params, 'intensity', 0.2, 2, 0.05);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.tone1 = rand(0.3, 1.5, 0.01);
+  params.tone2 = rand(0.5, 2, 0.01);
+  params.tone3 = rand(1, 2.5, 0.01);
+  params.hueBase = rand(0, 360, 1);
+  params.hueRange = rand(60, 240, 1);
+  params.wobble = rand(0.2, 0.9, 0.01);
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+  ctx.fillStyle = '#0b0a07';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+});

--- a/public/spectrogram-painter/style.css
+++ b/public/spectrogram-painter/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/t-square-fractal/index.html
+++ b/public/t-square-fractal/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>T-Square Fractal | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/t-square-fractal/main.js
+++ b/public/t-square-fractal/main.js
@@ -1,0 +1,126 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+const params = {
+  depth: 7,
+  initialSize: 380,
+  ratio: 0.5,
+  hueStart: 200,
+  hueEnd: 40,
+  saturation: 70,
+  lightness: 55,
+  alpha: 0.9,
+  strokeAlpha: 0.4,
+  rotation: 0,
+  rotSpeed: 0.05,
+  shrink: 0,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+let time = 0;
+
+/**
+ * 正方形を描き、各辺の中点にスケールした子正方形を配置
+ * @param {number} cx
+ * @param {number} cy
+ * @param {number} size
+ * @param {number} depth
+ */
+function tSquare(cx, cy, size, depth) {
+  if (depth <= 0 || size < 1) return;
+  const t = 1 - depth / params.depth;
+  const hue = params.hueStart + (params.hueEnd - params.hueStart) * t;
+  ctx.fillStyle = `hsla(${hue}, ${params.saturation}%, ${params.lightness}%, ${params.alpha})`;
+  ctx.strokeStyle = `hsla(${hue}, 90%, 75%, ${params.strokeAlpha})`;
+  ctx.lineWidth = 0.8;
+  const half = size / 2;
+  ctx.fillRect(cx - half, cy - half, size, size);
+  ctx.strokeRect(cx - half, cy - half, size, size);
+
+  const child = size * params.ratio - params.shrink;
+  // 4 辺の中点に子正方形
+  tSquare(cx - half, cy, child, depth - 1); // 左
+  tSquare(cx + half, cy, child, depth - 1); // 右
+  tSquare(cx, cy - half, child, depth - 1); // 上
+  tSquare(cx, cy + half, child, depth - 1); // 下
+}
+
+function draw() {
+  time += 1 / 60;
+  ctx.fillStyle = 'rgba(11, 10, 7, 0.18)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const ang = params.rotation + time * params.rotSpeed;
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(ang);
+  tSquare(0, 0, params.initialSize, Math.round(params.depth));
+  ctx.restore();
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'T-Square Fractal',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'depth', 1, 9, 1);
+gui.add(params, 'initialSize', 100, 600, 1);
+gui.add(params, 'ratio', 0.3, 0.6, 0.01);
+gui.add(params, 'shrink', 0, 20, 0.5);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueEnd', 0, 360, 1);
+gui.add(params, 'saturation', 0, 100, 1);
+gui.add(params, 'lightness', 20, 80, 1);
+gui.add(params, 'alpha', 0.2, 1, 0.01);
+gui.add(params, 'strokeAlpha', 0, 1, 0.01);
+gui.add(params, 'rotation', -3.14, 3.14, 0.01);
+gui.add(params, 'rotSpeed', -0.5, 0.5, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+
+gui.addButton('Random', () => {
+  params.depth = rand(5, 8, 1);
+  params.initialSize = rand(200, 500, 1);
+  params.ratio = rand(0.42, 0.55, 0.01);
+  params.hueStart = rand(0, 360, 1);
+  params.hueEnd = rand(0, 360, 1);
+  params.saturation = rand(40, 90, 1);
+  params.rotSpeed = rand(-0.2, 0.2, 0.01);
+  gui.updateDisplay();
+});
+
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  gui.updateDisplay();
+});

--- a/public/t-square-fractal/style.css
+++ b/public/t-square-fractal/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}

--- a/public/virus-capsid/index.html
+++ b/public/virus-capsid/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Virus Capsid | atelier.yuske.app</title>
+    <link rel="stylesheet" href="./style.css" />
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <header>
+      <a href="/">&larr; Back to Top</a>
+    </header>
+    <main>
+      <canvas id="canvas"></canvas>
+    </main>
+    <div id="gui-container"></div>
+  </body>
+</html>

--- a/public/virus-capsid/main.js
+++ b/public/virus-capsid/main.js
@@ -1,0 +1,265 @@
+// @ts-check
+
+import TileUI from 'https://cdn.jsdelivr.net/npm/@yuske-nakajima/tileui/dist/tileui.js';
+
+// 20 面体ウイルスカプシド。icosahedron の頂点を球面上に配置し、面を三角形パッチで描く。
+const params = {
+  subdivisions: 1, // 1=icosa, 2=geodesic, 3=高解像度
+  radius: 240,
+  rotX: 0.01,
+  rotY: 0.03,
+  rotZ: 0.005,
+  hueStart: 120,
+  hueRange: 100,
+  strokeAlpha: 0.7,
+  fillAlpha: 0.6,
+  spikeLength: 30,
+  spikeCount: 20,
+  trailFade: 0.15,
+  pulse: 0.12,
+};
+const defaults = { ...params };
+
+const canvas = /** @type {HTMLCanvasElement} */ (
+  document.getElementById('canvas')
+);
+const ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+// 正 20 面体の頂点・面を生成
+function makeIcosahedron() {
+  const t = (1 + Math.sqrt(5)) / 2;
+  const verts = [
+    [-1, t, 0],
+    [1, t, 0],
+    [-1, -t, 0],
+    [1, -t, 0],
+    [0, -1, t],
+    [0, 1, t],
+    [0, -1, -t],
+    [0, 1, -t],
+    [t, 0, -1],
+    [t, 0, 1],
+    [-t, 0, -1],
+    [-t, 0, 1],
+  ].map((v) => {
+    const len = Math.hypot(v[0], v[1], v[2]);
+    return [v[0] / len, v[1] / len, v[2] / len];
+  });
+  const faces = [
+    [0, 11, 5],
+    [0, 5, 1],
+    [0, 1, 7],
+    [0, 7, 10],
+    [0, 10, 11],
+    [1, 5, 9],
+    [5, 11, 4],
+    [11, 10, 2],
+    [10, 7, 6],
+    [7, 1, 8],
+    [3, 9, 4],
+    [3, 4, 2],
+    [3, 2, 6],
+    [3, 6, 8],
+    [3, 8, 9],
+    [4, 9, 5],
+    [2, 4, 11],
+    [6, 2, 10],
+    [8, 6, 7],
+    [9, 8, 1],
+  ];
+  return { verts, faces };
+}
+
+function subdivide(mesh, depth) {
+  for (let d = 0; d < depth; d++) {
+    const newFaces = [];
+    for (const [a, b, c] of mesh.faces) {
+      const ab = mid(mesh.verts[a], mesh.verts[b]);
+      const bc = mid(mesh.verts[b], mesh.verts[c]);
+      const ca = mid(mesh.verts[c], mesh.verts[a]);
+      const iab = mesh.verts.push(ab) - 1;
+      const ibc = mesh.verts.push(bc) - 1;
+      const ica = mesh.verts.push(ca) - 1;
+      newFaces.push([a, iab, ica]);
+      newFaces.push([b, ibc, iab]);
+      newFaces.push([c, ica, ibc]);
+      newFaces.push([iab, ibc, ica]);
+    }
+    mesh.faces = newFaces;
+  }
+  return mesh;
+}
+
+function mid(a, b) {
+  const m = [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2, (a[2] + b[2]) / 2];
+  const len = Math.hypot(m[0], m[1], m[2]);
+  return [m[0] / len, m[1] / len, m[2] / len];
+}
+
+let mesh = makeIcosahedron();
+let currentSub = 1;
+
+function rebuild() {
+  mesh = makeIcosahedron();
+  subdivide(mesh, Math.max(0, Math.round(params.subdivisions) - 1));
+  currentSub = Math.round(params.subdivisions);
+}
+rebuild();
+
+let rx = 0;
+let ry = 0;
+let rz = 0;
+let time = 0;
+
+function draw() {
+  time += 1 / 60;
+  if (currentSub !== Math.round(params.subdivisions)) rebuild();
+  ctx.fillStyle = `rgba(11, 10, 7, ${params.trailFade})`;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  rx += params.rotX;
+  ry += params.rotY;
+  rz += params.rotZ;
+
+  const cx = canvas.width / 2;
+  const cy = canvas.height / 2;
+  const R = params.radius * (1 + Math.sin(time * 2) * params.pulse);
+
+  // 回転行列を適用しつつスクリーン座標算出
+  const cosX = Math.cos(rx);
+  const sinX = Math.sin(rx);
+  const cosY = Math.cos(ry);
+  const sinY = Math.sin(ry);
+  const cosZ = Math.cos(rz);
+  const sinZ = Math.sin(rz);
+  const projected = mesh.verts.map((v) => {
+    let [x, y, z] = v;
+    // X
+    let ny = y * cosX - z * sinX;
+    let nz = y * sinX + z * cosX;
+    y = ny;
+    z = nz;
+    // Y
+    let nx = x * cosY + z * sinY;
+    nz = -x * sinY + z * cosY;
+    x = nx;
+    z = nz;
+    // Z
+    nx = x * cosZ - y * sinZ;
+    ny = x * sinZ + y * cosZ;
+    x = nx;
+    y = ny;
+    const persp = 600 / (600 + z * R);
+    return { x: cx + x * R * persp, y: cy + y * R * persp, z, depth: z };
+  });
+
+  // 面を z ソート
+  const faceOrder = mesh.faces.map((f, idx) => ({
+    f,
+    idx,
+    z: (projected[f[0]].z + projected[f[1]].z + projected[f[2]].z) / 3,
+  }));
+  faceOrder.sort((a, b) => a.z - b.z);
+
+  for (const { f, z } of faceOrder) {
+    const [a, b, c] = f;
+    const p1 = projected[a];
+    const p2 = projected[b];
+    const p3 = projected[c];
+    const light = (1 - z) * 0.5;
+    const hue = params.hueStart + light * params.hueRange;
+    ctx.fillStyle = `hsla(${hue}, 80%, ${30 + light * 40}%, ${params.fillAlpha})`;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 80%, ${params.strokeAlpha})`;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(p1.x, p1.y);
+    ctx.lineTo(p2.x, p2.y);
+    ctx.lineTo(p3.x, p3.y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+  }
+
+  // スパイク（外側の棘）
+  const spikeIndices = [];
+  const sc = Math.round(params.spikeCount);
+  for (let i = 0; i < sc; i++) {
+    spikeIndices.push(Math.floor((i * mesh.verts.length) / sc));
+  }
+  for (const idx of spikeIndices) {
+    const p = projected[idx];
+    const outer = {
+      x: cx + ((p.x - cx) / R) * (R + params.spikeLength),
+      y: cy + ((p.y - cy) / R) * (R + params.spikeLength),
+    };
+    const hue = params.hueStart + params.hueRange * 0.5;
+    ctx.strokeStyle = `hsla(${hue}, 90%, 70%, 0.8)`;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(outer.x, outer.y);
+    ctx.stroke();
+    ctx.fillStyle = `hsla(${hue}, 100%, 80%, 0.9)`;
+    ctx.beginPath();
+    ctx.arc(outer.x, outer.y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function tick() {
+  draw();
+  requestAnimationFrame(tick);
+}
+tick();
+
+const gui = new TileUI({
+  title: 'Virus Capsid',
+  container: /** @type {HTMLElement} */ (
+    document.getElementById('gui-container')
+  ),
+  columns: 3,
+  dock: 'right',
+  collapsible: true,
+  overlay: true,
+  toggleKey: 'g',
+});
+
+gui.add(params, 'subdivisions', 1, 4, 1);
+gui.add(params, 'radius', 120, 400, 1);
+gui.add(params, 'rotX', -0.05, 0.05, 0.001);
+gui.add(params, 'rotY', -0.05, 0.05, 0.001);
+gui.add(params, 'rotZ', -0.05, 0.05, 0.001);
+gui.add(params, 'hueStart', 0, 360, 1);
+gui.add(params, 'hueRange', 0, 360, 1);
+gui.add(params, 'strokeAlpha', 0.1, 1, 0.01);
+gui.add(params, 'fillAlpha', 0.1, 1, 0.01);
+gui.add(params, 'spikeLength', 0, 60, 1);
+gui.add(params, 'spikeCount', 0, 40, 1);
+gui.add(params, 'trailFade', 0.05, 0.4, 0.01);
+gui.add(params, 'pulse', 0, 0.3, 0.01);
+
+function rand(min, max, step = 1) {
+  const v = min + Math.random() * (max - min);
+  return Math.round(v / step) * step;
+}
+gui.addButton('Random', () => {
+  params.subdivisions = rand(1, 3, 1);
+  params.hueStart = rand(0, 360, 1);
+  params.hueRange = rand(30, 200, 1);
+  params.rotX = rand(-0.03, 0.03, 0.001);
+  params.rotY = rand(-0.03, 0.03, 0.001);
+  params.rotZ = rand(-0.03, 0.03, 0.001);
+  params.spikeLength = rand(15, 45, 1);
+  rebuild();
+  gui.updateDisplay();
+});
+gui.addButton('Reset', () => {
+  Object.assign(params, { ...defaults });
+  rebuild();
+  gui.updateDisplay();
+});

--- a/public/virus-capsid/style.css
+++ b/public/virus-capsid/style.css
@@ -1,0 +1,46 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  background: #0b0a07;
+  overflow: hidden;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 100;
+  padding: 0.75rem 1rem;
+}
+
+header a {
+  color: #999;
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: color 0.2s;
+}
+
+header a:hover {
+  color: #e0e0e0;
+}
+
+main {
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  z-index: 0;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 0;
+}


### PR DESCRIPTION
## Summary

Issue #153 のサブ issue から 30 件分のページを追加（PR #226 の続編）。

## Closes

Closes #146
Closes #149
Closes #150
Closes #151
Closes #152
Closes #155
Closes #157
Closes #158
Closes #159
Closes #160
Closes #161
Closes #162
Closes #163
Closes #164
Closes #165
Closes #166
Closes #167
Closes #168
Closes #169
Closes #170
Closes #171
Closes #172
Closes #173
Closes #174
Closes #175
Closes #177
Closes #178
Closes #179
Closes #180
Closes #181

## Test plan

- [ ] 各ページが開ける
- [ ] TileUI コントロールが動作する
- [ ] Random / Reset が動作する