### PR TITLE
chore(deps): pnpm を 11.5.3 から 11.6.0 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "atelier-yuske-app",
   "private": true,
-  "packageManager": "pnpm@11.5.3",
+  "packageManager": "pnpm@11.6.0",
   "engines": {
     "node": "24.16.0",
-    "pnpm": "11.5.3"
+    "pnpm": "11.6.0"
   },
   "scripts": {
     "dev": "vite public",


### PR DESCRIPTION
## 概要

- pnpm を 11.5.3 から 11.6.0 に更新
- `package.json` の `packageManager` および `engines.pnpm` フィールドを 11.6.0 に変更
- あわせて Node.js を 24.15.0 から 24.16.0 に更新し、`engines.node` を修正
- devDependencies（@biomejs/biome, @playwright/test, eslint, typescript, typescript-eslint, vite）を各最新バージョンに更新

## 変更内容

- `package.json`: `packageManager`、`engines.node`、`engines.pnpm`、devDependencies を更新
- `pnpm-lock.yaml`: 上記依存更新に伴うロックファイル再生成

## 関連

Closes #377